### PR TITLE
Updated popularFunders resolver to return only 5 popular funders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - added `publishedQuestion` resolver to `src/resolvers/versionedQuestion.ts`
 
 ### Updated
+- Updated `popularFunders` resolver to return only 5 popular funders [#500]
 - Upgrade `nodemailer` from `6.10.1` to `7.0.10` to address security vulnerability
 - Updated `ORCID_REGEX` in `helper.ts` so that urls can be submitted without a the `www.` Also, added `stripORCIDIdentifierBaseURL` to just strip out all protocols and domains to extract the OrcidID [#251]
 - Updated `OrcidAPI` to handle `404` errors so that we return null rather than throwing an error [#251]

--- a/src/models/Affiliation.ts
+++ b/src/models/Affiliation.ts
@@ -399,7 +399,7 @@ export class PopularFunder {
     this.nbrPlans = options.nbrPlans;
   }
 
-  static async top20(context: MyContext): Promise<PopularFunder[]> {
+  static async top5(context: MyContext): Promise<PopularFunder[]> {
     // Get the date range for the past year
     const today = new Date();
     const lastYear = new Date();
@@ -407,19 +407,19 @@ export class PopularFunder {
     const startDate = lastYear.toISOString().split('T')[0];
     const endDate = today.toISOString().split('T')[0];
 
-    // Get the top 20 funders based on the number of plans created in the past year
+    // Get the top 5 funders based on the number of plans created in the past year
     const sql = 'SELECT a.id, a.uri, a.displayName, a.apiTarget, COUNT(p.id) AS nbrPlans ' +
                 'FROM affiliations a ' +
                 'LEFT JOIN projectFundings pf ON pf.affiliationId = a.uri ' +
                 'LEFT JOIN projects p ON p.id = pf.projectId ' +
                 'WHERE a.active = 1 AND a.funder = 1 AND p.isTestProject = 0 AND p.created BETWEEN ? AND ? ' +
                 'GROUP BY a.id, a.uri, a.displayName ' +
-                'ORDER BY nbrPlans DESC LIMIT 20';
+                'ORDER BY nbrPlans DESC LIMIT 5';
     const results = await Affiliation.query(
       context,
       sql,
       [`${startDate} 00:00:00`, `${endDate} 23:59:59`],
-      'PopularFunder.top20'
+      'PopularFunder.top5'
     );
     if (Array.isArray(results) && results.length > 0) {
       return results.map((entry) => { return new PopularFunder(entry) });

--- a/src/models/__tests__/Affiliation.spec.ts
+++ b/src/models/__tests__/Affiliation.spec.ts
@@ -531,7 +531,7 @@ describe('PopularFunder', () => {
   });
 });
 
-describe('top20', () => {
+describe('top5', () => {
   it('should call query with correct params and return the popular funders', async () => {
     const context = await buildMockContextWithToken(logger);
     const localQuery = jest.fn();
@@ -546,12 +546,12 @@ describe('top20', () => {
     });
 
     localQuery.mockResolvedValueOnce([popularFunder]);
-    const result = await PopularFunder.top20(context);
+    const result = await PopularFunder.top5(context);
     const expectedSql = 'SELECT a.id, a.uri, a.displayName, a.apiTarget, COUNT(p.id) AS nbrPlans ' +
                         'FROM affiliations a LEFT JOIN projectFundings pf ON pf.affiliationId = a.uri ' +
                         'LEFT JOIN projects p ON p.id = pf.projectId WHERE a.active = 1 AND a.funder = 1 ' +
                         'AND p.isTestProject = 0 AND p.created BETWEEN ? AND ? GROUP BY a.id, a.uri, ' +
-                        'a.displayName ORDER BY nbrPlans DESC LIMIT 20';
+                        'a.displayName ORDER BY nbrPlans DESC LIMIT 5';
     // Get the date range for the past year
     const today = new Date();
     const lastYear = new Date();
@@ -564,7 +564,7 @@ describe('top20', () => {
       context,
       expectedSql,
       [`${startDate} 00:00:00`, `${endDate} 23:59:59`],
-      'PopularFunder.top20'
+      'PopularFunder.top5'
     );
     expect(result).toEqual([popularFunder]);
   });
@@ -575,7 +575,7 @@ describe('top20', () => {
     (Affiliation.query as jest.Mock) = localQuery;
 
     localQuery.mockResolvedValueOnce([]);
-    const result = await PopularFunder.top20(context);
+    const result = await PopularFunder.top5(context);
     expect(result).toEqual([]);
   });
 
@@ -585,6 +585,6 @@ describe('top20', () => {
     (Affiliation.query as jest.Mock) = localQuery;
 
     localQuery.mockRejectedValueOnce(new Error('Query failed'));
-    await expect(PopularFunder.top20(context)).rejects.toThrow('Query failed');
+    await expect(PopularFunder.top5(context)).rejects.toThrow('Query failed');
   });
 });

--- a/src/resolvers/affiliation.ts
+++ b/src/resolvers/affiliation.ts
@@ -62,7 +62,7 @@ export const resolvers: Resolvers = {
     popularFunders: async (_, __, context: MyContext): Promise<PopularFunder[]> => {
       const reference = 'popularFunders resolver';
       try {
-        return await PopularFunder.top20(context);
+        return await PopularFunder.top5(context);
       } catch (err) {
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
         throw InternalServerError();


### PR DESCRIPTION
## Description

- Updated `popularFunders` resolver to return only 5 popular funders (the client will only show 5 per the comments in the frontend ticket ([956](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/956)) and my discussions with Becky)

Fixes # ([500](https://github.com/CDLUC3/dmsp_backend_prototype/issues/500))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested and tested with unit test

## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules