### PR TITLE
Fixed breaking build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - changed `sections` resolver to `versionedSections` on the `src/resolvers/plan.ts` file and changed the reference for `PlanSearchResult.sections` to `versionedSections`
 
 ### Fixed
+- Fixed breaking build by removing `NODE_ENV=production` before `npm ci` which was skipping devDependencies, but needed for the build process.
 - `addSection` mutation resolver was not saving `tags`. Added code to add tags for new section [#445]
 - Fixed issue where updating an answer, funding or members was not triggering the creation of a new PlanVersion
 - Fixed bug with maintaining the latest PlanVersion (common standard JSON) when a plan is updated

--- a/Dockerfile.aws
+++ b/Dockerfile.aws
@@ -12,9 +12,6 @@ ENV CI=true
 # to the /app working directory
 COPY package*.json ./
 
-# Set production environment before installing dependencies to omit devDependencies
-ENV NODE_ENV=production
-
 # Install dependencies in /app (excluding devDependencies)
 RUN npm ci
 


### PR DESCRIPTION

## Description

-Updated Dockerfile.aws to remove the "NODE_ENV=production" from the `Dependencies` stage, since we need devDependencies for the `Build` stage, and we were getting the error:
```

> [builder 5/7] RUN npm run build:
--
0.403
0.403 > dmsp_apollo@1.0.0 build
0.403 > rm -rf ./dist && npm run generate && npm run compile
0.403
0.505 npm warn config production Use `--omit=dev` instead.
0.540
0.540 > dmsp_apollo@1.0.0 generate
0.540 > graphql-codegen
0.540
0.543 sh: graphql-codegen: not found


```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


