### PR TITLE
Removed the setting of  dmspr token in refreshTokenController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 - Removed references to `outputs` from schemas and reslvers
 - Removed the `@types/eslint__js` dependency because `@eslint/jest` includes its own types now
 
+### Fixed
+- Removed the setting of `dmspr` token in the `refreshTokenController` because it was overriding the expiration of that refreshToken to be the same as the default `authToken`
+
 ============================================================================
 prior to 2025-10-21
 

--- a/src/controllers/refreshTokenController.ts
+++ b/src/controllers/refreshTokenController.ts
@@ -22,7 +22,6 @@ export const refreshTokenController = async (req: Request, res: Response) => {
       if (newAccessToken) {
         // Set the new access token
         setTokenCookie(res, 'dmspt', newAccessToken);
-        setTokenCookie(res, 'dmspr', refreshToken);
 
         // Send the new access token to the client
         res.status(200).json({ success: true, message: 'ok' });


### PR DESCRIPTION

## Description

Users were getting logged out sooner than expected. I believe one issue is that when the auth token is refreshed the first time, the expiration date of the `refreshToken` is overwritten from the original 24 hr time to whatever the `dmspt` auth token was given. We don't need to set the `dmpsr` token in this function, so I removed it.

Fixes # ([549](https://github.com/CDLUC3/dmsp_backend_prototype/issues/549))

