### PR TITLE
Added slug to tags array in PlanSectionOverview query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # DMP Tool Apollo Server Change Log
 
 ### Added 
+- Added `slug` to tags array returned in `PlanSectionOverview`
 - Added new `ssoPassthruController` and `ssoCallbackController` stub controllers
 - Added a `findByEmailDomain` endpoint to the `Affiliation` model
 

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -136,6 +136,7 @@ export class PlanSectionProgress {
           JSON_ARRAYAGG(
             JSON_OBJECT(
               'id', t.id,
+              'slug', t.slug,
               'name', t.name,
               'description', t.description
             )

--- a/src/models/__tests__/Plan.spec.ts
+++ b/src/models/__tests__/Plan.spec.ts
@@ -211,6 +211,7 @@ describe('PlanSectionProgress.findByPlanId', () => {
           JSON_ARRAYAGG(
             JSON_OBJECT(
               'id', t.id,
+              'slug', t.slug,
               'name', t.name,
               'description', t.description
             )


### PR DESCRIPTION
## Description

Added missing `slug` to the `tags` array returned by the `PlanSectionProgress` model.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

All unit tests pass and verified via the UI locally

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules