### PR TITLE
Updated VersionedTemplateSearchResult search function to return versionedTemplateCustomizationId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated the `VersionedTemplateSearchResult` to return `versionedTemplateCustomizationId` for the `search` function [#166]
 - Update `domain` to `emailDomain` in `AffiliationEmailDomain` model to match field name in table
 - Update buildspec to use `--omit=dev` instead of `--production` on `npm` commands
 - Updated `re3data-os-populate.ts` because `fetchWithTimeout` kept erroring out when we populate the OpenSearch data. We needed to add a `catch` and `retries` because a single failed attempt would kill the entire sync. [#118]

--- a/src/models/VersionedTemplate.ts
+++ b/src/models/VersionedTemplate.ts
@@ -65,6 +65,7 @@ export class VersionedTemplateSearchResult {
     term: string,
     options: TemplateQueryOptions = VersionedTemplate.getDefaultPaginationOptions(),
   ): Promise<PaginatedQueryResults<VersionedTemplateSearchResult>> {
+    const userAffiliationId = context.token?.affiliationId;
     const whereFilters = ['vt.active = 1 AND vt.versionType = ?'];
     const values = [TemplateVersionType.PUBLISHED.toString()];
 
@@ -114,8 +115,11 @@ export class VersionedTemplateSearchResult {
       'FROM versionedTemplates vt',
       'LEFT JOIN users u ON u.id = vt.modifiedById',
       'LEFT JOIN affiliations a ON a.uri = vt.ownerId',
-      'LEFT JOIN versionedTemplateCustomizations vtc ON vtc.currentVersionedTemplateId = vt.id'
+      'LEFT JOIN versionedTemplateCustomizations vtc ON vtc.currentVersionedTemplateId = vt.id',
+      'AND vtc.affiliationId = ?'
     ].join(' ');
+
+    values.unshift(userAffiliationId);
 
     const response: PaginatedQueryResults<VersionedTemplateSearchResult> = await VersionedTemplate.queryWithPagination(
       context,

--- a/src/models/VersionedTemplate.ts
+++ b/src/models/VersionedTemplate.ts
@@ -38,6 +38,7 @@ export class VersionedTemplateSearchResult {
   public modifiedById: number;
   public modifiedByName: string;
   public modified: string;
+  public versionedTemplateCustomizationId?: number;
 
   constructor(options) {
     this.id = options.id;
@@ -54,6 +55,7 @@ export class VersionedTemplateSearchResult {
     this.modifiedById = options.modifiedById;
     this.modifiedByName = options.modifiedByName;
     this.modified = options.modified;
+    this.versionedTemplateCustomizationId = options.versionedTemplateCustomizationId;
   }
 
   // Find all of the high level details about the published templates matching the search term
@@ -103,13 +105,17 @@ export class VersionedTemplateSearchResult {
       opts.cursorField = 'vt.id';
     }
 
-    const sqlStatement = 'SELECT vt.id, vt.templateId, vt.name, vt.description, vt.version, vt.visibility, vt.bestPractice, \
-                            vt.modified, vt.modifiedById, TRIM(CONCAT(u.givenName, CONCAT(\' \', u.surName))) as modifiedByName, \
-                            a.id as ownerId, vt.ownerId as ownerURI, a.displayName as ownerDisplayName, \
-                            a.searchName as ownerSearchName \
-                          FROM versionedTemplates vt \
-                            LEFT JOIN users u ON u.id = vt.modifiedById \
-                            LEFT JOIN affiliations a ON a.uri = vt.ownerId';
+    const sqlStatement = [
+      'SELECT vt.id, vt.templateId, vt.name, vt.description, vt.version, vt.visibility, vt.bestPractice,',
+      'vt.modified, vt.modifiedById, TRIM(CONCAT(u.givenName, " ", u.surName)) as modifiedByName,',
+      'a.id as ownerId, vt.ownerId as ownerURI, a.displayName as ownerDisplayName,',
+      'a.searchName as ownerSearchName,',
+      'vtc.id as versionedTemplateCustomizationId',
+      'FROM versionedTemplates vt',
+      'LEFT JOIN users u ON u.id = vt.modifiedById',
+      'LEFT JOIN affiliations a ON a.uri = vt.ownerId',
+      'LEFT JOIN versionedTemplateCustomizations vtc ON vtc.currentVersionedTemplateId = vt.id'
+    ].join(' ');
 
     const response: PaginatedQueryResults<VersionedTemplateSearchResult> = await VersionedTemplate.queryWithPagination(
       context,

--- a/src/models/__tests__/VersionedTemplate.spec.ts
+++ b/src/models/__tests__/VersionedTemplate.spec.ts
@@ -85,13 +85,15 @@ describe('VersionedTemplateSearchResult', () => {
 
       const term = versionedTemplateSearchResult.name.split(0, 5)[0];
       const result = await VersionedTemplateSearchResult.search('Test', context, term);
-      const sql = 'SELECT vt.id, vt.templateId, vt.name, vt.description, vt.version, vt.visibility, vt.bestPractice, \
-                            vt.modified, vt.modifiedById, TRIM(CONCAT(u.givenName, CONCAT(\' \', u.surName))) as modifiedByName, \
-                            a.id as ownerId, vt.ownerId as ownerURI, a.displayName as ownerDisplayName, \
-                            a.searchName as ownerSearchName \
-                          FROM versionedTemplates vt \
-                            LEFT JOIN users u ON u.id = vt.modifiedById \
-                            LEFT JOIN affiliations a ON a.uri = vt.ownerId';
+      const sql =
+            'SELECT vt.id, vt.templateId, vt.name, vt.description, vt.version, vt.visibility, vt.bestPractice, ' +
+            'vt.modified, vt.modifiedById, TRIM(CONCAT(u.givenName, " ", u.surName)) as modifiedByName, ' +
+            'a.id as ownerId, vt.ownerId as ownerURI, a.displayName as ownerDisplayName, ' +
+            'a.searchName as ownerSearchName, vtc.id as versionedTemplateCustomizationId ' +
+            'FROM versionedTemplates vt ' +
+            'LEFT JOIN users u ON u.id = vt.modifiedById ' +
+            'LEFT JOIN affiliations a ON a.uri = vt.ownerId ' +
+            'LEFT JOIN versionedTemplateCustomizations vtc ON vtc.currentVersionedTemplateId = vt.id';
       const vals = [TemplateVersionType.PUBLISHED, `%${term.toLowerCase()}%`, `%${term.toLowerCase()}%`];
       const whereFilters = ['vt.active = 1 AND vt.versionType = ?',
                             '(LOWER(vt.name) LIKE ? OR LOWER(a.searchName) LIKE ?)'];

--- a/src/models/__tests__/VersionedTemplate.spec.ts
+++ b/src/models/__tests__/VersionedTemplate.spec.ts
@@ -85,6 +85,7 @@ describe('VersionedTemplateSearchResult', () => {
 
       const term = versionedTemplateSearchResult.name.split(0, 5)[0];
       const result = await VersionedTemplateSearchResult.search('Test', context, term);
+      const affiliationId = context.token.affiliationId;
       const sql =
             'SELECT vt.id, vt.templateId, vt.name, vt.description, vt.version, vt.visibility, vt.bestPractice, ' +
             'vt.modified, vt.modifiedById, TRIM(CONCAT(u.givenName, " ", u.surName)) as modifiedByName, ' +
@@ -93,8 +94,8 @@ describe('VersionedTemplateSearchResult', () => {
             'FROM versionedTemplates vt ' +
             'LEFT JOIN users u ON u.id = vt.modifiedById ' +
             'LEFT JOIN affiliations a ON a.uri = vt.ownerId ' +
-            'LEFT JOIN versionedTemplateCustomizations vtc ON vtc.currentVersionedTemplateId = vt.id';
-      const vals = [TemplateVersionType.PUBLISHED, `%${term.toLowerCase()}%`, `%${term.toLowerCase()}%`];
+            'LEFT JOIN versionedTemplateCustomizations vtc ON vtc.currentVersionedTemplateId = vt.id AND vtc.affiliationId = ?';
+      const vals = [affiliationId, TemplateVersionType.PUBLISHED, `%${term.toLowerCase()}%`, `%${term.toLowerCase()}%`];
       const whereFilters = ['vt.active = 1 AND vt.versionType = ?',
                             '(LOWER(vt.name) LIKE ? OR LOWER(a.searchName) LIKE ?)'];
 

--- a/src/schemas/versionedTemplate.ts
+++ b/src/schemas/versionedTemplate.ts
@@ -79,6 +79,8 @@ export const typeDefs = gql`
     modifiedByName: String
     "The timestamp when the Template was last modified"
     modified: String
+    "The id of the template customization (undefined means the template has not been customized yet)"
+    versionedTemplateCustomizationId: Int
   }
 
   type CustomizableTemplateSearchResults implements PaginatedQueryResults {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5457,6 +5457,8 @@ export type VersionedTemplateSearchResult = {
   templateId?: Maybe<Scalars['Int']['output']>;
   /** The major.minor semantic version */
   version?: Maybe<Scalars['String']['output']>;
+  /** The id of the template customization (undefined means the template has not been customized yet) */
+  versionedTemplateCustomizationId?: Maybe<Scalars['Int']['output']>;
   /** The template's availability setting: Public is available to everyone, Private only your affiliation */
   visibility?: Maybe<TemplateVisibility>;
 };
@@ -8043,6 +8045,7 @@ export type VersionedTemplateSearchResultResolvers<ContextType = MyContext, Pare
   ownerURI?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   templateId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   version?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  versionedTemplateCustomizationId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   visibility?: Resolver<Maybe<ResolversTypes['TemplateVisibility']>, ParentType, ContextType>;
 };
 


### PR DESCRIPTION
## Description

- Updated the `VersionedTemplateSearchResult` to return `versionedTemplateCustomizationId` for the `search` function

Fixes # ([166](https://github.com/CDLUC3/dmptool-doc/issues/166))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested and updated unit test for the updated sql query


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules