### PR TITLE
Fixed broken copy of template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 - Removed `ioredis` package
 
 ### Fixed
+- Fixed breaking cloning of template. The `addTemplate` was updated to accept a `copyFromVersionedTemplateId` so that we copy from versioned template, section and questions, when it's not a template from the user's org. Otherwise we check for `copyFromTemplateId` to copy/clone from templates, sections and questions, and if neither are present, we continue to create a new record for `templates` table [#1006]
 - Fixed issue with templates not cloning with sections and questions by updating the `addTemplate` mutation to clone from non-versioned template, section and question [#1006]
 ## v1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@
 - Removed deprecated `@types/bcrypt` and `uuidv4` packages
 - Removed `ioredis` package
 
+### Fixed
+- Fixed issue with templates not cloning with sections and questions by updating the `addTemplate` mutation to clone from non-versioned template, section and question [#1006]
 ## v1.0
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.1.0
 
 ### Added
+- Added new field, `sourceVersionedTemplateId` field to `templates` table so we can track the source when cloned from a `versionedTemplates` record [#1006]
 - Added `customizableTemplates` query and `CustomizableTemplateSearchResult` to the `versionedTemplate` schema and resolver
 - Added `TemplateCustomization` model resolver and schema
 - Added `templateCustomizationService` which handles updating the status of `templateCustomizations` when the customized template is archived or republished

--- a/data-migrations/2026-02-13-1200-add-sourceVersionedTemplateId.sql
+++ b/data-migrations/2026-02-13-1200-add-sourceVersionedTemplateId.sql
@@ -1,0 +1,7 @@
+-- Add sourceVersionedTemplateId field to templates table
+-- This field tracks when a template was copied from a specific versioned template
+
+ALTER TABLE `templates`
+ADD COLUMN `sourceVersionedTemplateId` int unsigned DEFAULT NULL AFTER `sourceTemplateId`,
+ADD KEY `sourceVersionedTemplateId` (`sourceVersionedTemplateId`),
+ADD CONSTRAINT `templates_ibfk_5` FOREIGN KEY (`sourceVersionedTemplateId`) REFERENCES `versionedTemplates` (`id`) ON DELETE CASCADE;

--- a/src/models/Template.ts
+++ b/src/models/Template.ts
@@ -111,6 +111,7 @@ export class TemplateSearchResult {
 // A Template for creating a DMP
 export class Template extends MySqlModel {
   public sourceTemplateId?: number;
+  public sourceVersionedTemplateId?: number;
   public name: string;
   public description?: string;
   public ownerId?: string;
@@ -129,7 +130,8 @@ export class Template extends MySqlModel {
     this.name = options.name;
     this.ownerId = options.ownerId;
     this.description = options.description;
-    this.sourceTemplateId = options.sourceTemplateId
+    this.sourceTemplateId = options.sourceTemplateId;
+    this.sourceVersionedTemplateId = options.sourceVersionedTemplateId;
     this.latestPublishVisibility = options.latestPublishVisibility ?? TemplateVisibility.ORGANIZATION;
     this.latestPublishVersion = options.latestPublishVersion ?? '';
     this.latestPublishDate = options.latestPublishDate ?? null;

--- a/src/resolvers/template.ts
+++ b/src/resolvers/template.ts
@@ -3,7 +3,9 @@ import { Template, TemplateSearchResult, TemplateVisibility } from "../models/Te
 import { Affiliation } from "../models/Affiliation";
 import { TemplateCollaborator } from "../models/Collaborator";
 import { Section } from "../models/Section";
-import { Question } from '../models/Question';
+import { Question } from "../models/Question";
+import { VersionedSection } from '../models/VersionedSection';
+import { VersionedQuestion } from "../models/VersionedQuestion";
 import { User, UserRole } from '../models/User';
 import { MyContext } from "../context";
 import { cloneTemplate, generateTemplateVersion, hasPermissionOnTemplate } from "../services/templateService";
@@ -78,19 +80,68 @@ export const resolvers: Resolvers = {
   },
 
   Mutation: {
-    // Add a new template by copying an existing one or starting from scratch (copyFromTemplateId left blank).
+    // Add a new template by copying an existing one or starting from scratch.
+    //    - copyFromTemplateId: Copy from working template (must be owned by admin)
+    //    - copyFromVersionedTemplateId: Copy from published version (any published template)
     //    - called by the Template Builder - prior template selection page AND the initial page
-    addTemplate: async (_, { name, copyFromTemplateId }, context: MyContext): Promise<Template> => {
+    addTemplate: async (_, { name, copyFromTemplateId, copyFromVersionedTemplateId }, context: MyContext): Promise<Template> => {
       const reference = 'addTemplate resolver';
       try {
         if (isAdmin(context.token)) {
           let template: Template;
-          if (copyFromTemplateId) {
-            // Fetch the Template we are cloning
-            const original = await Template.findById(reference, context, copyFromTemplateId);
-            template = cloneTemplate(context.token?.id, context.token.affiliationId, original);
-            template.name = name;
+          let adminOwnsTemplate = false;
+          let sourceTemplateId: number;
+
+          // Validate that only one copy source is provided
+          if (copyFromTemplateId && copyFromVersionedTemplateId) {
+            template = new Template({ name, ownerId: context.token.affiliationId });
+            template.addError('general', 'Cannot specify both copyFromTemplateId and copyFromVersionedTemplateId');
+            return template;
           }
+
+          if (copyFromTemplateId) {
+            // Copy from a working template (must be owned by admin)
+            const originalTemplate = await Template.findById(reference, context, copyFromTemplateId);
+            
+            if (originalTemplate) {
+              // Check if the admin owns this template
+              if (originalTemplate.ownerId === context.token.affiliationId) {
+                adminOwnsTemplate = true;
+                sourceTemplateId = copyFromTemplateId;
+                template = cloneTemplate(context.token?.id, context.token.affiliationId, originalTemplate);
+                template.name = name;
+                template.sourceTemplateId = copyFromTemplateId;
+                template.sourceVersionedTemplateId = null;
+              } else {
+                // Admin doesn't own this template, cannot copy from working version
+                template = new Template({ name, ownerId: context.token.affiliationId });
+                template.addError('general', 'You do not have permission to copy from this template. Use the published version instead.');
+                return template;
+              }
+            } else {
+              // Template not found
+              template = new Template({ name, ownerId: context.token.affiliationId });
+              template.addError('general', 'Template not found');
+              return template;
+            }
+          } else if (copyFromVersionedTemplateId) {
+            // Copy from a published versioned template (any published template)
+            const versionedTemplate = await VersionedTemplate.findById(reference, context, copyFromVersionedTemplateId);
+            
+            if (versionedTemplate) {
+              adminOwnsTemplate = false; // Always copy from versioned tables
+              template = cloneTemplate(context.token?.id, context.token.affiliationId, versionedTemplate);
+              template.name = name;
+              template.sourceTemplateId = null;
+              template.sourceVersionedTemplateId = copyFromVersionedTemplateId;
+            } else {
+              // Versioned template not found
+              template = new Template({ name, ownerId: context.token.affiliationId });
+              template.addError('general', 'Published template version not found');
+              return template;
+            }
+          }
+
           if (!template) {
             // Create a new blank template
             template = new Template({ name, ownerId: context.token.affiliationId });
@@ -105,42 +156,71 @@ export const resolvers: Resolvers = {
             template.addError('general', 'Unable to create Template');
           }
 
-          if (templateId && copyFromTemplateId && !newTemplate.hasErrors()) {
-            // Fetch and copy sections to sections table for new template
-            const sections = await Section.findByTemplateId(reference, context, copyFromTemplateId);
+          if (templateId && (copyFromTemplateId || copyFromVersionedTemplateId) && !newTemplate.hasErrors()) {
+            if (adminOwnsTemplate) {
+              // Copy from working tables (templates, sections, questions)
+              const sections = await Section.findByTemplateId(reference, context, sourceTemplateId);
 
-            for (const section of sections) {
-              const sectionId = section.id;
-              const newSection = cloneSection(context.token?.id, templateId, section);
-              if (newSection && !newSection.hasErrors()) {
-                const createdSection = await newSection.create(context, templateId);
+              for (const section of sections) {
+                const sectionId = section.id;
+                const newSection = cloneSection(context.token?.id, templateId, section);
+                if (newSection && !newSection.hasErrors()) {
+                  const createdSection = await newSection.create(context, templateId);
+                  const createdSectionId = createdSection.id;
 
-                const createdSectionId = createdSection.id;
+                  // Fetch and copy all related questions from questions table
+                  const questions = await Question.findBySectionId(reference, context, sectionId);
 
-                //Fetch and copy all related questions to copy to questions table for new template
-                const questions = await Question.findBySectionId(
-                  reference,
-                  context,
-                  sectionId //original sectionId since we are copying to the questions table, not versionedQuestions table
-                );
-
-                for (const q of questions) {
-                  const question = cloneQuestion(context.token?.id, templateId, createdSectionId, q);
-                  if (question) {
-                    const newQuestion = await question.create(context);
-                    if (newQuestion && newQuestion.hasErrors()) {
-                      context.logger.error(`${reference} failed to clone question`);
-                      newTemplate.addError('questions', 'Created Template but unable to clone all questions');
+                  for (const q of questions) {
+                    const question = cloneQuestion(context.token?.id, templateId, createdSectionId, q);
+                    if (question) {
+                      const newQuestion = await question.create(context);
+                      if (newQuestion && newQuestion.hasErrors()) {
+                        context.logger.error(`${reference} failed to clone question`);
+                        newTemplate.addError('questions', 'Created Template but unable to clone all questions');
+                      }
                     }
                   }
+                } else {
+                  context.logger.error(`${reference} failed to clone section`);
+                  newTemplate.addError('sections', 'Created Template but unable to clone all sections');
                 }
-              } else {
-                context.logger.error(`${reference} failed to clone section`);
-                newTemplate.addError('sections', 'Created Template but unable to clone all sections');
+              }
+            } else {
+              // Copy from published/versioned tables (versionedTemplates, versionedSections, versionedQuestions)
+              const versionedSections = await VersionedSection.findByTemplateId(reference, context, copyFromVersionedTemplateId);
+
+              for (const versionedSection of versionedSections) {
+                const versionedSectionId = versionedSection.id;
+                const section = cloneSection(context.token?.id, templateId, versionedSection);
+                if (section && !section.hasErrors()) {
+                  const newSection = await section.create(context, templateId);
+                  const sectionId = newSection.id;
+
+                  // Fetch and copy all related versionedQuestions to questions table
+                  const versionedQuestions = await VersionedQuestion.findByVersionedSectionId(
+                    reference,
+                    context,
+                    versionedSectionId
+                  );
+
+                  for (const versionedQuestion of versionedQuestions) {
+                    const question = await cloneQuestion(context.token?.id, templateId, sectionId, versionedQuestion);
+                    if (question) {
+                      const newQuestion = await question.create(context);
+                      if (newQuestion && newQuestion.hasErrors()) {
+                        context.logger.error(`${reference} failed to clone question`);
+                        newTemplate.addError('questions', 'Created Template but unable to clone all questions');
+                      }
+                    }
+                  }
+                } else {
+                  context.logger.error(`${reference} failed to clone section`);
+                  newTemplate.addError('sections', 'Created Template but unable to clone all sections');
+                }
               }
             }
           }
-
 
           return newTemplate;
         }
@@ -314,6 +394,17 @@ export const resolvers: Resolvers = {
       if (parent.ownerId) {
         const owner = await Affiliation.findByURI('TemplateSearchResult.owner', context, parent.ownerId);
         return owner?.displayName || null;
+      }
+      return null;
+    },
+    latestVersionedTemplateId: async (parent: TemplateSearchResult, _, context: MyContext): Promise<number | null> => {
+      if (parent.id && parent.latestPublishVersion) {
+        const versionedTemplate = await VersionedTemplate.findActiveByTemplateId(
+          'TemplateSearchResult.latestVersionedTemplateId',
+          context,
+          parent.id
+        );
+        return versionedTemplate?.id || null;
       }
       return null;
     },

--- a/src/resolvers/template.ts
+++ b/src/resolvers/template.ts
@@ -112,12 +112,7 @@ export const resolvers: Resolvers = {
                 template.name = name;
                 template.sourceTemplateId = copyFromTemplateId;
                 template.sourceVersionedTemplateId = null;
-              } else {
-                // Admin doesn't own this template, cannot copy from working version
-                template = new Template({ name, ownerId: context.token.affiliationId });
-                template.addError('general', 'You do not have permission to copy from this template. Use the published version instead.');
-                return template;
-              }
+              } 
             } else {
               // Template not found
               template = new Template({ name, ownerId: context.token.affiliationId });
@@ -394,17 +389,6 @@ export const resolvers: Resolvers = {
       if (parent.ownerId) {
         const owner = await Affiliation.findByURI('TemplateSearchResult.owner', context, parent.ownerId);
         return owner?.displayName || null;
-      }
-      return null;
-    },
-    latestVersionedTemplateId: async (parent: TemplateSearchResult, _, context: MyContext): Promise<number | null> => {
-      if (parent.id && parent.latestPublishVersion) {
-        const versionedTemplate = await VersionedTemplate.findActiveByTemplateId(
-          'TemplateSearchResult.latestVersionedTemplateId',
-          context,
-          parent.id
-        );
-        return versionedTemplate?.id || null;
       }
       return null;
     },

--- a/src/resolvers/template.ts
+++ b/src/resolvers/template.ts
@@ -3,8 +3,7 @@ import { Template, TemplateSearchResult, TemplateVisibility } from "../models/Te
 import { Affiliation } from "../models/Affiliation";
 import { TemplateCollaborator } from "../models/Collaborator";
 import { Section } from "../models/Section";
-import { VersionedSection } from '../models/VersionedSection';
-import { VersionedQuestion } from "../models/VersionedQuestion";
+import { Question } from '../models/Question';
 import { User, UserRole } from '../models/User';
 import { MyContext } from "../context";
 import { cloneTemplate, generateTemplateVersion, hasPermissionOnTemplate } from "../services/templateService";
@@ -87,8 +86,8 @@ export const resolvers: Resolvers = {
         if (isAdmin(context.token)) {
           let template: Template;
           if (copyFromTemplateId) {
-            // Fetch the VersionedTemplate we are cloning
-            const original = await VersionedTemplate.findVersionedTemplateById(reference, context, copyFromTemplateId);
+            // Fetch the Template we are cloning
+            const original = await Template.findById(reference, context, copyFromTemplateId);
             template = cloneTemplate(context.token?.id, context.token.affiliationId, original);
             template.name = name;
           }
@@ -107,23 +106,26 @@ export const resolvers: Resolvers = {
           }
 
           if (templateId && copyFromTemplateId && !newTemplate.hasErrors()) {
-            // Fetch and copy versionedSections to sections table for new template
-            const versionedSections = await VersionedSection.findByTemplateId(reference, context, copyFromTemplateId);
-            for (const versionedSection of versionedSections) {
-              const versionedSectionId = versionedSection.id;
-              const section = cloneSection(context.token?.id, templateId, versionedSection)
-              if (section && !section.hasErrors()) {
-                const newSection = await section.create(context, templateId);
-                const sectionId = newSection.id;
+            // Fetch and copy sections to sections table for new template
+            const sections = await Section.findByTemplateId(reference, context, copyFromTemplateId);
 
-                //Fetch and copy all related versionedQuestions to copy to questions table for new template
-                const versionedQuestions = await VersionedQuestion.findByVersionedSectionId(
+            for (const section of sections) {
+              const sectionId = section.id;
+              const newSection = cloneSection(context.token?.id, templateId, section);
+              if (newSection && !newSection.hasErrors()) {
+                const createdSection = await newSection.create(context, templateId);
+
+                const createdSectionId = createdSection.id;
+
+                //Fetch and copy all related questions to copy to questions table for new template
+                const questions = await Question.findBySectionId(
                   reference,
                   context,
-                  versionedSectionId
+                  sectionId //original sectionId since we are copying to the questions table, not versionedQuestions table
                 );
-                for (const versionedQuestion of versionedQuestions) {
-                  const question = await cloneQuestion(context.token?.id, templateId, sectionId, versionedQuestion);
+
+                for (const q of questions) {
+                  const question = cloneQuestion(context.token?.id, templateId, createdSectionId, q);
                   if (question) {
                     const newQuestion = await question.create(context);
                     if (newQuestion && newQuestion.hasErrors()) {

--- a/src/schemas/template.ts
+++ b/src/schemas/template.ts
@@ -50,8 +50,6 @@ export const typeDefs = gql`
     ownerId: String
     "The display name of the affiliation that owns the Template"
     ownerDisplayName: String
-    "versionedTemplateId of the template"
-    latestVersionedTemplateId: Int
     "The id of the person who created the template"
     createdById: Int
     "the name of the person who created the template"

--- a/src/schemas/template.ts
+++ b/src/schemas/template.ts
@@ -10,7 +10,7 @@ export const typeDefs = gql`
 
   extend type Mutation {
     "Create a new Template. Leave the 'copyFromTemplateId' blank to create a new template from scratch"
-    addTemplate(name: String!, copyFromTemplateId: Int): Template
+    addTemplate(name: String!, copyFromTemplateId: Int, copyFromVersionedTemplateId: Int): Template
     "Update a Template"
     updateTemplate(templateId: Int!, name: String!, bestPractice: Boolean): Template
     "Archive a Template (unpublishes any associated PublishedTemplate"
@@ -50,6 +50,8 @@ export const typeDefs = gql`
     ownerId: String
     "The display name of the affiliation that owns the Template"
     ownerDisplayName: String
+    "versionedTemplateId of the template"
+    latestVersionedTemplateId: Int
     "The id of the person who created the template"
     createdById: Int
     "the name of the person who created the template"
@@ -101,6 +103,8 @@ export const typeDefs = gql`
 
     "The template that this one was derived from"
     sourceTemplateId: Int
+    "The versioned template that this one was derived from"
+    sourceVersionedTemplateId: Int
     "The name/title of the template"
     name: String!
     "A description of the purpose of the template"
@@ -134,6 +138,7 @@ export const typeDefs = gql`
     general: String
 
     sourceTemplateId: String
+    sourceVersionedTemplateId: String
     name: String
     description: String
     ownerId: String

--- a/src/types.ts
+++ b/src/types.ts
@@ -1443,6 +1443,7 @@ export type MutationAddTagArgs = {
 
 export type MutationAddTemplateArgs = {
   copyFromTemplateId?: InputMaybe<Scalars['Int']['input']>;
+  copyFromVersionedTemplateId?: InputMaybe<Scalars['Int']['input']>;
   name: Scalars['String']['input'];
 };
 
@@ -3804,6 +3805,8 @@ export type Template = {
   sections?: Maybe<Array<Maybe<Section>>>;
   /** The template that this one was derived from */
   sourceTemplateId?: Maybe<Scalars['Int']['output']>;
+  /** The versioned template that this one was derived from */
+  sourceVersionedTemplateId?: Maybe<Scalars['Int']['output']>;
 };
 
 /** A user that that belongs to a different affiliation that can edit the Template */
@@ -3903,6 +3906,7 @@ export type TemplateErrors = {
   ownerId?: Maybe<Scalars['String']['output']>;
   sectionIds?: Maybe<Scalars['String']['output']>;
   sourceTemplateId?: Maybe<Scalars['String']['output']>;
+  sourceVersionedTemplateId?: Maybe<Scalars['String']['output']>;
 };
 
 /** A search result for templates */
@@ -3928,6 +3932,8 @@ export type TemplateSearchResult = {
   latestPublishVersion?: Maybe<Scalars['String']['output']>;
   /** Visibility set for the last published template */
   latestPublishVisibility?: Maybe<TemplateVisibility>;
+  /** versionedTemplateId of the template */
+  latestVersionedTemplateId?: Maybe<Scalars['Int']['output']>;
   /** The timestamp when the Template was last modified */
   modified?: Maybe<Scalars['String']['output']>;
   /** The id of the person who last modified the template */
@@ -6624,6 +6630,7 @@ export type TemplateResolvers<ContextType = MyContext, ParentType extends Resolv
   owner?: Resolver<Maybe<ResolversTypes['Affiliation']>, ParentType, ContextType>;
   sections?: Resolver<Maybe<Array<Maybe<ResolversTypes['Section']>>>, ParentType, ContextType>;
   sourceTemplateId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  sourceVersionedTemplateId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
 };
 
 export type TemplateCollaboratorResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['TemplateCollaborator'] = ResolversParentTypes['TemplateCollaborator']> = {
@@ -6673,6 +6680,7 @@ export type TemplateErrorsResolvers<ContextType = MyContext, ParentType extends 
   ownerId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   sectionIds?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   sourceTemplateId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  sourceVersionedTemplateId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 };
 
 export type TemplateSearchResultResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['TemplateSearchResult'] = ResolversParentTypes['TemplateSearchResult']> = {
@@ -6686,6 +6694,7 @@ export type TemplateSearchResultResolvers<ContextType = MyContext, ParentType ex
   latestPublishDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   latestPublishVersion?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   latestPublishVisibility?: Resolver<Maybe<ResolversTypes['TemplateVisibility']>, ParentType, ContextType>;
+  latestVersionedTemplateId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   modifiedByName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3932,8 +3932,6 @@ export type TemplateSearchResult = {
   latestPublishVersion?: Maybe<Scalars['String']['output']>;
   /** Visibility set for the last published template */
   latestPublishVisibility?: Maybe<TemplateVisibility>;
-  /** versionedTemplateId of the template */
-  latestVersionedTemplateId?: Maybe<Scalars['Int']['output']>;
   /** The timestamp when the Template was last modified */
   modified?: Maybe<Scalars['String']['output']>;
   /** The id of the person who last modified the template */
@@ -6694,7 +6692,6 @@ export type TemplateSearchResultResolvers<ContextType = MyContext, ParentType ex
   latestPublishDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   latestPublishVersion?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   latestPublishVisibility?: Resolver<Maybe<ResolversTypes['TemplateVisibility']>, ParentType, ContextType>;
-  latestVersionedTemplateId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   modifiedByName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;


### PR DESCRIPTION
## Description

Fixed breaking cloning of template. The `addTemplate` was updated to accept a `copyFromVersionedTemplateId` so that we copy from versioned template, section and questions, when it's not a template from the user's org. Otherwise we check for `copyFromTemplateId` to copy/clone from templates, sections and questions, and if neither are present, we continue to create a new record for `templates` table
- Added new field, `sourceVersionedTemplateId` field to `templates` table so we can track the source when cloned from a `versionedTemplates` record
- Updated `addTemplate` resolver to either copy from `templates`, `sections` and `questions` when `copyFromTemplateId` is specified, and from `versionedTemplates`, `versionedSections` and `versionedQuestions` when `copyFromVersionedTemplateId` is specified. Otherwise, we just create a new template record from the `name`

Fixes # ([1006](https://github.com/CDLUC3/dmsp_frontend_prototype/issues/1006))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually tested with corresponding  frontend changes


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules