### PR TITLE
Fix pagination issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - Removed `ioredis` package
 
 ### Fixed
+- In `preparePaginationOptions` function, wrapped each cursorField with `COALESCE` to handle `NULL` values in SQL `CONCAT`, otherwise if any cursorField is NULL, it would just return a null value due to the way `CONCAT` works [#107]
 - Fixed breaking cloning of template. The `addTemplate` was updated to accept a `copyFromVersionedTemplateId` so that we copy from versioned template, section and questions, when it's not a template from the user's org. Otherwise we check for `copyFromTemplateId` to copy/clone from templates, sections and questions, and if neither are present, we continue to create a new record for `templates` table [#1006]
 - Fixed issue with templates not cloning with sections and questions by updating the `addTemplate` mutation to clone from non-versioned template, section and question [#1006]
 ## v1.0

--- a/src/models/MySqlModel.ts
+++ b/src/models/MySqlModel.ts
@@ -234,9 +234,12 @@ export class MySqlModel {
         cursorFields.unshift(paginationOptions.sortField);
       }
 
+      // Wrap each field with COALESCE to handle NULL values in SQL CONCAT
+      const coalesced = cursorFields.map(field => `COALESCE(${field}, '')`).join(', ');
+
       return {
         ...paginationOptions,
-        cursorField: `LOWER(REPLACE(CONCAT(${cursorFields.join(', ')}), ' ', '_'))`
+        cursorField: `LOWER(REPLACE(CONCAT(${coalesced}), ' ', '_'))`
       };
     }
   }
@@ -381,14 +384,14 @@ export class MySqlModel {
 
       const totalCount = calculateTotalCount
         ? await this.getTotalCountForPagination(
-            apolloContext,
-            sqlStatement,
-            whereClause,
-            groupByClause,
-            options.countField ?? 'id',
-            values,
-            reference
-          )
+          apolloContext,
+          sqlStatement,
+          whereClause,
+          groupByClause,
+          options.countField ?? 'id',
+          values,
+          reference
+        )
         : 0;
 
       const currentOffset = options.offset ?? 0;
@@ -470,14 +473,14 @@ export class MySqlModel {
       // Use original WHERE clause and original values for total count
       const totalCount: number = calculateTotalCount
         ? await this.getTotalCountForPagination(
-            apolloContext,
-            sqlStatement,
-            originalWhereClause,
-            groupByClause,
-            options.countField ?? 'id',
-            values,
-            reference
-          )
+          apolloContext,
+          sqlStatement,
+          originalWhereClause,
+          groupByClause,
+          options.countField ?? 'id',
+          values,
+          reference
+        )
         : 0;
 
       const nextCursor = items.length > 0 ? items[items.length - 1]?.cursorId : undefined;

--- a/src/models/__tests__/MySqlModel.spec.ts
+++ b/src/models/__tests__/MySqlModel.spec.ts
@@ -325,7 +325,7 @@ describe('preparePaginationOptions', () => {
     const result = MySqlModel.preparePaginationOptions(options);
     expect(result).toEqual({
       ...options,
-      cursorField: 'LOWER(REPLACE(CONCAT(name, id), \' \', \'_\'))'
+      cursorField: "LOWER(REPLACE(CONCAT(COALESCE(name, ''), COALESCE(id, '')), ' ', '_'))",
     });
   });
 
@@ -342,7 +342,7 @@ describe('preparePaginationOptions', () => {
     const result = MySqlModel.preparePaginationOptions(options);
     expect(result).toEqual({
       ...options,
-      cursorField: 'LOWER(REPLACE(CONCAT(name, custom_field), \' \', \'_\'))'
+      cursorField: "LOWER(REPLACE(CONCAT(COALESCE(name, ''), COALESCE(custom_field, '')), ' ', '_'))"
     });
   });
 
@@ -359,7 +359,7 @@ describe('preparePaginationOptions', () => {
     expect(result).toEqual({
       ...options,
       availableSortFields: [],
-      cursorField: 'LOWER(REPLACE(CONCAT(custom_field), \' \', \'_\'))'
+      cursorField: "LOWER(REPLACE(CONCAT(COALESCE(custom_field, '')), ' ', '_'))",
     });
   });
 });
@@ -562,7 +562,7 @@ describe('queryWithPagination', () => {
       {
         ...options,
         availableSortFields: [],
-        cursorField: 'LOWER(REPLACE(CONCAT(id), \' \', \'_\'))'
+        cursorField: "LOWER(REPLACE(CONCAT(COALESCE(id, '')), ' ', '_'))",
       },
       reference,
       true

--- a/src/types.ts
+++ b/src/types.ts
@@ -4332,6 +4332,7 @@ export type TemplateCustomizationOverview = {
   customizationLastCustomized?: Maybe<Scalars['String']['output']>;
   customizationLastCustomizedById?: Maybe<Scalars['Int']['output']>;
   customizationLastCustomizedByName?: Maybe<Scalars['String']['output']>;
+  customizationLastPublishedDate?: Maybe<Scalars['String']['output']>;
   customizationMigrationStatus: TemplateCustomizationMigrationStatus;
   customizationStatus: TemplateCustomizationStatus;
   errors?: Maybe<TemplateCustomizationErrors>;
@@ -7394,6 +7395,7 @@ export type TemplateCustomizationOverviewResolvers<ContextType = MyContext, Pare
   customizationLastCustomized?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   customizationLastCustomizedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   customizationLastCustomizedByName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  customizationLastPublishedDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   customizationMigrationStatus?: Resolver<ResolversTypes['TemplateCustomizationMigrationStatus'], ParentType, ContextType>;
   customizationStatus?: Resolver<ResolversTypes['TemplateCustomizationStatus'], ParentType, ContextType>;
   errors?: Resolver<Maybe<ResolversTypes['TemplateCustomizationErrors']>, ParentType, ContextType>;


### PR DESCRIPTION
## Description

- Added `COALESCE` to the `cursorField` calculation so that `NULL` isn't returned, and therefore `nextCursor = NULL` any time a cursorField value was NULL.

Fixes # ([107](https://github.com/CDLUC3/dmptool-doc/issues/107))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually tested with the `template/customizations` page, which is where it was observed to be breaking.


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules