### PR TITLE
Fix for the popular funders query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 - Added models and resolvers for ProjectContributor, ProjectFunder, ProjectOutput and Project
 
 ### Updated
+- Fixed bug with `Affiliation.top20` query which was still referencing the old `projectFunders` table 
 - Updated package.json and tsconfig.json with options for sourcemaps which is supposed to help making debugging/breakpoints in IDEs more reliable.
 - Updated most tests since they mostly require tokens which require email which is now async because it comes from the UserEmail model.
 - Updated resolvers, models and controllers to use correct methods for using email from the UserEmail model (or use convenience method `getEmail` on the User model).

--- a/src/models/Affiliation.ts
+++ b/src/models/Affiliation.ts
@@ -413,7 +413,7 @@ export class PopularFunder {
     // Get the top 20 funders based on the number of plans created in the past year
     const sql = 'SELECT a.id, a.uri, a.displayName, COUNT(p.id) AS nbrPlans ' +
                 'FROM affiliations a ' +
-                'LEFT JOIN projectFunders pf ON pf.affiliationId = a.uri ' +
+                'LEFT JOIN projectFundings pf ON pf.affiliationId = a.uri ' +
                 'LEFT JOIN projects p ON p.id = pf.projectId ' +
                 'WHERE a.active = 1 AND a.funder = 1 AND p.isTestProject = 0 AND p.created BETWEEN ? AND ? ' +
                 'GROUP BY a.id, a.uri, a.displayName ' +

--- a/src/models/__tests__/Affiliation.spec.ts
+++ b/src/models/__tests__/Affiliation.spec.ts
@@ -541,7 +541,7 @@ describe('top20', () => {
     localQuery.mockResolvedValueOnce([popularFunder]);
     const result = await PopularFunder.top20(context);
     const expectedSql = 'SELECT a.id, a.uri, a.displayName, COUNT(p.id) AS nbrPlans ' +
-                        'FROM affiliations a LEFT JOIN projectFunders pf ON pf.affiliationId = a.uri ' +
+                        'FROM affiliations a LEFT JOIN projectFundings pf ON pf.affiliationId = a.uri ' +
                         'LEFT JOIN projects p ON p.id = pf.projectId WHERE a.active = 1 AND a.funder = 1 ' +
                         'AND p.isTestProject = 0 AND p.created BETWEEN ? AND ? GROUP BY a.id, a.uri, ' +
                         'a.displayName ORDER BY nbrPlans DESC LIMIT 20';


### PR DESCRIPTION
## Description

Fixes an issue affecting [#380](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/380)

- Switch `Affiliation.top20` to use the new `projectFundings` table instead of the old `projectFunders` table

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

All tests pass and verified the `popularFunders` query is returning data again in the Apollo explorer window

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules