### PR TITLE
Update Answer model to set a default output type for ResearchOutputTable entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.1.0
 
 ### Added
+- Added logic to set a default output type for each entry in a `ResearchOutputTable` answer.
 - Added `guidanceText` and `sampleText` fields to `addQuestionCustomization` and added `json`, `questionText`, `requirementText`, `guidanceText`, `sampleText`, `useSampleTextAsDefault` and `required` to `addCustomQuestionInput` [#130]
 - Added `questionCustomizationByVersionedQuestion` resolver [#130]
 - Added `findByCustomizationAndVersionedQuestion` method to `QuestionCustomization` model [#130]

--- a/src/models/Answer.ts
+++ b/src/models/Answer.ts
@@ -2,9 +2,16 @@ import { MyContext } from "../context";
 import { MySqlModel } from "./MySqlModel";
 import {
   isNullOrUndefined,
-  removeNullAndUndefinedFromJSON
+  removeNullAndUndefinedFromJSON,
 } from "../utils/helpers";
-import { AnswerSchemaMap } from "@dmptool/types";
+import {
+  AnswerSchemaMap,
+  AnyResearchOutputTableColumnAnswerType,
+  ResearchOutputTableRowAnswerType,
+  CURRENT_SCHEMA_VERSION,
+  QuestionFormatsEnum,
+  SelectBoxAnswerType
+} from "@dmptool/types";
 
 export class Answer extends MySqlModel {
   public planId: number;
@@ -68,11 +75,62 @@ export class Answer extends MySqlModel {
   prepForSave(): void {
     // Remove leading/trailing blank spaces
     this.json = this.json?.trim();
+
+    const parsedJSON = JSON.parse(this.json);
+
+    // If this is not a research output table, we don't need to do anything further
+    if (parsedJSON.type !== QuestionFormatsEnum.enum.researchOutputTable) {
+      return;
+    }
+
+    // Extract the output type columns
+    let modified = false;
+
+    // Process each output in the table
+    parsedJSON.answer = parsedJSON.answer.map((row: ResearchOutputTableRowAnswerType) => {
+      const columns: AnyResearchOutputTableColumnAnswerType[] = row.columns || [];
+      const typeCol = columns.find((col: AnyResearchOutputTableColumnAnswerType) => {
+        return col.commonStandardId === 'type';
+      }) as SelectBoxAnswerType;
+
+      // If the output type column is missing or empty/null
+      if (!typeCol || !typeCol.answer || typeCol.answer.trim() === '') {
+        modified = true;
+
+        // Create the default column object
+        const defaultTypeCol: SelectBoxAnswerType = {
+          type: "selectBox",
+          commonStandardId: 'type',
+          answer: "Unknown",
+          meta: { schemaVersion: CURRENT_SCHEMA_VERSION },
+        } as unknown as SelectBoxAnswerType;
+
+        // Return the row with the updated columns list
+        return {
+          ...row,
+          columns: [
+            ...columns.filter((col: AnyResearchOutputTableColumnAnswerType) => {
+              return col.commonStandardId !== 'type';
+            }),
+            defaultTypeCol
+          ]
+        };
+      }
+
+      return row;
+    });
+
+// Only stringify and re-assign if we actually changed something
+    if (modified) {
+      this.json = JSON.stringify(parsedJSON);
+    }
   }
 
   //Create a new Answer
   async create(context: MyContext): Promise<Answer> {
     const reference = 'Answer.create';
+
+    this.prepForSave();
 
     // First make sure the record is valid
     if (await this.isValid()) {
@@ -99,6 +157,8 @@ export class Answer extends MySqlModel {
 
   //Update an existing Answer
   async update(context: MyContext, noTouch = false): Promise<Answer> {
+    this.prepForSave();
+
     if (await this.isValid()) {
       if (this.id) {
         await Answer.update(context, Answer.tableName, this, 'Answer.update', [], noTouch);

--- a/src/models/__tests__/Answer.spec.ts
+++ b/src/models/__tests__/Answer.spec.ts
@@ -64,6 +64,130 @@ describe('Answer', () => {
     expect(Object.keys(answer.errors).length).toBe(1);
     expect(answer.errors['planId']).toBeTruthy();
   });
+
+  it('prepForSave should NOT add the default output type column if the answer is NOT a ResearchOutputTableAnswer', async () => {
+    answer.json = `{"type":"textArea","answer":"California","meta":{"schemaVersion":"${CURRENT_SCHEMA_VERSION}"}}`;
+    answer.prepForSave();
+    expect(answer.json).toEqual(answer.json);
+  });
+
+  it('prepForSave should NOT add the default output type column if the answer is a ResearchOutputTableAnswer but has one defined', async () => {
+    answer.json = JSON.stringify({
+      type: "researchOutputTable",
+      columnHeadings: ["Title", "Type"],
+      answer: [{
+        columns: [
+          {
+            type: "text",
+            commonStandardId: 'title',
+            answer: "",
+            meta: { schemaVersion: CURRENT_SCHEMA_VERSION },
+          },
+          {
+            type: "selectBox",
+            commonStandardId: 'type',
+            answer: "",
+            meta: { schemaVersion: CURRENT_SCHEMA_VERSION },
+          }
+        ]
+      }],
+      meta: {
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      }
+    });
+    answer.prepForSave();
+    expect(answer.json).toEqual(answer.json);
+  });
+
+  it('prepForSave should add the default output type column if the answer is a ResearchOutputTableAnswer and it is missing', async () => {
+    const baseJSON = {
+      type: "researchOutputTable",
+      columnHeadings: ["Title", "Type"],
+      answer: [{
+        columns: [
+          {
+            type: "text",
+            commonStandardId: 'title',
+            answer: "",
+            meta: { schemaVersion: CURRENT_SCHEMA_VERSION },
+          }
+        ]
+      }],
+      meta: {
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      }
+    };
+    answer.json = JSON.stringify(baseJSON);
+
+    const expectedJSON = JSON.stringify({
+      type: "researchOutputTable",
+      columnHeadings: ["Title", "Type"],
+      answer: [{
+        columns: [
+          ...baseJSON.answer[0].columns,
+          {
+            type: "selectBox",
+            commonStandardId: 'type',
+            answer: "Unknown",
+            meta: { schemaVersion: CURRENT_SCHEMA_VERSION },
+          }
+        ]
+      }],
+      meta: { schemaVersion: CURRENT_SCHEMA_VERSION }
+    });
+    answer.prepForSave();
+    expect(answer.json).toEqual(expectedJSON);
+  });
+
+  it('prepForSave should add the default output type column if the answer is a ResearchOutputTableAnswer and it is blank', async () => {
+    const baseJSON = {
+      type: "researchOutputTable",
+      columnHeadings: ["Title", "Type"],
+      answer: [
+        {
+          columns: [
+            {
+              type: "text",
+              commonStandardId: 'title',
+              answer: "",
+              meta: { schemaVersion: CURRENT_SCHEMA_VERSION },
+            },
+            {
+              type: "selectBox",
+              commonStandardId: 'type',
+              answer: "dataset",
+              meta: { schemaVersion: CURRENT_SCHEMA_VERSION },
+            }
+          ]
+        },
+        {
+          columns: [
+            {
+              type: "text",
+              commonStandardId: 'title',
+              answer: "",
+              meta: { schemaVersion: CURRENT_SCHEMA_VERSION },
+            },
+            {
+              type: "selectBox",
+              commonStandardId: 'type',
+              answer: "",
+              meta: { schemaVersion: CURRENT_SCHEMA_VERSION },
+            }
+          ]
+        }
+      ],
+      meta: {
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      }
+    };
+    answer.json = JSON.stringify(baseJSON);
+
+    const expectedJSON = baseJSON;
+    expectedJSON.answer[1].columns[1].answer = "Unknown";
+    answer.prepForSave();
+    expect(answer.json).toEqual(JSON.stringify(expectedJSON));
+  });
 });
 
 describe('findBy Queries', () => {


### PR DESCRIPTION
## Description

Related to frontend PR [#1199](https://github.com/CDLUC3/dmptool-ui/pull/1199) 
Part of Fix for [#33](https://github.com/CDLUC3/dmptool-doc/issues/33)

- Update the Answer model to call the `prepForSave` function when creating or updating an Answer.
- Update the `prepForSave` function to ensure that each row/entry in a `ResearchOutputTable` answer has an output type entry. The UI no longer requires it, so we set it to "Unknown"

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Added additional unit tests


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules