### PR TITLE
Renamed docker compose network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - added `publishedQuestion` resolver to `src/resolvers/versionedQuestion.ts`
 
 ### Updated
+- Updated `docker-compose.yaml` to use the `dmptool-network` which will be shared with other repos
 - Updated `answer`, `fundings`, `members` and `plans` resolver to use new `hasPermissionOnPlan` function
 - Update the `tokenService` to add `dmpIds` array that stores the DMPs the user has access to
 - Updated the `ProjectSearchResult.search` query to provide plan counts by status and filter by status options

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@
 # It is intended to run the Apollo server in an "offline" mode. All data will be mocked.
 #
 networks:
-  apollo-network:
+  dmptool-network:
     driver: bridge
 
 services:
@@ -20,7 +20,7 @@ services:
       - MYSQL_ROOT_PASSWORD=d0ckerSecr3t
       - MYSQL_DATABASE=dmsp
     networks:
-      - apollo-network
+      - dmptool-network
     volumes:
       - ./docker/mysql:/var/lib/mysql
 
@@ -29,7 +29,7 @@ services:
     container_name: dynamodb
     command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ./data"
     networks:
-      - apollo-network
+      - dmptool-network
     ports:
       - "8000:8000"
     expose:
@@ -43,7 +43,7 @@ services:
     container_name: apollo-redis
     command: redis-server
     networks:
-      - apollo-network
+      - dmptool-network
     ports:
       - "6379:6379"
     volumes:
@@ -61,7 +61,7 @@ services:
     ports:
       - "4000:4000"
     networks:
-      - apollo-network
+      - dmptool-network
     expose:
       - 4000
     env_file:


### PR DESCRIPTION
Renamed the docker compose network from `apollo-network` to `dmptool-network` since we are sharing it with other services for the application (`dmsp_frontend_prototype` and `dmptool-narrative-generator`).

This will allow the frontend to be run with `docker compose up` and still let the nextJS server side actions hit the local backend app. It will also allow the narrative-generator to access the same MySQL DB and DynamoDB table that the backend app uses