### PR TITLE
[Bug fix] - Backend returns duplicate versionedTemplates when client calls publishedTemplates query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # DMP Tool Apollo Server Change Log
 
 ### Fixed
+- When generating a new `versionedTemplate`, we need to deactivate the old ones in the db [#363]
 - Bug with `FunderPopularityResult` in the GraphQL schema that was making `apiTarget` non-nullable
 
 ## v0.2 - Initial deploy to the stage environment

--- a/src/services/templateService.ts
+++ b/src/services/templateService.ts
@@ -89,6 +89,15 @@ export const generateTemplateVersion = async (
 
   // If the version was successfully created and there are no errors
   if (created && !created.hasErrors()) {
+
+    // Deactivate previous versions only *after* successful creation
+    for (const v of versions) {
+      if (v.active) {
+        const versionInstance = new VersionedTemplate({ ...v, active: false });
+        await versionInstance.update(context);
+      }
+    }
+
     const sections = await Section.findByTemplateId('generateTemplateVersion', context, template.id);
 
     try {


### PR DESCRIPTION

## Description

Backend is currently returning different versions of the same template when clients call `publishedTemplates` query. This is because the older `versionedTemplate` are not deactivated, when a new one is generated.

- Added code to set `active=false` for all previous versions if the newly generated versionedTemplate was successfully added.

Fixes # ([363](https://github.com/CDLUC3/dmsp_backend_prototype/issues/363))

## Type of change
Please delete options that are not relevant

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually tested.


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules