### PR TITLE
Merge DMP work search results in batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated the `batch_update_related_works` stored procedure to operate on batches of DMPs and improve speed of stored procedure by joining based on plan ID rather than plan ID or DMP DOI. Updated the unit tests to use `@testcontainers/mysql` so that they can run in CI, are self-contained and don't affect local tables.
 - Updated `answerByVersionedQuestionId` query and `addAnswer` mutation to pass in `versionedCustomSectionId` and `versionedCustomQuestionid` variables so that we can get and save the correct answers [#173]
 - Updated sql query in `findActiveByTemplateAffiliationAndQuestion` function in `VersionedQuestionCustomization` model to include `affiliationId` so that we can get the name of the org that made the customization [#173]
 - Updated `publishedQuestion` resolver in `versionedQuestion.ts` to return customization info, including customized sample answer and name of org that made the customization [#173]

--- a/data-migrations/2026-04-10-1600-refactor-stored-procs.sql
+++ b/data-migrations/2026-04-10-1600-refactor-stored-procs.sql
@@ -1,0 +1,252 @@
+DROP PROCEDURE IF EXISTS create_related_works_staging_tables;
+DROP PROCEDURE IF EXISTS batch_update_related_works;
+DROP PROCEDURE IF EXISTS cleanup_orphan_works;
+
+DELIMITER $$
+
+-- Creates the two temporary staging tables that callers populate before
+-- calling batch_update_related_works.
+CREATE PROCEDURE `create_related_works_staging_tables`()
+BEGIN
+  DROP TEMPORARY TABLE IF EXISTS stagingWorkVersions;
+  CREATE TEMPORARY TABLE stagingWorkVersions
+  (
+    `doi`              VARCHAR(255) NOT NULL PRIMARY KEY,
+    `hash`             BINARY(16)   NOT NULL,
+    `workType`         VARCHAR(255) NOT NULL,
+    `publicationDate`  DATE         NULL,
+    `title`            TEXT         NULL,
+    `abstractText`     MEDIUMTEXT         NULL,
+    `authors`          JSON         NOT NULL,
+    `institutions`     JSON         NOT NULL,
+    `funders`          JSON         NOT NULL,
+    `awards`           JSON         NOT NULL,
+    `publicationVenue` VARCHAR(1000) NULL,
+    `sourceName`       VARCHAR(255) NOT NULL,
+    `sourceUrl`        VARCHAR(255) NOT NULL
+  ) ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_0900_ai_ci;
+
+  DROP TEMPORARY TABLE IF EXISTS stagingRelatedWorks;
+  CREATE TEMPORARY TABLE stagingRelatedWorks
+  (
+    `id`                 INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `planId`             INT UNSIGNED NOT NULL,
+    `workDoi`            VARCHAR(255) NOT NULL,
+    `hash`               BINARY(16)   NOT NULL,
+    `sourceType`         VARCHAR(32)  NOT NULL,
+    `score`              FLOAT        NOT NULL,
+    `status`             VARCHAR(255) NOT NULL,
+    `scoreMax`           FLOAT        NOT NULL,
+    `doiMatch`           JSON         NOT NULL,
+    `contentMatch`       JSON         NOT NULL,
+    `authorMatches`      JSON         NOT NULL,
+    `institutionMatches` JSON         NOT NULL,
+    `funderMatches`      JSON         NOT NULL,
+    `awardMatches`       JSON         NOT NULL,
+
+    INDEX (`planId`, `workDoi`),
+    CONSTRAINT unique_plan_work UNIQUE (`planId`, `workDoi`)
+  ) ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_0900_ai_ci;
+END$$
+
+DELIMITER ;
+
+DELIMITER $$
+
+-- Upserts staging data into works, workVersions, and relatedWorks within a transaction.
+--
+-- Flow:
+--   1. Insert new works and workVersions (deduplicated by DOI and hash).
+--   2. Resolve staging rows to real foreign keys (planId, workVersionId).
+--   3. Insert new relatedWorks links for plans that don't already link to a given DOI.
+--   4. Update existing relatedWorks links (matched by DOI, not workVersionId)
+--      with the latest staging data (behaviour depends on mode: see below).
+--   5. (System mode only) Delete stale PENDING links no longer present in this batch.
+--
+-- Modes:
+--   systemMatched = FALSE (user-triggered): only syncs the status field on existing links.
+--   systemMatched = TRUE  (system re-match): overwrites all scoring fields on PENDING rows,
+--     if a new workVersion was crated in step 1 the workVersionId is updated,
+--     and garbage-collects stale PENDING links no longer present in this batch.
+CREATE PROCEDURE `batch_update_related_works`(IN systemMatched BOOLEAN)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+      ROLLBACK;
+      RESIGNAL;
+    END;
+
+  START TRANSACTION;
+
+  -- works: register any new DOIs, skips if DOI already exists (unique_doi constraint)
+  INSERT IGNORE INTO works (doi)
+  SELECT doi
+  FROM stagingWorkVersions;
+
+  -- workVersions: insert new version snapshots. Skips if this (workId, hash) pair
+  -- already exists (unique_hash composite constraint). workId is resolved via s.doi = w.doi.
+  INSERT IGNORE INTO workVersions (workId, hash, workType, publicationDate, title,
+                                   abstractText, authors, institutions, funders,
+                                   awards, publicationVenue, sourceName,
+                                   sourceUrl)
+  SELECT w.id,
+         s.hash,
+         s.workType,
+         s.publicationDate,
+         s.title,
+         s.abstractText,
+         s.authors,
+         s.institutions,
+         s.funders,
+         s.awards,
+         s.publicationVenue,
+         s.sourceName,
+         s.sourceUrl
+  FROM stagingWorkVersions s
+         INNER JOIN works w ON s.doi = w.doi;
+
+  DROP TEMPORARY TABLE IF EXISTS resolvedStagingLinks;
+  CREATE TEMPORARY TABLE resolvedStagingLinks
+  (
+    `id`            INT UNSIGNED NOT NULL,
+    `planId`        INT          NOT NULL,
+    `workVersionId` INT UNSIGNED NOT NULL,
+    `workDoi`       VARCHAR(255) NOT NULL,
+    UNIQUE KEY (`planId`, `workVersionId`)
+  )
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_0900_ai_ci;
+
+  -- resolvedStagingLinks: map each staging row to its real foreign keys (planId, workVersionId)
+  -- by joining through works and workVersions on doi and hash.
+  -- The id column carries stagingRelatedWorks.id so we can join back to it later.
+  INSERT INTO resolvedStagingLinks (id, planId, workVersionId, workDoi)
+  SELECT s.id  AS id,
+         p.id  AS planId,
+         wv.id AS workVersionId,
+         s.workDoi
+  FROM stagingRelatedWorks s
+         JOIN plans p ON s.planId = p.id
+         JOIN works w ON s.workDoi = w.doi
+         JOIN workVersions wv ON wv.workId = w.id AND wv.hash = s.hash;
+
+  -- relatedWorks: link works to plans. Deduplicates by (planId, DOI) rather than
+  -- relying on the table's unique_planId_workVersionId constraint, because a single
+  -- work can have multiple workVersions (different hashes) and we only want one
+  -- link per plan per work.
+  INSERT INTO relatedWorks (planId, workVersionId, sourceType, score, status,
+                            scoreMax, doiMatch, contentMatch, authorMatches,
+                            institutionMatches, funderMatches, awardMatches)
+  SELECT links.planId,
+         links.workVersionId,
+         s.sourceType,
+         s.score,
+         s.status,
+         s.scoreMax,
+         s.doiMatch,
+         s.contentMatch,
+         s.authorMatches,
+         s.institutionMatches,
+         s.funderMatches,
+         s.awardMatches
+  FROM resolvedStagingLinks links
+         JOIN stagingRelatedWorks s ON links.id = s.id
+         LEFT JOIN (
+    relatedWorks r
+      JOIN workVersions wv ON r.workVersionId = wv.id
+      JOIN works w ON wv.workId = w.id
+    ) ON links.planId = r.planId AND links.workDoi = w.doi
+  WHERE r.id IS NULL;                   -- only insert if not already linked
+
+  -- User-triggered match: only sync the status field, preserving existing scoring data.
+  -- <=> treats NULL = NULL as true.
+  IF systemMatched = FALSE THEN
+    UPDATE relatedWorks r
+      JOIN workVersions wv ON r.workVersionId = wv.id
+      JOIN works w ON wv.workId = w.id
+      JOIN resolvedStagingLinks links ON r.planId = links.planId AND w.doi = links.workDoi
+      JOIN stagingRelatedWorks s ON links.id = s.id
+    SET r.status = s.status
+    WHERE NOT (r.status <=> s.status);
+  END IF;
+
+  -- System re-match: update PENDING rows with latest scoring data and workVersionId
+  -- (which may point to a newer version of the same work if its metadata hash changed)
+  IF systemMatched = TRUE THEN
+    UPDATE relatedWorks r
+      JOIN workVersions wv ON r.workVersionId = wv.id
+      JOIN works w ON wv.workId = w.id
+      JOIN resolvedStagingLinks links ON r.planId = links.planId AND w.doi = links.workDoi
+      JOIN stagingRelatedWorks s ON links.id = s.id
+    SET r.workVersionId      = links.workVersionId,
+        r.sourceType         = s.sourceType,
+        r.score              = s.score,
+        r.scoreMax           = s.scoreMax,
+        r.doiMatch           = s.doiMatch,
+        r.contentMatch       = s.contentMatch,
+        r.authorMatches      = s.authorMatches,
+        r.institutionMatches = s.institutionMatches,
+        r.funderMatches      = s.funderMatches,
+        r.awardMatches       = s.awardMatches
+    WHERE r.status = 'PENDING';
+
+    -- affectedPlanIds: collect plans in this batch so the stale-link cleanup only touches relevant plans
+    DROP TEMPORARY TABLE IF EXISTS affectedPlanIds;
+    CREATE TEMPORARY TABLE affectedPlanIds (
+      `planId` INT NOT NULL PRIMARY KEY
+    ) ENGINE = InnoDB;
+    INSERT INTO affectedPlanIds (planId)
+    SELECT DISTINCT planId FROM resolvedStagingLinks;
+
+    -- Remove stale PENDING links for affected plans that were not present
+    -- in this batch. Joins on (planId, workVersionId), so if a work's hash
+    -- changed, the old version's link is deleted.
+    DELETE r
+    FROM relatedWorks r
+      JOIN affectedPlanIds ap ON r.planId = ap.planId
+      LEFT JOIN resolvedStagingLinks links ON r.planId = links.planId AND r.workVersionId = links.workVersionId
+    WHERE r.status = 'PENDING'
+      AND links.id IS NULL;
+  END IF;
+
+  COMMIT;
+
+END$$
+
+DELIMITER ;
+
+DELIMITER $$
+
+-- cleanup_orphan_works: garbage-collect workVersions and works that are no longer
+-- referenced by any relatedWorks row
+CREATE PROCEDURE `cleanup_orphan_works`()
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+      ROLLBACK;
+      RESIGNAL;
+    END;
+
+  START TRANSACTION;
+
+  -- Delete workVersions that are no longer referenced by any relatedWorks row
+  DELETE wv
+  FROM workVersions wv
+         LEFT JOIN relatedWorks r ON r.workVersionId = wv.id
+  WHERE r.id IS NULL;
+
+  -- Delete works that have no remaining workVersions
+  DELETE w
+  FROM works w
+         LEFT JOIN workVersions wv ON wv.workId = w.id
+  WHERE wv.id IS NULL;
+
+  COMMIT;
+END$$
+
+DELIMITER ;

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "@graphql-codegen/cli": "^6.2.1",
         "@graphql-codegen/typescript": "^5.0.9",
         "@graphql-codegen/typescript-resolvers": "^5.1.7",
+        "@testcontainers/mysql": "^11.13.0",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/express-oauth-server": "^2.0.10",
@@ -2305,6 +2306,13 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -3506,6 +3514,72 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -4454,6 +4528,17 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/@keyv/redis": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/@keyv/redis/-/redis-5.1.6.tgz",
@@ -4476,6 +4561,16 @@
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
       "license": "MIT"
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
     },
     "node_modules/@mswjs/interceptors": {
       "version": "0.41.3",
@@ -5523,6 +5618,16 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@testcontainers/mysql": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@testcontainers/mysql/-/mysql-11.14.0.tgz",
+      "integrity": "sha512-0/OKd1gOvnl0qS+RIpmT6J0XKWpjkVyIbOtS3cFTVR8t6Ps7W9TV0U+zp7FPxCmitWuWYPXwH/+RQXF+1jZuZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "testcontainers": "^11.14.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -5643,6 +5748,29 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/docker-modem": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
+      "integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
+    "node_modules/@types/dockerode": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-4.0.1.tgz",
+      "integrity": "sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/docker-modem": "*",
+        "@types/node": "*",
+        "@types/ssh2": "*"
       }
     },
     "node_modules/@types/esrecurse": {
@@ -5835,6 +5963,43 @@
         "@types/http-errors": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2-streams": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.13.tgz",
+      "integrity": "sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -6492,6 +6657,19 @@
         "node": ">=14.6"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -6617,6 +6795,44 @@
         "node": ">= 8"
       }
     },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -6648,6 +6864,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/assert": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
@@ -6661,6 +6887,20 @@
         "object.assign": "^4.1.4",
         "util": "^0.12.5"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async-retry": {
       "version": "1.3.3",
@@ -6729,6 +6969,21 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
       "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
     },
     "node_modules/babel-jest": {
       "version": "30.3.0",
@@ -6839,6 +7094,124 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.0.tgz",
+      "integrity": "sha512-xzqKsCFxAek9aezYhjJuJRXBIaYlg/0OGDTZp+T8eYmYMlm66cs6cYko02drIyjN2CBbi+I6L7YfXyqpqtKRXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+      "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.12.0.tgz",
+      "integrity": "sha512-w28i8lkBgREV3rPXGbgK+BO66q+ZpKqRWrZLiCdmmUlLPrQ45CzkvRhN+7lnv00Gpi2zy5naRxnUFAxCECDm9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+      "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.13",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
@@ -6864,6 +7237,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "node_modules/bcryptjs": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
@@ -6884,6 +7267,58 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/body-parser": {
@@ -6999,6 +7434,41 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -7011,6 +7481,26 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -7254,6 +7744,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
@@ -7512,6 +8009,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -7595,6 +8109,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -7637,6 +8158,48 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/create-require": {
@@ -7888,6 +8451,128 @@
         "node": ">=8"
       }
     },
+    "node_modules/docker-compose": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.4.2.tgz",
+      "integrity": "sha512-rPHigTKGaEHpkUmfd69QgaOp+Os5vGJwG/Ry8lcr8W/382AmI+z/D7qoa9BybKIkqNppaIbs8RYeHSevdQjWww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/docker-modem": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.7.tgz",
+      "integrity": "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "readable-stream": "^3.5.0",
+        "split-ca": "^1.0.1",
+        "ssh2": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/docker-modem/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/dockerode": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.10.tgz",
+      "integrity": "sha512-8L/P9JynLBiG7/coiA4FlQXegHltRqS0a+KqI44P1zgQh8QLHTg7FKOwhkBgSJwZTeHsq30WRoVFLuwkfK0YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "@grpc/grpc-js": "^1.11.1",
+        "@grpc/proto-loader": "^0.7.13",
+        "docker-modem": "^5.0.7",
+        "protobufjs": "^7.3.2",
+        "tar-fs": "^2.1.4",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/dockerode/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/dockerode/node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/dockerode/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dockerode/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/dot-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
@@ -7991,6 +8676,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/env-paths": {
@@ -8286,12 +8981,42 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -8428,6 +9153,13 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8794,6 +9526,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -8909,6 +9648,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-port": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
+      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-proto": {
@@ -9351,6 +10103,27 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -10749,6 +11522,52 @@
         "@keyv/serialize": "^1.1.1"
       }
     },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -10874,6 +11693,13 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -11402,6 +12228,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mnemonist": {
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
@@ -11476,6 +12309,14 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -12289,6 +13130,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -12315,6 +13173,101 @@
         "node": ">= 8"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/properties-reader": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-3.0.1.tgz",
+      "integrity": "sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "mkdirp": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/properties?sponsor=1"
+      }
+    },
+    "node_modules/properties-reader/node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/protobufjs/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -12334,6 +13287,17 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -12434,6 +13398,63 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -13105,6 +14126,13 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split-ca": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -13146,6 +14174,46 @@
         "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
       }
     },
+    "node_modules/ssh-remote-port-forward": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ssh-remote-port-forward/-/ssh-remote-port-forward-1.0.4.tgz",
+      "integrity": "sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ssh2": "^0.5.48",
+        "ssh2": "^1.4.0"
+      }
+    },
+    "node_modules/ssh-remote-port-forward/node_modules/@types/ssh2": {
+      "version": "0.5.52",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.52.tgz",
+      "integrity": "sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2-streams": "*"
+      }
+    },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -13178,11 +14246,54 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/strict-event-emitter": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
       "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/string-env-interpolation": {
@@ -13520,6 +14631,44 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -13588,6 +14737,40 @@
         "node": "*"
       }
     },
+    "node_modules/testcontainers": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-11.14.0.tgz",
+      "integrity": "sha512-r9pniwv/iwzyHaI7gwAvAm4Y+IvjJg3vBWdjrUCaDMc2AXIr4jKbq7jJO18Mw2ybs73pZy1Aj7p/4RVBGMRWjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "@types/dockerode": "^4.0.1",
+        "archiver": "^7.0.1",
+        "async-lock": "^1.4.1",
+        "byline": "^5.0.0",
+        "debug": "^4.4.3",
+        "docker-compose": "^1.4.2",
+        "dockerode": "^4.0.10",
+        "get-port": "^7.2.0",
+        "proper-lockfile": "^4.1.2",
+        "properties-reader": "^3.0.1",
+        "ssh-remote-port-forward": "^1.0.4",
+        "tar-fs": "^3.1.2",
+        "tmp": "^0.2.5",
+        "undici": "^7.24.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/thread-stream": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
@@ -13635,6 +14818,16 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {
@@ -13949,6 +15142,13 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true,
+      "license": "Unlicense"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -14081,6 +15281,16 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
@@ -14239,6 +15449,13 @@
         "is-typed-array": "^1.1.3",
         "which-typed-array": "^1.1.2"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "9.0.1",
@@ -14745,6 +15962,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@graphql-codegen/cli": "^6.2.1",
     "@graphql-codegen/typescript": "^5.0.9",
     "@graphql-codegen/typescript-resolvers": "^5.1.7",
+    "@testcontainers/mysql": "^11.13.0",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/express-oauth-server": "^2.0.10",

--- a/src/datasources/__tests__/relatedWorksTables.spec.ts
+++ b/src/datasources/__tests__/relatedWorksTables.spec.ts
@@ -1,15 +1,12 @@
+import fs from 'fs';
+import path from 'path';
 import mysql, { Connection } from 'mysql2/promise';
-import { generalConfig } from '../../config/generalConfig';
-import { getParameter } from '../parameterStore';
-import { MyContext } from '../../context';
-import { buildContext } from '../../__mocks__/context';
-import { logger } from '../../logger';
+import { MySqlContainer, StartedMySqlContainer } from '@testcontainers/mysql';
 import { Author, Award, ContentMatch, DoiMatch, Funder, Institution, ItemMatch } from '../../types';
 import type { ResultSetHeader } from 'mysql2/promise';
 
 interface RelatedWork {
-  planId: string | null | undefined;
-  dmpDoi: string | null | undefined;
+  planId: number;
   workDoi: string;
   hash: Buffer;
   sourceType: string;
@@ -58,7 +55,18 @@ interface Project {
   modifiedById: number;
 }
 
-export async function insertProjectAndPlan(connection: Connection, project: Project, plan: Plan) {
+async function executeProceduresSql(conn: Connection, sql: string): Promise<void> {
+  const cleaned = sql.replace(/DELIMITER\s+\$\$\s*/g, '').replace(/DELIMITER\s+;\s*/g, '');
+  const statements = cleaned
+    .split('$$')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  for (const stmt of statements) {
+    await conn.query(stmt);
+  }
+}
+
+async function insertProjectAndPlan(connection: Connection, project: Project, plan: Plan): Promise<number> {
   await connection.beginTransaction();
 
   try {
@@ -72,7 +80,7 @@ export async function insertProjectAndPlan(connection: Connection, project: Proj
 
     const projectId = projectResult.insertId;
 
-    await connection.query(
+    const [planResult] = await connection.execute<ResultSetHeader>(
       `
     INSERT INTO plans (
       projectId, versionedTemplateId, visibility, status, dmpId, languageId, featured, createdById, modifiedById
@@ -92,21 +100,21 @@ export async function insertProjectAndPlan(connection: Connection, project: Proj
     );
 
     await connection.commit();
+    return planResult.insertId;
   } catch (err) {
     await connection.rollback();
     throw err;
   }
 }
 
-export async function insertRelatedWorks(connection: Connection, data: RelatedWork[]) {
+async function insertRelatedWorks(connection: Connection, data: RelatedWork[]) {
   if (data.length === 0) {
     return;
   }
   const sql =
-    'INSERT INTO stagingRelatedWorks (planId, dmpDoi, workDoi, hash, sourceType, score, status, scoreMax, doiMatch, contentMatch, authorMatches, institutionMatches, funderMatches, awardMatches) VALUES ?';
+    'INSERT INTO stagingRelatedWorks (planId, workDoi, hash, sourceType, score, status, scoreMax, doiMatch, contentMatch, authorMatches, institutionMatches, funderMatches, awardMatches) VALUES ?';
   const values = data.map((item) => [
     item.planId,
-    item.dmpDoi,
     item.workDoi,
     item.hash,
     item.sourceType,
@@ -124,7 +132,7 @@ export async function insertRelatedWorks(connection: Connection, data: RelatedWo
   await connection.query(sql, [values]);
 }
 
-export async function insertWorkVersions(connection: Connection, data: WorkVersion[]) {
+async function insertWorkVersions(connection: Connection, data: WorkVersion[]) {
   if (data.length === 0) {
     return;
   }
@@ -149,134 +157,166 @@ export async function insertWorkVersions(connection: Connection, data: WorkVersi
   await connection.query(sql, [values]);
 }
 
-let connection: mysql.Connection | null = null;
-let context: MyContext;
+const MIGRATIONS_DIR = path.join(__dirname, '../../../data-migrations');
 
-// Function to attempt to connect to the database in certain situations
-async function tryGetConnection(context: MyContext) {
-  try {
-    let connection: Connection;
-
-    // If we are running locally (test) or in the AWS development env (dev)
-    if (['dev', 'test'].includes(generalConfig.env)) {
-      if (generalConfig.env === 'test') {
-        // Running locally so use the Docker compose MySQL instance
-        connection = await mysql.createConnection({
-          host: 'localhost',
-          port: 3306,
-          user: 'root',
-          password: 'd0ckerSecr3t',
-          database: 'dmptool',
-          multipleStatements: true,
-        });
-      } else {
-        // Running in the AWS development environment so use the RDS instance
-        connection = await mysql.createConnection({
-          host: await getParameter(context, '/uc3/dmp/tool/dev/RdsHost'),
-          port: Number(await getParameter(context, '/uc3/dmp/tool/dev/RdsPort')),
-          user: await getParameter(context, '/uc3/dmp/tool/dev/RdsUsername'),
-          password: await getParameter(context, '/uc3/dmp/tool/dev/RdsPassword'),
-          database: await getParameter(context, '/uc3/dmp/tool/dev/RdsName'),
-          multipleStatements: true,
-        });
-      }
-      return connection;
-    } else {
-      // We are running in a different environment so skip the tests!
-      return null;
-    }
-  } catch (err) {
-    if (err.code === 'ECONNREFUSED' || err.code === 'ENOTFOUND' || err.code === 'EACCES' || err.code === 'ER_ACCESS_DENIED_ERROR') {
-      console.warn('MySQL is not running or access denied, skipping tests.');
-      return null;
-    }
-    throw err; // unexpected error, let it bubble
-  }
-}
+let container: StartedMySqlContainer;
+let connection: Connection;
+let planAId: number;
 
 const testPlanDOIs = ['https://doi.org/10.11111/2A3B4C'];
 const testWorkDOIs = ['10.1234/fake-doi-001', '10.5678/sample.abc.2025'];
 
-function clearTestRecords() {
-  if (connection) {
-    const placeholders = testWorkDOIs.map(() => '?').join(', ');
-    connection.query(
-      `
-      DELETE FROM relatedWorks
-        WHERE workVersionId IN (
-          SELECT workVersions.id
-          FROM workVersions
-              INNER JOIN works ON workVersions.workId = works.id
-          WHERE works.doi IN (${placeholders})
-      );
-    `,
-      testWorkDOIs,
-    );
-
-    connection.query(
-      `
-      DELETE FROM workVersions
-        WHERE workId IN (SELECT id FROM works WHERE doi IN (${placeholders}))
-    `,
-      testWorkDOIs,
-    );
-
-    connection.query(
-      `
-      DELETE FROM works
-        WHERE doi IN (${placeholders})
-    `,
-      testWorkDOIs,
-    );
-
-    connection.query(
-      `
-      DELETE FROM plans
-        WHERE dmpId = '${testPlanDOIs[0]}'
-    `,
-      testWorkDOIs,
-    );
-
-    connection.query(
-      `
-      DELETE FROM projects
-        WHERE title = '${testPlanDOIs[0]}'
-    `,
-      testWorkDOIs,
-    );
-  }
-}
-
 beforeAll(async () => {
-  context = buildContext(logger);
-  connection = await tryGetConnection(context);
-  clearTestRecords();
-});
+  container = await new MySqlContainer('mysql:8.0').withDatabase('dmptool').withRootPassword('test').start();
+
+  connection = await mysql.createConnection({
+    host: container.getHost(),
+    port: container.getMappedPort(3306),
+    user: 'root',
+    password: 'test',
+    database: 'dmptool',
+    multipleStatements: true,
+  });
+
+  // Apply all migrations in chronological order (filenames sort lexicographically by date)
+  const migrationFiles = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+
+  for (const file of migrationFiles) {
+    const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, file), 'utf-8');
+    if (sql.includes('DELIMITER')) {
+      await executeProceduresSql(connection, sql);
+    } else {
+      await connection.query(sql);
+    }
+  }
+
+  // Seed minimal reference data for FK constraints
+  await connection.query(`
+    INSERT INTO users (id, password, role, givenName, surName)
+    VALUES (1, 'dummy', 'RESEARCHER', 'Test', 'User');
+  `);
+  await connection.query(`
+    INSERT INTO affiliations (uri, name, displayName, createdById, modifiedById)
+    VALUES ('https://ror.org/test', 'Test University', 'Test University', 1, 1);
+  `);
+  await connection.query(`
+    INSERT INTO templates (id, name, ownerId, latestPublishVisibility, createdById, modifiedById)
+    VALUES (1, 'Test Template', 'https://ror.org/test', 'PRIVATE', 1, 1);
+  `);
+  await connection.query(`
+    INSERT INTO versionedTemplates (id, templateId, version, versionedById, name, ownerId, visibility, createdById, modifiedById)
+    VALUES (1, 1, '1.0', 1, 'Test Template v1', 'https://ror.org/test', 'PRIVATE', 1, 1);
+  `);
+}, 120000);
 
 afterAll(async () => {
-  clearTestRecords();
   if (connection) await connection.end();
+  if (container) await container.stop();
 });
 
-describe('Related Works Tables', () => {
-  // Tests that the related works tables stored procedures insert, update and
-  // delete records correctly.
-  test('1. should insert works', async () => {
-    // Inserts new related works, work versions and works and checks that
-    // they have been inserted correctly
-    if (!connection) {
-      console.warn('Skipping test: MySQL not available');
-      return;
-    }
+const makeDoiMatch = (score = 1.0): DoiMatch => ({
+  found: true,
+  score,
+  sources: [{ awardId: 'ABC', awardUrl: 'https://url-of-funder/award-page' }],
+});
 
-    await insertProjectAndPlan(
+const makeContentMatch = (score: number, titleHighlight: string): ContentMatch => ({
+  score,
+  titleHighlight,
+  abstractHighlights: ['An <mark>abstract</mark>'],
+});
+
+const makeItemMatch = (index: number, score: number, fields: string[]): ItemMatch => ({
+  index,
+  score,
+  fields,
+});
+
+const workVersion1: WorkVersion = {
+  doi: testWorkDOIs[0],
+  hash: Buffer.from('c4ca4238a0b923820dcc509a6f75849b', 'hex'),
+  workType: 'DATASET',
+  publicationDate: '2025-01-01',
+  title: 'Juvenile Eel Recruitment and Reef Nursery Conditions (JERRNC)',
+  abstractText: 'An abstract',
+  authors: [
+    {
+      orcid: '0000-0003-1234-5678',
+      firstInitial: 'A',
+      givenName: 'Alyssa',
+      middleInitials: 'M',
+      middleNames: 'Marie',
+      surname: 'Langston',
+      full: null,
+    },
+  ],
+  institutions: [{ name: 'University of California, Berkeley', ror: '01an7q238' }],
+  funders: [{ name: 'National Science Foundation', ror: '021nxhr62' }],
+  awards: [{ awardId: 'ABC' }],
+  publicationVenue: 'Zenodo',
+  sourceName: 'DataCite',
+  sourceUrl: `https://commons.datacite.org/doi.org/${testWorkDOIs[0]}`,
+};
+
+const workVersion2: WorkVersion = {
+  doi: testWorkDOIs[1],
+  hash: Buffer.from('c81e728d9d4c2f636f067f89cc14862c', 'hex'),
+  workType: 'ARTICLE',
+  publicationDate: '2025-02-01',
+  title: 'Climate Resilience of Eel-Reef Mutualisms: A Longitudinal Study',
+  abstractText: 'An abstract',
+  authors: [
+    {
+      orcid: '0000-0003-1234-5678',
+      firstInitial: 'A',
+      givenName: 'Alyssa',
+      middleInitials: 'M',
+      middleNames: 'Marie',
+      surname: 'Langston',
+      full: null,
+    },
+    {
+      orcid: null,
+      firstInitial: 'D',
+      givenName: 'David',
+      middleInitials: null,
+      middleNames: null,
+      surname: 'Choi',
+      full: null,
+    },
+  ],
+  institutions: [{ name: 'University of California, Berkeley', ror: '01an7q238' }],
+  funders: [{ name: 'National Science Foundation', ror: '021nxhr62' }],
+  awards: [{ awardId: 'ABC' }],
+  publicationVenue: 'Nature',
+  sourceName: 'OpenAlex',
+  sourceUrl: 'https://openalex.org/works/W0000000001',
+};
+
+function makeRelatedWork(overrides: Partial<RelatedWork> & { planId: number; workDoi: string; hash: Buffer }): RelatedWork {
+  return {
+    sourceType: 'SYSTEM_MATCHED',
+    score: 1.0,
+    status: 'PENDING',
+    scoreMax: 1.0,
+    doiMatch: makeDoiMatch(),
+    contentMatch: makeContentMatch(18.0, 'Juvenile <mark>Eel</mark> Recruitment and Reef Nursery Conditions (JERRNC)'),
+    authorMatches: [makeItemMatch(0, 2.0, ['full', 'ror'])],
+    institutionMatches: [makeItemMatch(0, 2.0, ['name', 'ror'])],
+    funderMatches: [makeItemMatch(0, 1.0, ['name'])],
+    awardMatches: [{ index: 0, score: 10.0 } as ItemMatch],
+    ...overrides,
+  };
+}
+
+describe('Related Works Tables', () => {
+  test('1. should insert works', async () => {
+    planAId = await insertProjectAndPlan(
       connection,
-      {
-        title: testPlanDOIs[0],
-        isTestProject: true,
-        createdById: 1,
-        modifiedById: 1,
-      },
+      { title: testPlanDOIs[0], isTestProject: true, createdById: 1, modifiedById: 1 },
       {
         versionedTemplateId: 1,
         visibility: 'PRIVATE',
@@ -289,1247 +329,381 @@ describe('Related Works Tables', () => {
       },
     );
 
-    const workVersionsData = [
-      {
-        doi: testWorkDOIs[0],
-        hash: Buffer.from('c4ca4238a0b923820dcc509a6f75849b', 'hex'),
-        workType: 'DATASET',
-        publicationDate: '2025-01-01',
-        title: 'Juvenile Eel Recruitment and Reef Nursery Conditions (JERRNC)',
-        abstractText: 'An abstract',
-        authors: [
-          {
-            orcid: '0000-0003-1234-5678',
-            firstInitial: 'A',
-            givenName: 'Alyssa',
-            middleInitials: 'M',
-            middleNames: 'Marie',
-            surname: 'Langston',
-            full: null,
-          },
-        ],
-        institutions: [
-          {
-            name: 'University of California, Berkeley',
-            ror: '01an7q238',
-          },
-        ],
-        funders: [{ name: 'National Science Foundation', ror: '021nxhr62' }],
-        awards: [{ awardId: 'ABC' }],
-        publicationVenue: 'Zenodo',
-        sourceName: 'DataCite',
-        sourceUrl: `https://commons.datacite.org/doi.org/${testWorkDOIs[0]}`,
-      },
-      {
-        doi: testWorkDOIs[1],
-        hash: Buffer.from('c81e728d9d4c2f636f067f89cc14862c', 'hex'),
-        workType: 'ARTICLE',
-        publicationDate: '2025-02-01',
-        title: 'Climate Resilience of Eel-Reef Mutualisms: A Longitudinal Study',
-        abstractText: 'An abstract',
-        authors: [
-          {
-            orcid: '0000-0003-1234-5678',
-            firstInitial: 'A',
-            givenName: 'Alyssa',
-            middleInitials: 'M',
-            middleNames: 'Marie',
-            surname: 'Langston',
-            full: null,
-          },
-          {
-            orcid: null,
-            firstInitial: 'D',
-            givenName: 'David',
-            middleInitials: null,
-            middleNames: null,
-            surname: 'Choi',
-            full: null,
-          },
-        ],
-        institutions: [
-          {
-            name: 'University of California, Berkeley',
-            ror: '01an7q238',
-          },
-        ],
-        funders: [{ name: 'National Science Foundation', ror: '021nxhr62' }],
-        awards: [{ awardId: 'ABC' }],
-        publicationVenue: 'Nature',
-        sourceName: 'OpenAlex',
-        sourceUrl: 'https://openalex.org/works/W0000000001',
-      },
-    ];
-    const relatedWorksData = [
-      {
-        planId: null,
-        dmpDoi: '10.11111/2A3B4C',
-        workDoi: testWorkDOIs[0],
-        hash: Buffer.from('c4ca4238a0b923820dcc509a6f75849b', 'hex'),
-        sourceType: 'SYSTEM_MATCHED',
-        score: 1.0,
-        status: 'PENDING',
-        scoreMax: 1.0,
-        doiMatch: {
-          found: true,
-          score: 1.0,
-          sources: [
-            {
-              awardId: 'ABC',
-              awardUrl: 'https://url-of-funder/award-page',
-            },
-          ],
-        },
-        contentMatch: {
-          score: 18.0,
-          titleHighlight: 'Juvenile <mark>Eel</mark> Recruitment and Reef Nursery Conditions (JERRNC)',
-          abstractHighlights: ['An <mark>abstract</mark>'],
-        },
-        authorMatches: [
-          {
-            index: 0,
-            score: 2.0,
-            fields: ['full', 'ror'],
-          },
-        ],
-        institutionMatches: [
-          {
-            index: 0,
-            score: 2.0,
-            fields: ['name', 'ror'],
-          },
-        ],
-        funderMatches: [
-          {
-            index: 0,
-            score: 1.0,
-            fields: ['name'],
-          },
-        ],
-        awardMatches: [
-          {
-            index: 0,
-            score: 10.0,
-          },
-        ],
-      },
-      {
-        planId: null,
-        dmpDoi: '10.11111/2A3B4C',
+    const relatedWorksData: RelatedWork[] = [
+      makeRelatedWork({ planId: planAId, workDoi: testWorkDOIs[0], hash: workVersion1.hash }),
+      makeRelatedWork({
+        planId: planAId,
         workDoi: testWorkDOIs[1],
-        hash: Buffer.from('c81e728d9d4c2f636f067f89cc14862c', 'hex'),
-        sourceType: 'SYSTEM_MATCHED',
+        hash: workVersion2.hash,
         score: 0.8,
-        status: 'PENDING',
-        scoreMax: 1.0,
-        doiMatch: {
-          found: true,
-          score: 1.0,
-          sources: [
-            {
-              awardId: 'ABC',
-              awardUrl: 'https://url-of-funder/award-page',
-            },
-          ],
-        },
-        contentMatch: {
-          score: 18.0,
-          titleHighlight: 'Climate Resilience of <mark>Eel-Reef</mark> Mutualisms: A Longitudinal Study',
-          abstractHighlights: ['An <mark>abstract</mark>'],
-        },
-        authorMatches: [
-          {
-            index: 0,
-            score: 2.0,
-            fields: ['full', 'ror'],
-          },
-        ],
-        institutionMatches: [
-          {
-            index: 0,
-            score: 2.0,
-            fields: ['name', 'ror'],
-          },
-        ],
-        funderMatches: [
-          {
-            index: 0,
-            score: 1.0,
-            fields: ['name'],
-          },
-        ],
-        awardMatches: [
-          {
-            index: 0,
-            score: 10.0,
-          },
-        ],
-      },
+        contentMatch: makeContentMatch(
+          18.0,
+          'Climate Resilience of <mark>Eel-Reef</mark> Mutualisms: A Longitudinal Study',
+        ),
+      }),
     ];
-    await connection.query('CALL create_related_works_staging_tables');
-    await insertWorkVersions(connection, workVersionsData);
-    await insertRelatedWorks(connection, relatedWorksData);
-    const systemMatched = true;
-    await connection.query("CALL batch_update_related_works(?)", [systemMatched]);
 
-    // Check relatedWorks table
+    await connection.query('CALL create_related_works_staging_tables');
+    await insertWorkVersions(connection, [workVersion1, workVersion2]);
+    await insertRelatedWorks(connection, relatedWorksData);
+    await connection.query('CALL batch_update_related_works(?)', [true]);
+    await connection.query('CALL cleanup_orphan_works');
+
     const [relatedWorksRows] = await connection.execute('SELECT * FROM relatedWorks');
     expect(relatedWorksRows).toHaveLength(2);
     expect(relatedWorksRows).toMatchObject([
       {
-        id: expect.any(Number), // 👈 auto-increment id
-        planId: expect.any(Number), // 👈 auto-increment id
-        workVersionId: expect.any(Number), // 👈 auto-increment id
+        id: expect.any(Number),
+        planId: expect.any(Number),
+        workVersionId: expect.any(Number),
         sourceType: 'SYSTEM_MATCHED',
         score: 1,
         scoreMax: 1.0,
         status: 'PENDING',
-        doiMatch: {
-          found: true,
-          score: 1.0,
-          sources: [
-            {
-              awardId: 'ABC',
-              awardUrl: 'https://url-of-funder/award-page',
-            },
-          ],
-        },
-        contentMatch: {
-          score: 18.0,
-          titleHighlight: 'Juvenile <mark>Eel</mark> Recruitment and Reef Nursery Conditions (JERRNC)',
-          abstractHighlights: ['An <mark>abstract</mark>'],
-        },
-        authorMatches: [
-          {
-            index: 0,
-            score: 2.0,
-            fields: ['full', 'ror'],
-          },
-        ],
-        institutionMatches: [
-          {
-            index: 0,
-            score: 2.0,
-            fields: ['name', 'ror'],
-          },
-        ],
-        funderMatches: [
-          {
-            index: 0,
-            score: 1.0,
-            fields: ['name'],
-          },
-        ],
-        awardMatches: [
-          {
-            index: 0,
-            score: 10.0,
-          },
-        ],
+        doiMatch: makeDoiMatch(),
+        contentMatch: makeContentMatch(
+          18.0,
+          'Juvenile <mark>Eel</mark> Recruitment and Reef Nursery Conditions (JERRNC)',
+        ),
+        authorMatches: [makeItemMatch(0, 2.0, ['full', 'ror'])],
+        institutionMatches: [makeItemMatch(0, 2.0, ['name', 'ror'])],
+        funderMatches: [makeItemMatch(0, 1.0, ['name'])],
+        awardMatches: [{ index: 0, score: 10.0 }],
       },
       {
-        id: expect.any(Number), // 👈 auto-increment id
-        planId: expect.any(Number), // 👈 auto-increment id
-        workVersionId: expect.any(Number), // 👈 auto-increment id
+        id: expect.any(Number),
+        planId: expect.any(Number),
+        workVersionId: expect.any(Number),
         sourceType: 'SYSTEM_MATCHED',
         score: expect.closeTo(0.8, 5),
         scoreMax: 1.0,
         status: 'PENDING',
-        doiMatch: {
-          found: true,
-          score: 1.0,
-          sources: [
-            {
-              awardId: 'ABC',
-              awardUrl: 'https://url-of-funder/award-page',
-            },
-          ],
-        },
-        contentMatch: {
-          score: 18.0,
-          titleHighlight: 'Climate Resilience of <mark>Eel-Reef</mark> Mutualisms: A Longitudinal Study',
-          abstractHighlights: ['An <mark>abstract</mark>'],
-        },
-        authorMatches: [
-          {
-            index: 0,
-            score: 2.0,
-            fields: ['full', 'ror'],
-          },
-        ],
-        institutionMatches: [
-          {
-            index: 0,
-            score: 2.0,
-            fields: ['name', 'ror'],
-          },
-        ],
-        funderMatches: [
-          {
-            index: 0,
-            score: 1.0,
-            fields: ['name'],
-          },
-        ],
-        awardMatches: [
-          {
-            index: 0,
-            score: 10.0,
-          },
-        ],
+        doiMatch: makeDoiMatch(),
+        contentMatch: makeContentMatch(
+          18.0,
+          'Climate Resilience of <mark>Eel-Reef</mark> Mutualisms: A Longitudinal Study',
+        ),
+        authorMatches: [makeItemMatch(0, 2.0, ['full', 'ror'])],
+        institutionMatches: [makeItemMatch(0, 2.0, ['name', 'ror'])],
+        funderMatches: [makeItemMatch(0, 1.0, ['name'])],
+        awardMatches: [{ index: 0, score: 10.0 }],
       },
     ]);
 
-    // Check workVersions table
     const [workVersionsRows] = await connection.execute('SELECT * FROM workVersions');
     expect(workVersionsRows).toHaveLength(2);
     expect(workVersionsRows).toMatchObject([
       {
-        id: expect.any(Number), // 👈 auto-increment id
-        workId: expect.any(Number), // 👈 auto-increment id
-        hash: Buffer.from('c4ca4238a0b923820dcc509a6f75849b', 'hex'),
+        id: expect.any(Number),
+        workId: expect.any(Number),
+        hash: workVersion1.hash,
         workType: 'DATASET',
         publicationDate: expect.any(Date),
-        title: 'Juvenile Eel Recruitment and Reef Nursery Conditions (JERRNC)',
-        abstractText: 'An abstract',
-        authors: [
-          {
-            orcid: '0000-0003-1234-5678',
-            firstInitial: 'A',
-            givenName: 'Alyssa',
-            middleInitials: 'M',
-            middleNames: 'Marie',
-            surname: 'Langston',
-            full: null,
-          },
-        ],
-        institutions: [
-          {
-            name: 'University of California, Berkeley',
-            ror: '01an7q238',
-          },
-        ],
-        funders: [{ name: 'National Science Foundation', ror: '021nxhr62' }],
-        awards: [{ awardId: 'ABC' }],
-        publicationVenue: 'Zenodo',
-        sourceName: 'DataCite',
-        sourceUrl: `https://commons.datacite.org/doi.org/${testWorkDOIs[0]}`,
+        title: workVersion1.title,
+        abstractText: workVersion1.abstractText,
+        authors: workVersion1.authors,
+        institutions: workVersion1.institutions,
+        funders: workVersion1.funders,
+        awards: workVersion1.awards,
+        publicationVenue: workVersion1.publicationVenue,
+        sourceName: workVersion1.sourceName,
+        sourceUrl: workVersion1.sourceUrl,
       },
       {
-        id: expect.any(Number), // 👈 auto-increment id
-        workId: expect.any(Number), // 👈 auto-increment id
-        hash: Buffer.from('c81e728d9d4c2f636f067f89cc14862c', 'hex'),
+        id: expect.any(Number),
+        workId: expect.any(Number),
+        hash: workVersion2.hash,
         workType: 'ARTICLE',
         publicationDate: expect.any(Date),
-        title: 'Climate Resilience of Eel-Reef Mutualisms: A Longitudinal Study',
-        abstractText: 'An abstract',
-        authors: [
-          {
-            orcid: '0000-0003-1234-5678',
-            firstInitial: 'A',
-            givenName: 'Alyssa',
-            middleInitials: 'M',
-            middleNames: 'Marie',
-            surname: 'Langston',
-            full: null,
-          },
-          {
-            orcid: null,
-            firstInitial: 'D',
-            givenName: 'David',
-            middleInitials: null,
-            middleNames: null,
-            surname: 'Choi',
-            full: null,
-          },
-        ],
-        institutions: [
-          {
-            name: 'University of California, Berkeley',
-            ror: '01an7q238',
-          },
-        ],
-        funders: [{ name: 'National Science Foundation', ror: '021nxhr62' }],
-        awards: [{ awardId: 'ABC' }],
-        publicationVenue: 'Nature',
-        sourceName: 'OpenAlex',
-        sourceUrl: 'https://openalex.org/works/W0000000001',
+        title: workVersion2.title,
+        abstractText: workVersion2.abstractText,
+        authors: workVersion2.authors,
+        institutions: workVersion2.institutions,
+        funders: workVersion2.funders,
+        awards: workVersion2.awards,
+        publicationVenue: workVersion2.publicationVenue,
+        sourceName: workVersion2.sourceName,
+        sourceUrl: workVersion2.sourceUrl,
       },
     ]);
 
-    // Assert works table
     const [worksRows] = await connection.execute('SELECT * FROM works');
     expect(worksRows).toHaveLength(2);
     expect(worksRows).toMatchObject([
-      {
-        id: expect.any(Number), // 👈 auto-increment id
-        doi: testWorkDOIs[0],
-        created: expect.any(Date),
-      },
-      {
-        id: expect.any(Number), // 👈 auto-increment id
-        doi: testWorkDOIs[1],
-        created: expect.any(Date),
-      },
+      { id: expect.any(Number), doi: testWorkDOIs[0], created: expect.any(Date) },
+      { id: expect.any(Number), doi: testWorkDOIs[1], created: expect.any(Date) },
     ]);
   });
 
-  test("2. should update works", async () => {
-    // Updates the second related work and links an updated work version to this
-    // related work, then checks that the data has been updated correctly.
-    if (!connection) {
-      console.warn("Skipping test: MySQL not available");
-      return;
-    }
+  test('2. should update works', async () => {
+    const updatedWorkVersion2: WorkVersion = {
+      ...workVersion2,
+      hash: Buffer.from('eccbc87e4b5ce2fe28308fd9f2a7baf3', 'hex'),
+      workType: 'DATASET',
+      publicationDate: '2025-02-02',
+      title: 'Title: Climate Resilience of Eel-Reef Mutualisms: A Longitudinal Study',
+      abstractText: 'An abstract abstract',
+      authors: [...workVersion2.authors.slice(0, 1), { ...workVersion2.authors[1]!, givenName: 'Daniel' }],
+      institutions: [{ name: 'University of California', ror: '01an7q238' }],
+      funders: [{ name: 'National Science Foundation, USA', ror: '021nxhr62' }],
+      awards: [{ awardId: 'ABC' }, { awardId: '123' }],
+      publicationVenue: 'Nature Publications',
+      sourceName: 'DataCite',
+      sourceUrl: `https://commons.datacite.org/doi.org/${testWorkDOIs[1]}`,
+    };
 
-    const workVersionsData = [
-      {
-        doi: testWorkDOIs[0],
-        hash: Buffer.from("c4ca4238a0b923820dcc509a6f75849b", "hex"),
-        workType: "DATASET",
-        publicationDate: "2025-01-01",
-        title: "Juvenile Eel Recruitment and Reef Nursery Conditions (JERRNC)",
-        abstractText: "An abstract",
-        authors: [
-          {
-            orcid: "0000-0003-1234-5678",
-            firstInitial: "A",
-            givenName: "Alyssa",
-            middleInitials: "M",
-            middleNames: "Marie",
-            surname: "Langston",
-            full: null,
-          },
-        ],
-        institutions: [
-          {
-            name: "University of California, Berkeley",
-            ror: "01an7q238",
-          },
-        ],
-        funders: [{ name: "National Science Foundation", ror: "021nxhr62" }],
-        awards: [{ awardId: "ABC" }],
-        publicationVenue: "Zenodo",
-        sourceName: "DataCite",
-        sourceUrl: `https://commons.datacite.org/doi.org/${testWorkDOIs[0]}`,
-      },
-      {
-        doi: testWorkDOIs[1],
-        hash: Buffer.from("eccbc87e4b5ce2fe28308fd9f2a7baf3", "hex"), // Hash changed
-        workType: "DATASET", // Type changed
-        publicationDate: "2025-02-02", // Date changed
-        title: "Title: Climate Resilience of Eel-Reef Mutualisms: A Longitudinal Study", // Title changed
-        abstractText: "An abstract abstract", // Abstract changed
-        authors: [
-          // Authors changed
-          {
-            orcid: "0000-0003-1234-5678",
-            firstInitial: "A",
-            givenName: "Alyssa",
-            middleInitials: "M",
-            middleNames: "Marie",
-            surname: "Langston",
-            full: null,
-          },
-          {
-            orcid: null,
-            firstInitial: "D",
-            givenName: "Daniel",
-            middleInitials: null,
-            middleNames: null,
-            surname: "Choi",
-            full: null,
-          },
-        ],
-        institutions: [
-          // Institutions changed
-          {
-            name: "University of California",
-            ror: "01an7q238",
-          },
-        ],
-        funders: [{ name: "National Science Foundation, USA", ror: "021nxhr62" }], // Funders changed
-        awards: [{ awardId: "ABC" }, { awardId: "123" }], // Award IDs changed
-        publicationVenue: "Nature Publications", // Publication venue changed
-        sourceName: "DataCite", // Source Changed
-        sourceUrl: `https://commons.datacite.org/doi.org/${testWorkDOIs[1]}`, // Source URL changed
-      },
-    ];
-    const relatedWorksData = [
-      {
-        planId: null,
-        dmpDoi: "10.11111/2A3B4C",
-        workDoi: testWorkDOIs[0],
-        hash: Buffer.from("c4ca4238a0b923820dcc509a6f75849b", "hex"),
-        sourceType: "SYSTEM_MATCHED",
-        score: 1.0,
-        status: "PENDING",
-        scoreMax: 1.0,
-        doiMatch: {
-          found: true,
-          score: 1.0,
-          sources: [
-            {
-              awardId: "ABC",
-              awardUrl: "https://url-of-funder/award-page",
-            },
-          ],
-        },
-        contentMatch: {
-          score: 18.0,
-          titleHighlight: "Juvenile <mark>Eel</mark> Recruitment and Reef Nursery Conditions (JERRNC)",
-          abstractHighlights: ["An <mark>abstract</mark>"],
-        },
-        authorMatches: [
-          {
-            index: 0,
-            score: 2.0,
-            fields: ["full", "ror"],
-          },
-        ],
-        institutionMatches: [
-          {
-            index: 0,
-            score: 2.0,
-            fields: ["name", "ror"],
-          },
-        ],
-        funderMatches: [
-          {
-            index: 0,
-            score: 1.0,
-            fields: ["name"],
-          },
-        ],
-        awardMatches: [
-          {
-            index: 0,
-            score: 10.0,
-          },
-        ],
-      },
-      {
-        planId: null,
-        dmpDoi: "10.11111/2A3B4C",
+    const relatedWorksData: RelatedWork[] = [
+      makeRelatedWork({ planId: planAId, workDoi: testWorkDOIs[0], hash: workVersion1.hash }),
+      makeRelatedWork({
+        planId: planAId,
         workDoi: testWorkDOIs[1],
-        hash: Buffer.from("eccbc87e4b5ce2fe28308fd9f2a7baf3", "hex"), // Hash changed
-        sourceType: "SYSTEM_MATCHED",
-        score: 0.9, // Score changed
-        status: "PENDING",
-        scoreMax: 1.0,
-        doiMatch: {
-          // doiMatch changed
-          found: true,
-          score: 2.0,
-          sources: [
-            {
-              awardId: "ABC",
-              awardUrl: "https://url-of-funder/award-page",
-            },
-          ],
-        },
-        contentMatch: {
-          // contentMatch changed
-          score: 20.0,
-          titleHighlight: "Climate Resilience of <mark>Eel-Reef</mark> Mutualisms: A Longitudinal Study",
-          abstractHighlights: ["An <mark>abstract</mark>"],
-        },
-        authorMatches: [
-          // authorMatches changed
-          {
-            index: 1,
-            score: 2.0,
-            fields: ["full", "ror"],
-          },
-        ],
-        institutionMatches: [
-          // institutionMatches changed
-          {
-            index: 1,
-            score: 2.0,
-            fields: ["name", "ror"],
-          },
-        ],
-        funderMatches: [
-          // funderMatches changed
-          {
-            index: 1,
-            score: 1.0,
-            fields: ["name"],
-          },
-        ],
-        awardMatches: [
-          // awardMatches changed
-          {
-            index: 1,
-            score: 10.0,
-          },
-        ],
-      },
+        hash: updatedWorkVersion2.hash,
+        score: 0.9,
+        doiMatch: makeDoiMatch(2.0),
+        contentMatch: makeContentMatch(
+          20.0,
+          'Climate Resilience of <mark>Eel-Reef</mark> Mutualisms: A Longitudinal Study',
+        ),
+        authorMatches: [makeItemMatch(1, 2.0, ['full', 'ror'])],
+        institutionMatches: [makeItemMatch(1, 2.0, ['name', 'ror'])],
+        funderMatches: [makeItemMatch(1, 1.0, ['name'])],
+        awardMatches: [{ index: 1, score: 10.0 } as ItemMatch],
+      }),
     ];
-    await connection.query("CALL create_related_works_staging_tables");
-    await insertWorkVersions(connection, workVersionsData);
-    await insertRelatedWorks(connection, relatedWorksData);
-    const systemMatched = true;
-    await connection.query("CALL batch_update_related_works(?)", [systemMatched]);
 
-    // Check relatedWorks table
-    const [relatedWorksRows] = await connection.execute("SELECT * FROM relatedWorks");
+    await connection.query('CALL create_related_works_staging_tables');
+    await insertWorkVersions(connection, [workVersion1, updatedWorkVersion2]);
+    await insertRelatedWorks(connection, relatedWorksData);
+    await connection.query('CALL batch_update_related_works(?)', [true]);
+    await connection.query('CALL cleanup_orphan_works');
+
+    const [relatedWorksRows] = await connection.execute('SELECT * FROM relatedWorks');
     expect(relatedWorksRows).toHaveLength(2);
     expect(relatedWorksRows).toMatchObject([
       {
-        id: expect.any(Number), // 👈 auto-increment id
-        planId: expect.any(Number), // 👈 auto-increment id
-        workVersionId: expect.any(Number), // 👈 auto-increment id
-        sourceType: "SYSTEM_MATCHED",
+        sourceType: 'SYSTEM_MATCHED',
         score: 1,
         scoreMax: 1.0,
-        status: "PENDING",
-        doiMatch: {
-          found: true,
-          score: 1.0,
-          sources: [
-            {
-              awardId: "ABC",
-              awardUrl: "https://url-of-funder/award-page",
-            },
-          ],
-        },
-        contentMatch: {
-          score: 18.0,
-          titleHighlight: "Juvenile <mark>Eel</mark> Recruitment and Reef Nursery Conditions (JERRNC)",
-          abstractHighlights: ["An <mark>abstract</mark>"],
-        },
-        authorMatches: [
-          {
-            index: 0,
-            score: 2.0,
-            fields: ["full", "ror"],
-          },
-        ],
-        institutionMatches: [
-          {
-            index: 0,
-            score: 2.0,
-            fields: ["name", "ror"],
-          },
-        ],
-        funderMatches: [
-          {
-            index: 0,
-            score: 1.0,
-            fields: ["name"],
-          },
-        ],
-        awardMatches: [
-          {
-            index: 0,
-            score: 10.0,
-          },
-        ],
+        status: 'PENDING',
       },
       {
-        id: expect.any(Number), // 👈 auto-increment id
-        planId: expect.any(Number), // 👈 auto-increment id
-        workVersionId: expect.any(Number), // 👈 auto-increment id
-        sourceType: "SYSTEM_MATCHED",
+        sourceType: 'SYSTEM_MATCHED',
         score: expect.closeTo(0.9, 5),
         scoreMax: 1.0,
-        status: "PENDING",
-        doiMatch: {
-          found: true,
-          score: 2.0,
-          sources: [
-            {
-              awardId: "ABC",
-              awardUrl: "https://url-of-funder/award-page",
-            },
-          ],
-        },
-        contentMatch: {
-          score: 20.0,
-          titleHighlight: "Climate Resilience of <mark>Eel-Reef</mark> Mutualisms: A Longitudinal Study",
-          abstractHighlights: ["An <mark>abstract</mark>"],
-        },
-        authorMatches: [
-          {
-            index: 1,
-            score: 2.0,
-            fields: ["full", "ror"],
-          },
-        ],
-        institutionMatches: [
-          {
-            index: 1,
-            score: 2.0,
-            fields: ["name", "ror"],
-          },
-        ],
-        funderMatches: [
-          {
-            index: 1,
-            score: 1.0,
-            fields: ["name"],
-          },
-        ],
-        awardMatches: [
-          {
-            index: 1,
-            score: 10.0,
-          },
-        ],
+        status: 'PENDING',
+        doiMatch: makeDoiMatch(2.0),
+        contentMatch: makeContentMatch(
+          20.0,
+          'Climate Resilience of <mark>Eel-Reef</mark> Mutualisms: A Longitudinal Study',
+        ),
+        authorMatches: [makeItemMatch(1, 2.0, ['full', 'ror'])],
+        institutionMatches: [makeItemMatch(1, 2.0, ['name', 'ror'])],
+        funderMatches: [makeItemMatch(1, 1.0, ['name'])],
+        awardMatches: [{ index: 1, score: 10.0 }],
       },
     ]);
 
-    // Check workVersions table
-    const [workVersionsRows] = await connection.execute("SELECT * FROM workVersions");
+    const [workVersionsRows] = await connection.execute('SELECT * FROM workVersions');
     expect(workVersionsRows).toHaveLength(2);
     expect(workVersionsRows).toMatchObject([
+      { hash: workVersion1.hash, workType: 'DATASET', title: workVersion1.title },
       {
-        id: expect.any(Number), // 👈 auto-increment id
-        workId: expect.any(Number), // 👈 auto-increment id
-        hash: Buffer.from("c4ca4238a0b923820dcc509a6f75849b", "hex"),
-        workType: "DATASET",
-        publicationDate: expect.any(Date),
-        title: "Juvenile Eel Recruitment and Reef Nursery Conditions (JERRNC)",
-        abstractText: "An abstract",
-        authors: [
-          {
-            orcid: "0000-0003-1234-5678",
-            firstInitial: "A",
-            givenName: "Alyssa",
-            middleInitials: "M",
-            middleNames: "Marie",
-            surname: "Langston",
-            full: null,
-          },
-        ],
-        institutions: [
-          {
-            name: "University of California, Berkeley",
-            ror: "01an7q238",
-          },
-        ],
-        funders: [{ name: "National Science Foundation", ror: "021nxhr62" }],
-        awards: [{ awardId: "ABC" }],
-        publicationVenue: "Zenodo",
-        sourceName: "DataCite",
-        sourceUrl: `https://commons.datacite.org/doi.org/${testWorkDOIs[0]}`,
-      },
-      {
-        id: expect.any(Number), // 👈 auto-increment id
-        workId: expect.any(Number), // 👈 auto-increment id
-        hash: Buffer.from("eccbc87e4b5ce2fe28308fd9f2a7baf3", "hex"),
-        workType: "DATASET",
-        publicationDate: expect.any(Date),
-        title: "Title: Climate Resilience of Eel-Reef Mutualisms: A Longitudinal Study",
-        abstractText: "An abstract abstract",
-        authors: [
-          {
-            orcid: "0000-0003-1234-5678",
-            firstInitial: "A",
-            givenName: "Alyssa",
-            middleInitials: "M",
-            middleNames: "Marie",
-            surname: "Langston",
-            full: null,
-          },
-          {
-            orcid: null,
-            firstInitial: "D",
-            givenName: "Daniel",
-            middleInitials: null,
-            middleNames: null,
-            surname: "Choi",
-            full: null,
-          },
-        ],
-        institutions: [
-          {
-            name: "University of California",
-            ror: "01an7q238",
-          },
-        ],
-        funders: [{ name: "National Science Foundation, USA", ror: "021nxhr62" }],
-        awards: [{ awardId: "ABC" }, { awardId: "123" }],
-        publicationVenue: "Nature Publications",
-        sourceName: "DataCite",
-        sourceUrl: `https://commons.datacite.org/doi.org/${testWorkDOIs[1]}`,
+        hash: updatedWorkVersion2.hash,
+        workType: 'DATASET',
+        title: updatedWorkVersion2.title,
+        abstractText: updatedWorkVersion2.abstractText,
+        authors: updatedWorkVersion2.authors,
+        institutions: updatedWorkVersion2.institutions,
+        funders: updatedWorkVersion2.funders,
+        awards: updatedWorkVersion2.awards,
+        publicationVenue: updatedWorkVersion2.publicationVenue,
+        sourceName: updatedWorkVersion2.sourceName,
+        sourceUrl: updatedWorkVersion2.sourceUrl,
       },
     ]);
 
-    // Assert works table
-    const [worksRows] = await connection.execute("SELECT * FROM works");
+    const [worksRows] = await connection.execute('SELECT * FROM works');
     expect(worksRows).toHaveLength(2);
     expect(worksRows).toMatchObject([
-      {
-        id: expect.any(Number), // 👈 auto-increment id
-        doi: testWorkDOIs[0],
-        created: expect.any(Date),
-      },
-      {
-        id: expect.any(Number), // 👈 auto-increment id
-        doi: testWorkDOIs[1],
-        created: expect.any(Date),
-      },
+      { doi: testWorkDOIs[0], created: expect.any(Date) },
+      { doi: testWorkDOIs[1], created: expect.any(Date) },
     ]);
   });
 
-  test("3. should keep accepted and rejected works", async () => {
-    // Updates the status of the two related works to accepted and rejected
-    // and then runs procedures with empty data, which tests that accepted and
-    // rejected related works, work version and works are not deleted.
-    if (!connection) {
-      console.warn("Skipping test: MySQL not available");
-      return;
-    }
-
-    // Accept work
+  test('3. should keep accepted and rejected works', async () => {
+    // Accept first work, reject second
     await connection.query(`
       UPDATE relatedWorks
       SET status = 'ACCEPTED'
       WHERE workVersionId = (
-        SELECT workVersions.id
-        FROM workVersions
-          INNER JOIN works ON works.id = workVersions.workId
-        WHERE works.doi = '${testWorkDOIs[0]}'
+        SELECT wv.id FROM workVersions wv
+          INNER JOIN works w ON w.id = wv.workId
+        WHERE w.doi = '${testWorkDOIs[0]}'
+        LIMIT 1
       );
     `);
-
-    // Reject work
     await connection.query(`
       UPDATE relatedWorks
       SET status = 'REJECTED'
       WHERE workVersionId = (
-        SELECT workVersions.id
-        FROM workVersions
-          INNER JOIN works ON works.id = workVersions.workId
-        WHERE works.doi = '${testWorkDOIs[1]}'
+        SELECT wv.id FROM workVersions wv
+          INNER JOIN works w ON w.id = wv.workId
+        WHERE w.doi = '${testWorkDOIs[1]}'
+        LIMIT 1
       );
     `);
 
-    // Load empty data, which would delete any unlinked pending results
-    // but should keep accepted and rejected works
-    await connection.query("CALL create_related_works_staging_tables");
+    // Load empty staging data — should not delete accepted/rejected works
+    await connection.query('CALL create_related_works_staging_tables');
     await insertWorkVersions(connection, []);
     await insertRelatedWorks(connection, []);
-    const systemMatched = true;
-    await connection.query("CALL batch_update_related_works(?)", [systemMatched]);
+    await connection.query('CALL batch_update_related_works(?)', [true]);
+    await connection.query('CALL cleanup_orphan_works');
 
-    // Check relatedWorks table
-    const [relatedWorksRows] = await connection.execute("SELECT * FROM relatedWorks");
+    const [relatedWorksRows] = await connection.execute('SELECT * FROM relatedWorks');
     expect(relatedWorksRows).toHaveLength(2);
-    expect(relatedWorksRows).toMatchObject([
-      {
-        id: expect.any(Number), // 👈 auto-increment id
-        planId: expect.any(Number), // 👈 auto-increment id
-        workVersionId: expect.any(Number), // 👈 auto-increment id
-        sourceType: "SYSTEM_MATCHED",
-        score: 1,
-        scoreMax: 1.0,
-        status: "ACCEPTED",
-        doiMatch: {
-          found: true,
-          score: 1.0,
-          sources: [
-            {
-              awardId: "ABC",
-              awardUrl: "https://url-of-funder/award-page",
-            },
-          ],
-        },
-        contentMatch: {
-          score: 18.0,
-          titleHighlight: "Juvenile <mark>Eel</mark> Recruitment and Reef Nursery Conditions (JERRNC)",
-          abstractHighlights: ["An <mark>abstract</mark>"],
-        },
-        authorMatches: [
-          {
-            index: 0,
-            score: 2.0,
-            fields: ["full", "ror"],
-          },
-        ],
-        institutionMatches: [
-          {
-            index: 0,
-            score: 2.0,
-            fields: ["name", "ror"],
-          },
-        ],
-        funderMatches: [
-          {
-            index: 0,
-            score: 1.0,
-            fields: ["name"],
-          },
-        ],
-        awardMatches: [
-          {
-            index: 0,
-            score: 10.0,
-          },
-        ],
-      },
-      {
-        id: expect.any(Number), // 👈 auto-increment id
-        planId: expect.any(Number), // 👈 auto-increment id
-        workVersionId: expect.any(Number), // 👈 auto-increment id
-        sourceType: "SYSTEM_MATCHED",
-        score: expect.closeTo(0.9, 5),
-        scoreMax: 1.0,
-        status: "REJECTED",
-        doiMatch: {
-          found: true,
-          score: 2.0,
-          sources: [
-            {
-              awardId: "ABC",
-              awardUrl: "https://url-of-funder/award-page",
-            },
-          ],
-        },
-        contentMatch: {
-          score: 20.0,
-          titleHighlight: "Climate Resilience of <mark>Eel-Reef</mark> Mutualisms: A Longitudinal Study",
-          abstractHighlights: ["An <mark>abstract</mark>"],
-        },
-        authorMatches: [
-          {
-            index: 1,
-            score: 2.0,
-            fields: ["full", "ror"],
-          },
-        ],
-        institutionMatches: [
-          {
-            index: 1,
-            score: 2.0,
-            fields: ["name", "ror"],
-          },
-        ],
-        funderMatches: [
-          {
-            index: 1,
-            score: 1.0,
-            fields: ["name"],
-          },
-        ],
-        awardMatches: [
-          {
-            index: 1,
-            score: 10.0,
-          },
-        ],
-      },
-    ]);
+    expect(relatedWorksRows).toMatchObject([{ status: 'ACCEPTED' }, { status: 'REJECTED' }]);
 
-    // Check workVersions table
-    const [workVersionsRows] = await connection.execute("SELECT * FROM workVersions");
+    const [workVersionsRows] = await connection.execute('SELECT * FROM workVersions');
     expect(workVersionsRows).toHaveLength(2);
-    expect(workVersionsRows).toMatchObject([
-      {
-        id: expect.any(Number), // 👈 auto-increment id
-        workId: expect.any(Number), // 👈 auto-increment id
-        hash: Buffer.from("c4ca4238a0b923820dcc509a6f75849b", "hex"),
-        workType: "DATASET",
-        publicationDate: expect.any(Date),
-        title: "Juvenile Eel Recruitment and Reef Nursery Conditions (JERRNC)",
-        abstractText: "An abstract",
-        authors: [
-          {
-            orcid: "0000-0003-1234-5678",
-            firstInitial: "A",
-            givenName: "Alyssa",
-            middleInitials: "M",
-            middleNames: "Marie",
-            surname: "Langston",
-            full: null,
-          },
-        ],
-        institutions: [
-          {
-            name: "University of California, Berkeley",
-            ror: "01an7q238",
-          },
-        ],
-        funders: [{ name: "National Science Foundation", ror: "021nxhr62" }],
-        awards: [{ awardId: "ABC" }],
-        publicationVenue: "Zenodo",
-        sourceName: "DataCite",
-        sourceUrl: `https://commons.datacite.org/doi.org/${testWorkDOIs[0]}`,
-      },
-      {
-        id: expect.any(Number), // 👈 auto-increment id
-        workId: expect.any(Number), // 👈 auto-increment id
-        hash: Buffer.from("eccbc87e4b5ce2fe28308fd9f2a7baf3", "hex"),
-        workType: "DATASET",
-        publicationDate: expect.any(Date),
-        title: "Title: Climate Resilience of Eel-Reef Mutualisms: A Longitudinal Study",
-        abstractText: "An abstract abstract",
-        authors: [
-          {
-            orcid: "0000-0003-1234-5678",
-            firstInitial: "A",
-            givenName: "Alyssa",
-            middleInitials: "M",
-            middleNames: "Marie",
-            surname: "Langston",
-            full: null,
-          },
-          {
-            orcid: null,
-            firstInitial: "D",
-            givenName: "Daniel",
-            middleInitials: null,
-            middleNames: null,
-            surname: "Choi",
-            full: null,
-          },
-        ],
-        institutions: [
-          {
-            name: "University of California",
-            ror: "01an7q238",
-          },
-        ],
-        funders: [{ name: "National Science Foundation, USA", ror: "021nxhr62" }],
-        awards: [{ awardId: "ABC" }, { awardId: "123" }],
-        publicationVenue: "Nature Publications",
-        sourceName: "DataCite",
-        sourceUrl: `https://commons.datacite.org/doi.org/${testWorkDOIs[1]}`,
-      },
-    ]);
 
-    // Assert works table
-    const [worksRows] = await connection.execute("SELECT * FROM works");
+    const [worksRows] = await connection.execute('SELECT * FROM works');
     expect(worksRows).toHaveLength(2);
-    expect(worksRows).toMatchObject([
-      {
-        id: expect.any(Number), // 👈 auto-increment id
-        doi: testWorkDOIs[0],
-        created: expect.any(Date),
-      },
-      {
-        id: expect.any(Number), // 👈 auto-increment id
-        doi: testWorkDOIs[1],
-        created: expect.any(Date),
-      },
-    ]);
   });
 
-  test("4. should delete unlinked pending related works", async () => {
-    // Checks that unlinked pending related works and their work versions and works
-    // are deleted. Sets all works to pending, then makes an update where only
-    // one related work is in staging table, all other pending related works, work
-    // versions and works should be deleted.
-    if (!connection) {
-      console.warn("Skipping test: MySQL not available");
-      return;
-    }
+  test('4. should delete unlinked pending related works', async () => {
+    // Set all works back to pending
+    await connection.query(`UPDATE relatedWorks SET status = 'PENDING'`);
 
-    // Set work to pending
-    await connection.query(
-      `UPDATE relatedWorks
-       SET status = 'PENDING'`,
-    );
+    // Only keep one work in staging
+    const relatedWorksData: RelatedWork[] = [makeRelatedWork({ planId: planAId, workDoi: testWorkDOIs[0], hash: workVersion1.hash })];
 
-    // Only keep one work
-    const workVersionsData = [
-      {
-        doi: testWorkDOIs[0],
-        hash: Buffer.from("c4ca4238a0b923820dcc509a6f75849b", "hex"),
-        workType: "DATASET",
-        publicationDate: "2025-01-01",
-        title: "Juvenile Eel Recruitment and Reef Nursery Conditions (JERRNC)",
-        abstractText: "An abstract",
-        authors: [
-          {
-            orcid: "0000-0003-1234-5678",
-            firstInitial: "A",
-            givenName: "Alyssa",
-            middleInitials: "M",
-            middleNames: "Marie",
-            surname: "Langston",
-            full: null,
-          },
-        ],
-        institutions: [
-          {
-            name: "University of California, Berkeley",
-            ror: "01an7q238",
-          },
-        ],
-        funders: [{ name: "National Science Foundation", ror: "021nxhr62" }],
-        awards: [{ awardId: "ABC" }],
-        publicationVenue: "Zenodo",
-        sourceName: "DataCite",
-        sourceUrl: `https://commons.datacite.org/doi.org/${testWorkDOIs[0]}`,
-      },
-    ];
-    const relatedWorksData = [
-      {
-        planId: null,
-        dmpDoi: "10.11111/2A3B4C",
-        workDoi: testWorkDOIs[0],
-        hash: Buffer.from("c4ca4238a0b923820dcc509a6f75849b", "hex"),
-        sourceType: "SYSTEM_MATCHED",
-        score: 1.0,
-        status: "PENDING",
-        scoreMax: 1.0,
-        doiMatch: {
-          found: true,
-          score: 1.0,
-          sources: [
-            {
-              awardId: "ABC",
-              awardUrl: "https://url-of-funder/award-page",
-            },
-          ],
-        },
-        contentMatch: {
-          score: 18.0,
-          titleHighlight: "Juvenile <mark>Eel</mark> Recruitment and Reef Nursery Conditions (JERRNC)",
-          abstractHighlights: ["An <mark>abstract</mark>"],
-        },
-        authorMatches: [
-          {
-            index: 0,
-            score: 2.0,
-            fields: ["full", "ror"],
-          },
-        ],
-        institutionMatches: [
-          {
-            index: 0,
-            score: 2.0,
-            fields: ["name", "ror"],
-          },
-        ],
-        funderMatches: [
-          {
-            index: 0,
-            score: 1.0,
-            fields: ["name"],
-          },
-        ],
-        awardMatches: [
-          {
-            index: 0,
-            score: 10.0,
-          },
-        ],
-      },
-    ];
-    await connection.query("CALL create_related_works_staging_tables");
-    await insertWorkVersions(connection, workVersionsData);
+    await connection.query('CALL create_related_works_staging_tables');
+    await insertWorkVersions(connection, [workVersion1]);
     await insertRelatedWorks(connection, relatedWorksData);
-    const systemMatched = true;
-    await connection.query("CALL batch_update_related_works(?)", [systemMatched]);
+    await connection.query('CALL batch_update_related_works(?)', [true]);
+    await connection.query('CALL cleanup_orphan_works');
 
-    // Check relatedWorks table
-    const [relatedWorksRows] = await connection.execute("SELECT * FROM relatedWorks");
+    const [relatedWorksRows] = await connection.execute('SELECT * FROM relatedWorks');
     expect(relatedWorksRows).toHaveLength(1);
-    expect(relatedWorksRows).toMatchObject([
-      {
-        id: expect.any(Number), // 👈 auto-increment id
-        planId: expect.any(Number), // 👈 auto-increment id
-        workVersionId: expect.any(Number), // 👈 auto-increment id
-        sourceType: "SYSTEM_MATCHED",
-        score: 1,
-        scoreMax: 1.0,
-        status: "PENDING",
-        doiMatch: {
-          found: true,
-          score: 1.0,
-          sources: [
-            {
-              awardId: "ABC",
-              awardUrl: "https://url-of-funder/award-page",
-            },
-          ],
-        },
-        contentMatch: {
-          score: 18.0,
-          titleHighlight: "Juvenile <mark>Eel</mark> Recruitment and Reef Nursery Conditions (JERRNC)",
-          abstractHighlights: ["An <mark>abstract</mark>"],
-        },
-        authorMatches: [
-          {
-            index: 0,
-            score: 2.0,
-            fields: ["full", "ror"],
-          },
-        ],
-        institutionMatches: [
-          {
-            index: 0,
-            score: 2.0,
-            fields: ["name", "ror"],
-          },
-        ],
-        funderMatches: [
-          {
-            index: 0,
-            score: 1.0,
-            fields: ["name"],
-          },
-        ],
-        awardMatches: [
-          {
-            index: 0,
-            score: 10.0,
-          },
-        ],
-      },
-    ]);
+    expect(relatedWorksRows).toMatchObject([{ sourceType: 'SYSTEM_MATCHED', score: 1, status: 'PENDING' }]);
 
-    // Check workVersions table
-    const [workVersionsRows] = await connection.execute("SELECT * FROM workVersions");
+    const [workVersionsRows] = await connection.execute('SELECT * FROM workVersions');
     expect(workVersionsRows).toHaveLength(1);
     expect(workVersionsRows).toMatchObject([
-      {
-        id: expect.any(Number), // 👈 auto-increment id
-        workId: expect.any(Number), // 👈 auto-increment id
-        hash: Buffer.from("c4ca4238a0b923820dcc509a6f75849b", "hex"),
-        workType: "DATASET",
-        publicationDate: expect.any(Date),
-        title: "Juvenile Eel Recruitment and Reef Nursery Conditions (JERRNC)",
-        abstractText: "An abstract",
-        authors: [
-          {
-            orcid: "0000-0003-1234-5678",
-            firstInitial: "A",
-            givenName: "Alyssa",
-            middleInitials: "M",
-            middleNames: "Marie",
-            surname: "Langston",
-            full: null,
-          },
-        ],
-        institutions: [
-          {
-            name: "University of California, Berkeley",
-            ror: "01an7q238",
-          },
-        ],
-        funders: [{ name: "National Science Foundation", ror: "021nxhr62" }],
-        awards: [{ awardId: "ABC" }],
-        publicationVenue: "Zenodo",
-        sourceName: "DataCite",
-        sourceUrl: `https://commons.datacite.org/doi.org/${testWorkDOIs[0]}`,
-      },
+      { hash: workVersion1.hash, workType: 'DATASET', title: workVersion1.title },
     ]);
 
-    // Assert works table
-    const [worksRows] = await connection.execute("SELECT * FROM works");
+    const [worksRows] = await connection.execute('SELECT * FROM works');
     expect(worksRows).toHaveLength(1);
-    expect(worksRows).toMatchObject([
+    expect(worksRows).toMatchObject([{ doi: testWorkDOIs[0] }]);
+  });
+
+  test('5. should not delete other plans pending works when batching per-DMP', async () => {
+    // Setup: Create Plan B with its own work
+    const planBDoi = 'https://doi.org/10.22222/PLAN_B';
+    const workDoi3 = '10.9999/third-work-doi';
+
+    const planBId = await insertProjectAndPlan(
+      connection,
+      { title: planBDoi, isTestProject: true, createdById: 1, modifiedById: 1 },
       {
-        id: expect.any(Number), // 👈 auto-increment id
-        doi: testWorkDOIs[0],
-        created: expect.any(Date),
+        versionedTemplateId: 1,
+        visibility: 'PRIVATE',
+        status: 'DRAFT',
+        dmpId: planBDoi,
+        languageId: 'en-US',
+        featured: 0,
+        createdById: 1,
+        modifiedById: 1,
       },
+    );
+
+    const workVersion3: WorkVersion = {
+      ...workVersion1,
+      doi: workDoi3,
+      hash: Buffer.from('a87ff679a2f3e71d9181a67b7542122c', 'hex'),
+      title: 'Third Work for Plan B',
+    };
+
+    // Add a second work for Plan A and a work for Plan B (include both Plan A works in staging)
+    await connection.query('CALL create_related_works_staging_tables');
+    await insertWorkVersions(connection, [workVersion1, workVersion2, workVersion3]);
+    await insertRelatedWorks(connection, [
+      makeRelatedWork({ planId: planAId, workDoi: testWorkDOIs[0], hash: workVersion1.hash }),
+      makeRelatedWork({ planId: planAId, workDoi: testWorkDOIs[1], hash: workVersion2.hash }),
+      makeRelatedWork({ planId: planBId, workDoi: workDoi3, hash: workVersion3.hash }),
     ]);
+    await connection.query('CALL batch_update_related_works(?)', [true]);
+    await connection.query('CALL cleanup_orphan_works');
+
+    // Verify: Plan A has 2 works (one from test 4, one just added), Plan B has 1
+    const [beforeRows] = await connection.execute<any[]>(
+      'SELECT r.*, p.dmpId FROM relatedWorks r JOIN plans p ON r.planId = p.id ORDER BY p.dmpId, r.id',
+    );
+    const planABefore = beforeRows.filter((r: any) => r.dmpId === testPlanDOIs[0]);
+    const planBBefore = beforeRows.filter((r: any) => r.dmpId === planBDoi);
+    expect(planABefore).toHaveLength(2);
+    expect(planBBefore).toHaveLength(1);
+
+    // Now batch for Plan A only with just 1 of its 2 works
+    await connection.query('CALL create_related_works_staging_tables');
+    await insertWorkVersions(connection, [workVersion1]);
+    await insertRelatedWorks(connection, [makeRelatedWork({ planId: planAId, workDoi: testWorkDOIs[0], hash: workVersion1.hash })]);
+    await connection.query('CALL batch_update_related_works(?)', [true]);
+
+    // Plan A: stale pending work deleted, only the staged one remains
+    // Plan B: untouched — its PENDING work must still be there
+    const [afterRows] = await connection.execute<any[]>(
+      'SELECT r.*, p.dmpId FROM relatedWorks r JOIN plans p ON r.planId = p.id ORDER BY p.dmpId, r.id',
+    );
+    const planAAfter = afterRows.filter((r: any) => r.dmpId === testPlanDOIs[0]);
+    const planBAfter = afterRows.filter((r: any) => r.dmpId === planBDoi);
+
+    expect(planAAfter).toHaveLength(1);
+    expect(planBAfter).toHaveLength(1);
+  });
+
+  test('6. systemMatched=false should only update status, not delete or update metadata', async () => {
+    // State from test 5: Plan A has 1 PENDING work (testWorkDOIs[0]), Plan B has 1 PENDING work (workDoi3)
+    const planBDoi = 'https://doi.org/10.22222/PLAN_B';
+
+    // Capture current scores before the update
+    const [beforeRows] = await connection.execute<any[]>(
+      'SELECT r.score, r.scoreMax, r.sourceType, p.dmpId FROM relatedWorks r JOIN plans p ON r.planId = p.id',
+    );
+    const planABefore = beforeRows.find((r: any) => r.dmpId === testPlanDOIs[0]);
+
+    // Stage Plan A's work with status=ACCEPTED and different score/sourceType
+    await connection.query('CALL create_related_works_staging_tables');
+    await insertWorkVersions(connection, [workVersion1]);
+    await insertRelatedWorks(connection, [
+      makeRelatedWork({
+        planId: planAId,
+        workDoi: testWorkDOIs[0],
+        hash: workVersion1.hash,
+        status: 'ACCEPTED',
+        sourceType: 'USER_ADDED',
+        score: 999,
+      }),
+    ]);
+    await connection.query('CALL batch_update_related_works(?)', [false]);
+
+    const [afterRows] = await connection.execute<any[]>(
+      'SELECT r.score, r.sourceType, r.status, p.dmpId FROM relatedWorks r JOIN plans p ON r.planId = p.id ORDER BY p.dmpId',
+    );
+    const planAAfter = afterRows.find((r: any) => r.dmpId === testPlanDOIs[0]);
+    const planBAfter = afterRows.find((r: any) => r.dmpId === planBDoi);
+
+    // Status should be updated
+    expect(planAAfter.status).toBe('ACCEPTED');
+
+    // Score and sourceType should NOT be updated (systemMatched=false only touches status)
+    expect(planAAfter.score).toBe(planABefore.score);
+    expect(planAAfter.sourceType).toBe(planABefore.sourceType);
+
+    // Plan B's PENDING work should NOT be deleted (no PENDING deletion in systemMatched=false path)
+    expect(planBAfter).toBeDefined();
+    expect(planBAfter.status).toBe('PENDING');
   });
 });


### PR DESCRIPTION
## Description

Enables batches of DMP work searches to be merged and fixes a few other issues:
- Changed plan-to-DMP DOI join by removing `LOWER(CONCAT(...))` normalization and directly joining on `s.dmpDoi = p.dmpId`. DMP DOIs are pre-processed on the dmp-works-matching side to always be in the format `https://doi.org/' + uppercase DOI.
- Removed the per-column change detection on UPDATE, as comparing each field is expensive, especially with JSON columns.
- Scoped the PENDING deletes to affected DMPs only.                                
- Orphan cleanup is now a separate procedure run once after all DMPs process.

Fixes [#72](https://github.com/CDLUC3/dmptool-works-matching/issues/72)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Updated unit tests and have tested in dev. The tests now use `@testcontainers/mysql` so that they can be run in CI, are self-contained and don't affect tables in local db.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules