### PR TITLE
Feature/171/js update guidance resolver to include custom guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## v1.1.0
 
 ### Added
+- Added `ON DELETE CASCADE` sql migration script for deletion of `versionedTemplateCustomization` and `templateCustomization` FKs [#171]
+- Added `findByPosition` function to `CustomQuestion` to assist with reordering of custom questions [#171]
+- Added `findActiveByTemplateAffiliationAndQuestion` to `VersionedQuestionCustomization` and `findActiveByTemplateAffiliationAndSection` to `VersionedSectionCustomization` to help surface custom guidance [#171]
+- Added `MoveCustomQuestionDirection` enum to `questionCustomization` schema [#171]
+- Added new `templateCustomizationPublishHelpers.ts` service to help snapshot child customization records when publishing a templateCustomization [#171]
 - Added `versionedCustomSectionId` and `versionedCustomQuestionId` files to `answers` table [#159]
 - Added `findByVersionedCustomSectionId` and `findByVersionedSectionIdAndType` functions to VersionedCustomQuestion model [#159]
 - Added `versionedCustomSection` and `versionedCustomQuestion` chained resolvers to `answer` query [#159]
@@ -51,6 +56,11 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated the `publish` function in `TemplateCustomization` to `snapshotCustomizationChildren` and `rollbackPublishedSnapshot` helper functions to snapshot all child records into published versions [#171]
+- Updated `findByVersionedCustomSectionId` and `findByVersionedSectionIdAndType` in `VersionedCustomQuestion` to only grab records related to `active` `versionedTemplateCustomization` [#171]
+- Updated `guidanceSourcesForPlan` resolver in `guidance` resolver to pass in `customSectionId` [#171]
+- Updated `moveCustomQuestion` resolver in `questionCustomization` resolver to help with accurate reordering. Added `direction` variable to help with that [#171]
+- Updated `getGuidanceSourcesForPlan` function in `guidanceService` [#171]
 - Updated `Answer` model with `versionedCustomSectionId` and `versionedCustomQuestionId`, and added new `findFilledAnswersByCustomQuestionIds` and `findByPlanIdAndVersionedCustomQuestionId` functions, and updated `isValid` function to account for new id fields, and updated `create` function to check both `versionedQuestionId` and `versionedCustomQuestionId` for already existing answer [#159]
 - Updated `publishedQuestions` query in `versionedQuestion` resolver to return both `BASE` and `CUSTOM` versioned questions for the given versionedSectionId. Also, added `publishedCustomQuestions` query to return the `customQuestions` associated with a `customSection` [#159]
 - Updated `PlanSectionProgress` so that it returns custom sections, and correct totalQuestions counts that include customQuestions [#167]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added `findByPosition` function to `CustomQuestion` to assist with reordering of custom questions [#171]
 - Added `findActiveByTemplateAffiliationAndQuestion` to `VersionedQuestionCustomization` and `findActiveByTemplateAffiliationAndSection` to `VersionedSectionCustomization` to help surface custom guidance [#171]
 - Added `MoveCustomQuestionDirection` enum to `questionCustomization` schema [#171]
-- Added new `templateCustomizationPublishHelpers.ts` service to help snapshot child customization records when publishing a templateCustomization [#171]
+- Added new `templateCustomizationPublishHelpers.ts` service to help update snapshot child customization records when publishing a templateCustomization [#171]
 - Added `versionedCustomSectionId` and `versionedCustomQuestionId` files to `answers` table [#159]
 - Added `findByVersionedCustomSectionId` and `findByVersionedSectionIdAndType` functions to VersionedCustomQuestion model [#159]
 - Added `versionedCustomSection` and `versionedCustomQuestion` chained resolvers to `answer` query [#159]

--- a/data-migrations/2026-04-02-0154-add-cascade-to-versioned-sections-and-questions.sql
+++ b/data-migrations/2026-04-02-0154-add-cascade-to-versioned-sections-and-questions.sql
@@ -1,0 +1,38 @@
+-- Add ON DELETE CASCADE to versionedTemplateCustomizationId FKs on all four
+-- child tables. Previously these had no cascade, requiring manual deletion
+-- order in application code when rolling back a published snapshot.
+--
+-- Note: MariaDB requires DROP and ADD of a same-named FK constraint to be
+-- in separate ALTER TABLE statements to avoid a duplicate constraint name error.
+
+ALTER TABLE `versionedSectionCustomizations`
+  DROP FOREIGN KEY `fk_vSectionCust_templateCustId`;
+ALTER TABLE `versionedSectionCustomizations`
+  ADD CONSTRAINT `fk_vSectionCust_templateCustId`
+    FOREIGN KEY (`versionedTemplateCustomizationId`)
+    REFERENCES `versionedTemplateCustomizations` (`id`)
+    ON DELETE CASCADE;
+
+ALTER TABLE `versionedQuestionCustomizations`
+  DROP FOREIGN KEY `fk_vQCust_templateCustId`;
+ALTER TABLE `versionedQuestionCustomizations`
+  ADD CONSTRAINT `fk_vQCust_templateCustId`
+    FOREIGN KEY (`versionedTemplateCustomizationId`)
+    REFERENCES `versionedTemplateCustomizations` (`id`)
+    ON DELETE CASCADE;
+
+ALTER TABLE `versionedCustomSections`
+  DROP FOREIGN KEY `fk_vCustomSecs_templateCustId`;
+ALTER TABLE `versionedCustomSections`
+  ADD CONSTRAINT `fk_vCustomSecs_templateCustId`
+    FOREIGN KEY (`versionedTemplateCustomizationId`)
+    REFERENCES `versionedTemplateCustomizations` (`id`)
+    ON DELETE CASCADE;
+
+ALTER TABLE `versionedCustomQuestions`
+  DROP FOREIGN KEY `fk_vCustomQs_templateCustId`;
+ALTER TABLE `versionedCustomQuestions`
+  ADD CONSTRAINT `fk_vCustomQs_templateCustId`
+    FOREIGN KEY (`versionedTemplateCustomizationId`)
+    REFERENCES `versionedTemplateCustomizations` (`id`)
+    ON DELETE CASCADE;

--- a/data-migrations/2026-04-02-0154-add-cascade-to-versioned-sections-and-questions.sql
+++ b/data-migrations/2026-04-02-0154-add-cascade-to-versioned-sections-and-questions.sql
@@ -1,6 +1,6 @@
 -- Add ON DELETE CASCADE to versionedTemplateCustomizationId FKs on all four
 -- child tables. Previously these had no cascade, requiring manual deletion
--- order in application code when rolling back a published snapshot.
+-- in application code when rolling back a published snapshot.
 --
 -- Note: MariaDB requires DROP and ADD of a same-named FK constraint to be
 -- in separate ALTER TABLE statements to avoid a duplicate constraint name error.

--- a/data-migrations/2026-04-02-0154-add-cascade-to-versioned-sections-and-questions.sql
+++ b/data-migrations/2026-04-02-0154-add-cascade-to-versioned-sections-and-questions.sql
@@ -5,34 +5,37 @@
 -- Note: MariaDB requires DROP and ADD of a same-named FK constraint to be
 -- in separate ALTER TABLE statements to avoid a duplicate constraint name error.
 
-ALTER TABLE `versionedSectionCustomizations`
-  DROP FOREIGN KEY `fk_vSectionCust_templateCustId`;
-ALTER TABLE `versionedSectionCustomizations`
-  ADD CONSTRAINT `fk_vSectionCust_templateCustId`
-    FOREIGN KEY (`versionedTemplateCustomizationId`)
-    REFERENCES `versionedTemplateCustomizations` (`id`)
+ALTER TABLE versionedSectionCustomizations
+  DROP FOREIGN KEY fk_vSectionCust_templateCustId;
+ALTER TABLE versionedSectionCustomizations
+  ADD CONSTRAINT fk_vSectionCust_templateCustId_cascade
+    FOREIGN KEY (versionedTemplateCustomizationId)
+    REFERENCES versionedTemplateCustomizations(id)
     ON DELETE CASCADE;
 
-ALTER TABLE `versionedQuestionCustomizations`
-  DROP FOREIGN KEY `fk_vQCust_templateCustId`;
-ALTER TABLE `versionedQuestionCustomizations`
-  ADD CONSTRAINT `fk_vQCust_templateCustId`
-    FOREIGN KEY (`versionedTemplateCustomizationId`)
-    REFERENCES `versionedTemplateCustomizations` (`id`)
+
+ALTER TABLE versionedQuestionCustomizations
+  DROP FOREIGN KEY fk_vQCust_templateCustId;
+ALTER TABLE versionedQuestionCustomizations
+  ADD CONSTRAINT fk_vQCust_templateCustId_cascade
+    FOREIGN KEY (versionedTemplateCustomizationId)
+    REFERENCES versionedTemplateCustomizations(id)
     ON DELETE CASCADE;
 
-ALTER TABLE `versionedCustomSections`
-  DROP FOREIGN KEY `fk_vCustomSecs_templateCustId`;
-ALTER TABLE `versionedCustomSections`
-  ADD CONSTRAINT `fk_vCustomSecs_templateCustId`
-    FOREIGN KEY (`versionedTemplateCustomizationId`)
-    REFERENCES `versionedTemplateCustomizations` (`id`)
+
+ALTER TABLE versionedCustomSections
+  DROP FOREIGN KEY fk_vCustomSecs_templateCustId;
+ALTER TABLE versionedCustomSections
+  ADD CONSTRAINT fk_vCustomSecs_templateCustId_cascade
+    FOREIGN KEY (versionedTemplateCustomizationId)
+    REFERENCES versionedTemplateCustomizations(id)
     ON DELETE CASCADE;
 
-ALTER TABLE `versionedCustomQuestions`
-  DROP FOREIGN KEY `fk_vCustomQs_templateCustId`;
-ALTER TABLE `versionedCustomQuestions`
-  ADD CONSTRAINT `fk_vCustomQs_templateCustId`
-    FOREIGN KEY (`versionedTemplateCustomizationId`)
-    REFERENCES `versionedTemplateCustomizations` (`id`)
+
+ALTER TABLE versionedCustomQuestions
+  DROP FOREIGN KEY fk_vCustomQs_templateCustId;
+ALTER TABLE versionedCustomQuestions
+  ADD CONSTRAINT fk_vCustomQs_templateCustId_cascade
+    FOREIGN KEY (versionedTemplateCustomizationId)
+    REFERENCES versionedTemplateCustomizations(id)
     ON DELETE CASCADE;

--- a/data-migrations/2026-04-02-0756-add-cascade-to-template-customizations.sql
+++ b/data-migrations/2026-04-02-0756-add-cascade-to-template-customizations.sql
@@ -1,0 +1,44 @@
+ALTER TABLE customQuestions
+  DROP FOREIGN KEY fk_customQs_templateCustId,
+  ADD CONSTRAINT fk_customQs_templateCustId_cascade 
+    FOREIGN KEY (templateCustomizationId) REFERENCES templateCustomizations(id) ON DELETE CASCADE;
+
+ALTER TABLE customSections
+  DROP FOREIGN KEY fk_customSecs_templateCustId,
+  ADD CONSTRAINT fk_customSecs_templateCustId_cascade 
+    FOREIGN KEY (templateCustomizationId) REFERENCES templateCustomizations(id) ON DELETE CASCADE;
+
+ALTER TABLE questionCustomizations
+  DROP FOREIGN KEY fk_qCust_templateCustId,
+  ADD CONSTRAINT fk_qCust_templateCustId_cascade 
+    FOREIGN KEY (templateCustomizationId) REFERENCES templateCustomizations(id) ON DELETE CASCADE;
+
+ALTER TABLE sectionCustomizations
+  DROP FOREIGN KEY fk_sectionCust_templateCustId,
+  ADD CONSTRAINT fk_sectionCust_templateCustId_cascade 
+    FOREIGN KEY (templateCustomizationId) REFERENCES templateCustomizations(id) ON DELETE CASCADE;
+
+ALTER TABLE versionedTemplateCustomizations
+  DROP FOREIGN KEY fk_vTemplateCust_templateId,
+  ADD CONSTRAINT fk_vTemplateCust_templateId_cascade 
+    FOREIGN KEY (templateCustomizationId) REFERENCES templateCustomizations(id) ON DELETE CASCADE;
+
+    ALTER TABLE versionedCustomQuestions
+  DROP FOREIGN KEY fk_vCustomQs_questionId,
+  ADD CONSTRAINT fk_vCustomQs_questionId_cascade
+    FOREIGN KEY (customQuestionId) REFERENCES customQuestions(id) ON DELETE CASCADE;
+
+ALTER TABLE versionedCustomSections
+  DROP FOREIGN KEY fk_vCustomSecs_sectionId,
+  ADD CONSTRAINT fk_vCustomSecs_sectionId_cascade
+    FOREIGN KEY (customSectionId) REFERENCES customSections(id) ON DELETE CASCADE;
+
+ALTER TABLE versionedQuestionCustomizations
+  DROP FOREIGN KEY fk_vQCust_questionId,
+  ADD CONSTRAINT fk_vQCust_questionId_cascade
+    FOREIGN KEY (questionCustomizationId) REFERENCES questionCustomizations(id) ON DELETE CASCADE;
+
+ALTER TABLE versionedSectionCustomizations
+  DROP FOREIGN KEY fk_vSectionCust_sectionId,
+  ADD CONSTRAINT fk_vSectionCust_sectionId_cascade
+    FOREIGN KEY (sectionCustomizationId) REFERENCES sectionCustomizations(id) ON DELETE CASCADE;

--- a/data-migrations/2026-04-02-0756-add-cascade-to-template-customizations.sql
+++ b/data-migrations/2026-04-02-0756-add-cascade-to-template-customizations.sql
@@ -1,5 +1,4 @@
--- Add ON DELETE CASCADE to the versioned* FKs to their respective parent tables, 
--- to ensure that when a template customization is deleted, 
+-- Add ON DELETE CASCADE to ensure that when a template customization is deleted, 
 -- all associated versioned records are also deleted so that we don't have orphaned versioned records that reference deleted template customizations.
 ALTER TABLE customQuestions
   DROP FOREIGN KEY fk_customQs_templateCustId;

--- a/data-migrations/2026-04-02-0756-add-cascade-to-template-customizations.sql
+++ b/data-migrations/2026-04-02-0756-add-cascade-to-template-customizations.sql
@@ -2,46 +2,55 @@
 -- to ensure that when a template customization is deleted, 
 -- all associated versioned records are also deleted so that we don't have orphaned versioned records that reference deleted template customizations.
 ALTER TABLE customQuestions
-  DROP FOREIGN KEY fk_customQs_templateCustId,
-  ADD CONSTRAINT fk_customQs_templateCustId_cascade 
+  DROP FOREIGN KEY fk_customQs_templateCustId;
+ALTER TABLE customQuestions
+  ADD CONSTRAINT fk_customQs_templateCustId_cascade
     FOREIGN KEY (templateCustomizationId) REFERENCES templateCustomizations(id) ON DELETE CASCADE;
 
 ALTER TABLE customSections
-  DROP FOREIGN KEY fk_customSecs_templateCustId,
-  ADD CONSTRAINT fk_customSecs_templateCustId_cascade 
+  DROP FOREIGN KEY fk_customSecs_templateCustId;
+ALTER TABLE customSections
+  ADD CONSTRAINT fk_customSecs_templateCustId_cascade
     FOREIGN KEY (templateCustomizationId) REFERENCES templateCustomizations(id) ON DELETE CASCADE;
 
 ALTER TABLE questionCustomizations
-  DROP FOREIGN KEY fk_qCust_templateCustId,
-  ADD CONSTRAINT fk_qCust_templateCustId_cascade 
+  DROP FOREIGN KEY fk_qCust_templateCustId;
+ALTER TABLE questionCustomizations
+  ADD CONSTRAINT fk_qCust_templateCustId_cascade
     FOREIGN KEY (templateCustomizationId) REFERENCES templateCustomizations(id) ON DELETE CASCADE;
 
 ALTER TABLE sectionCustomizations
-  DROP FOREIGN KEY fk_sectionCust_templateCustId,
-  ADD CONSTRAINT fk_sectionCust_templateCustId_cascade 
+  DROP FOREIGN KEY fk_sectionCust_templateCustId;
+ALTER TABLE sectionCustomizations
+  ADD CONSTRAINT fk_sectionCust_templateCustId_cascade
     FOREIGN KEY (templateCustomizationId) REFERENCES templateCustomizations(id) ON DELETE CASCADE;
 
 ALTER TABLE versionedTemplateCustomizations
-  DROP FOREIGN KEY fk_vTemplateCust_templateId,
-  ADD CONSTRAINT fk_vTemplateCust_templateId_cascade 
+  DROP FOREIGN KEY fk_vTemplateCust_templateId;
+ALTER TABLE versionedTemplateCustomizations
+  ADD CONSTRAINT fk_vTemplateCust_templateId_cascade
     FOREIGN KEY (templateCustomizationId) REFERENCES templateCustomizations(id) ON DELETE CASCADE;
 
 ALTER TABLE versionedCustomQuestions
-  DROP FOREIGN KEY fk_vCustomQs_questionId,
+  DROP FOREIGN KEY fk_vCustomQs_questionId;
+ALTER TABLE versionedCustomQuestions
   ADD CONSTRAINT fk_vCustomQs_questionId_cascade
     FOREIGN KEY (customQuestionId) REFERENCES customQuestions(id) ON DELETE CASCADE;
 
 ALTER TABLE versionedCustomSections
-  DROP FOREIGN KEY fk_vCustomSecs_sectionId,
+  DROP FOREIGN KEY fk_vCustomSecs_sectionId;
+ALTER TABLE versionedCustomSections
   ADD CONSTRAINT fk_vCustomSecs_sectionId_cascade
     FOREIGN KEY (customSectionId) REFERENCES customSections(id) ON DELETE CASCADE;
 
 ALTER TABLE versionedQuestionCustomizations
-  DROP FOREIGN KEY fk_vQCust_questionId,
+  DROP FOREIGN KEY fk_vQCust_questionId;
+ALTER TABLE versionedQuestionCustomizations
   ADD CONSTRAINT fk_vQCust_questionId_cascade
     FOREIGN KEY (questionCustomizationId) REFERENCES questionCustomizations(id) ON DELETE CASCADE;
 
 ALTER TABLE versionedSectionCustomizations
-  DROP FOREIGN KEY fk_vSectionCust_sectionId,
+  DROP FOREIGN KEY fk_vSectionCust_sectionId;
+ALTER TABLE versionedSectionCustomizations
   ADD CONSTRAINT fk_vSectionCust_sectionId_cascade
     FOREIGN KEY (sectionCustomizationId) REFERENCES sectionCustomizations(id) ON DELETE CASCADE;

--- a/data-migrations/2026-04-02-0756-add-cascade-to-template-customizations.sql
+++ b/data-migrations/2026-04-02-0756-add-cascade-to-template-customizations.sql
@@ -1,3 +1,6 @@
+-- Add ON DELETE CASCADE to the versioned* FKs to their respective parent tables, 
+-- to ensure that when a template customization is deleted, 
+-- all associated versioned records are also deleted so that we don't have orphaned versioned records that reference deleted template customizations.
 ALTER TABLE customQuestions
   DROP FOREIGN KEY fk_customQs_templateCustId,
   ADD CONSTRAINT fk_customQs_templateCustId_cascade 
@@ -23,7 +26,7 @@ ALTER TABLE versionedTemplateCustomizations
   ADD CONSTRAINT fk_vTemplateCust_templateId_cascade 
     FOREIGN KEY (templateCustomizationId) REFERENCES templateCustomizations(id) ON DELETE CASCADE;
 
-    ALTER TABLE versionedCustomQuestions
+ALTER TABLE versionedCustomQuestions
   DROP FOREIGN KEY fk_vCustomQs_questionId,
   ADD CONSTRAINT fk_vCustomQs_questionId_cascade
     FOREIGN KEY (customQuestionId) REFERENCES customQuestions(id) ON DELETE CASCADE;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,7 +78,6 @@ services:
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
       - DEBUG=${DEBUG:-0}
       - SERVICES=ses,sqs,lambda,ssm,logs,events,dynamodb
-      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN}
     volumes:
       - "./docker/localstack:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/src/models/CustomQuestion.ts
+++ b/src/models/CustomQuestion.ts
@@ -379,4 +379,47 @@ export class CustomQuestion extends MySqlModel {
     return Array.isArray(results) ? results.map(r => new CustomQuestion(r)) : [];
   }
 
+  /**
+   * Find a custom question by its position within a template customization
+   *
+   * @param reference The reference to use for logging errors.
+   * @param context The Apollo context.
+   * @param templateCustomizationId The id of the template customization.
+   * @param sectionType The type of the section.
+   * @param sectionId The id of the section.
+   * @param pinnedQuestionType The type of the pinned question.
+   * @param pinnedQuestionId The id of the pinned question.
+   * @returns The custom question or null if not found.
+   */
+  static async findByPosition(
+    reference: string,
+    context: MyContext,
+    templateCustomizationId: number,
+    sectionType: string,
+    sectionId: number,
+    pinnedQuestionType: string | null,
+    pinnedQuestionId: number | null
+  ): Promise<CustomQuestion | null> {
+    const sql = `
+    SELECT * FROM customQuestions 
+    WHERE templateCustomizationId = ?
+      AND sectionType = ?
+      AND sectionId = ?
+      AND pinnedQuestionType <=> ?
+      AND pinnedQuestionId <=> ?
+    LIMIT 1
+  `;
+    // <=> is MySQL's NULL-safe equality operator.  It correctly handles the case where pinnedQuestionId is null, 
+    // since null = null is false in SQL but null <=> null is true.
+    const results = await CustomQuestion.query(context, sql, [
+      templateCustomizationId.toString(),
+      sectionType,
+      sectionId.toString(),
+      pinnedQuestionType,
+      pinnedQuestionId?.toString() ?? null,
+    ], reference);
+
+    return Array.isArray(results) && results.length > 0 ? new CustomQuestion(results[0]) : null;
+
+  }
 }

--- a/src/models/CustomQuestion.ts
+++ b/src/models/CustomQuestion.ts
@@ -380,7 +380,9 @@ export class CustomQuestion extends MySqlModel {
   }
 
   /**
-   * Find a custom question by its position within a template customization
+   * Find a custom question by its position within a template customization. This is needed when
+   * calling moveCustomQuestion we need to check whether another customQuestion exists in the position
+   * that we want to move another custom question to. The position is determined by the section and pinned question it is attached to.
    *
    * @param reference The reference to use for logging errors.
    * @param context The Apollo context.

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -188,6 +188,7 @@ export class PlanSectionProgress {
       AND vcq.versionedSectionType = 'CUSTOM'
       AND vcq.versionedTemplateCustomizationId = vtc.id
     WHERE vtc.templateCustomizationId = ?
+    AND vtc.active = 1
     GROUP BY vcs.customSectionId, vcs.name, vcs.pinnedVersionedSectionType, vcs.pinnedVersionedSectionId
   `;
     const rows = await Plan.query(context, sql, [templateCustomizationId.toString()], reference);

--- a/src/models/TemplateCustomization.ts
+++ b/src/models/TemplateCustomization.ts
@@ -623,7 +623,7 @@ export class TemplateCustomization extends MySqlModel {
   }
 
   /**
-   * Publish the customization
+   * Publish the template customization
    *
    * @param context The Apollo context.
    * @returns The published Template customization.
@@ -650,10 +650,11 @@ export class TemplateCustomization extends MySqlModel {
           currentVersionedTemplateId: this.currentVersionedTemplateId,
           active: true,
         });
+
         const created: VersionedTemplateCustomization = await newVersion.create(context);
 
         if (!isNullOrUndefined(created) && !created.hasErrors() && created.id) {
-          // Snapshot all child records into their versioned equivalents
+          // Snapshot all child records into their published, versioned equivalents
           await snapshotCustomizationChildren(ref, context, this, created);
 
           if (this.hasErrors()) {

--- a/src/models/TemplateCustomization.ts
+++ b/src/models/TemplateCustomization.ts
@@ -1,9 +1,5 @@
 import { MySqlModel } from "./MySqlModel";
 import { VersionedTemplateCustomization } from "./VersionedTemplateCustomization";
-import { VersionedCustomQuestion } from "./VersionedCustomQuestion";
-import { VersionedCustomSection } from "./VersionedCustomSection";
-import { CustomSection } from "./CustomSection";
-import { CustomQuestion } from "./CustomQuestion";
 import { MyContext } from "../context";
 import {
   isNullOrUndefined,
@@ -12,6 +8,10 @@ import {
 } from "../utils/helpers";
 import { PinnedSectionTypeEnum } from "./CustomSection";
 import { PinnedQuestionTypeEnum } from "./CustomQuestion";
+import {
+  snapshotCustomizationChildren,
+  rollbackPublishedSnapshot,
+} from "../services/templateCustomizationPublishHelpers";
 
 /**
  * The status of the customization.
@@ -629,6 +629,7 @@ export class TemplateCustomization extends MySqlModel {
    * @returns The published Template customization.
    */
   async publish(context: MyContext): Promise<TemplateCustomization> {
+    const ref = 'TemplateCustomization.publish';
 
     if (!this.id) {
       // Cannot publish it if it hasn't been saved yet!
@@ -643,123 +644,35 @@ export class TemplateCustomization extends MySqlModel {
       if (await this.isValid()) {
 
         // Create a new published version of the customization
-        const newVersion = new VersionedTemplateCustomization(
-          {
-            affiliationId: this.affiliationId,
-            templateCustomizationId: this.id,
-            currentVersionedTemplateId: this.currentVersionedTemplateId,
-            active: true
-          }
-        )
-
+        const newVersion = new VersionedTemplateCustomization({
+          affiliationId: this.affiliationId,
+          templateCustomizationId: this.id,
+          currentVersionedTemplateId: this.currentVersionedTemplateId,
+          active: true,
+        });
         const created: VersionedTemplateCustomization = await newVersion.create(context);
 
         if (!isNullOrUndefined(created) && !created.hasErrors() && created.id) {
-          // Snapshot custom sections into versionedCustomSections
-          const customSections = await CustomSection.findByCustomizationId(
-            'TemplateCustomization.publish',
-            context,
-            this.id
-          );
+          // Snapshot all child records into their versioned equivalents
+          await snapshotCustomizationChildren(ref, context, this, created);
 
-          for (const section of customSections) {
-            const versionedSection = new VersionedCustomSection({
-              versionedTemplateCustomizationId: created.id,
-              customSectionId: section.id,
-              pinnedVersionedSectionType: section.pinnedSectionType,
-              pinnedVersionedSectionId: section.pinnedSectionId,
-              name: section.name,
-              introduction: section.introduction,
-              requirements: section.requirements,
-              guidance: section.guidance,
-            });
-            const createdSection = await versionedSection.create(context);
+          if (this.hasErrors()) {
+            // Roll back: remove all child rows and the incomplete snapshot,
+            // then restore the prior active version.
+            await rollbackPublishedSnapshot(
+              context, created.id, this.latestPublishedVersionId);
+          } else {
+            // Update the status of the customization to reflect the change
+            this.status = TemplateCustomizationStatus.PUBLISHED;
+            this.isDirty = false;
+            this.latestPublishedVersionId = created.id;
+            this.latestPublishedDate = created.created;
+            // noTouch=true so the update method will not set isDirty to true
+            const published: TemplateCustomization = await this.update(context, true);
 
-            if (!createdSection || createdSection.hasErrors()) {
-              this.addError('general', `Unable to version custom section: ${section.name}`);
-              continue;
+            if (!published) {
+              this.addError('general', 'Unable to publish');
             }
-
-            // Snapshot custom questions for this section
-            const customQuestions = await CustomQuestion.findByCustomizationAndSectionId(
-              'TemplateCustomization.publish',
-              context,
-              this.id,
-              PinnedSectionTypeEnum.CUSTOM,
-              section.id
-            );
-
-            for (const question of customQuestions) {
-              const versionedQuestion = new VersionedCustomQuestion({
-                versionedTemplateCustomizationId: created.id,
-                customQuestionId: question.id,
-                versionedSectionType: question.sectionType,   // 'CUSTOM' since we're in a custom section
-                versionedSectionId: question.sectionId,
-                pinnedVersionedQuestionType: question.pinnedQuestionType ?? null,
-                pinnedVersionedQuestionId: question.pinnedQuestionId ?? null,
-                questionText: question.questionText,
-                json: question.json,
-                requirementText: question.requirementText ?? null,
-                guidanceText: question.guidanceText ?? null,
-                sampleText: question.sampleText ?? null,
-                useSampleTextAsDefault: question.useSampleTextAsDefault ?? false,
-                required: question.required ?? false,
-              });
-              const createdQuestion = await versionedQuestion.create(context);
-
-              if (!createdQuestion || createdQuestion.hasErrors()) {
-                this.addError('general', `Unable to version custom question in section: ${section.name}`);
-              }
-            }
-          }
-
-          // Snapshot custom questions attached to BASE sections — these are NOT
-          // covered by the loop above since that loop only iterates custom sections.
-          // findByCustomizationAndSectionType(BASE) returns all custom questions
-          // where sectionType = 'BASE', regardless of which specific base section
-          // they belong to.
-          const baseCustomQuestions = await CustomQuestion.findByCustomizationAndSectionType(
-            'TemplateCustomization.publish',
-            context,
-            this.id,
-            PinnedSectionTypeEnum.BASE
-          );
-
-          for (const question of baseCustomQuestions) {
-            const versionedQuestion = new VersionedCustomQuestion({
-              versionedTemplateCustomizationId: created.id,
-              customQuestionId: question.id,
-              versionedSectionType: question.sectionType,           // 'BASE'
-              versionedSectionId: question.sectionId,               // the versionedSection id
-              pinnedVersionedQuestionType: question.pinnedQuestionType ?? null,
-              pinnedVersionedQuestionId: question.pinnedQuestionId ?? null,
-              questionText: question.questionText,
-              json: question.json,
-              requirementText: question.requirementText ?? null,
-              guidanceText: question.guidanceText ?? null,
-              sampleText: question.sampleText ?? null,
-              useSampleTextAsDefault: question.useSampleTextAsDefault ?? false,
-              required: question.required ?? false,
-            });
-            const createdQuestion = await versionedQuestion.create(context);
-
-            if (!createdQuestion || createdQuestion.hasErrors()) {
-              this.addError(
-                'general',
-                `Unable to version custom question for base section id: ${question.sectionId}`
-              );
-            }
-          }
-
-          // Update the status of the customization to reflect the change
-          this.status = TemplateCustomizationStatus.PUBLISHED;
-          this.isDirty = false;
-          this.latestPublishedVersionId = created.id;
-          this.latestPublishedDate = created.created;
-          const published: TemplateCustomization = await this.update(context, true); // noTouch=true, the update method will not set isDirty to true
-
-          if (!published) {
-            this.addError('general', 'Unable to publish');
           }
         } else {
           this.errors = created?.errors ?? this.errors;

--- a/src/models/VersionedCustomQuestion.ts
+++ b/src/models/VersionedCustomQuestion.ts
@@ -330,10 +330,13 @@ export class VersionedCustomQuestion extends MySqlModel {
     versionedCustomSectionId: number
   ): Promise<VersionedCustomQuestion[]> {
     const sql = `
-    SELECT * FROM ${VersionedCustomQuestion.tableName}
-    WHERE versionedSectionType = 'CUSTOM'
-      AND versionedSectionId = ?
-    ORDER BY pinnedVersionedQuestionType ASC, pinnedVersionedQuestionId ASC
+    SELECT vcq.* FROM ${VersionedCustomQuestion.tableName} as vcq
+    JOIN versionedTemplateCustomizations as vtc
+      ON vcq.versionedTemplateCustomizationId = vtc.id
+    WHERE vcq.versionedSectionType = 'CUSTOM'
+      AND vcq.versionedSectionId = ?
+      AND vtc.active = 1
+    ORDER BY vcq.pinnedVersionedQuestionType ASC, vcq.pinnedVersionedQuestionId ASC
   `;
     const results = await VersionedCustomQuestion.query(
       context, sql, [versionedCustomSectionId.toString()], reference
@@ -350,9 +353,13 @@ export class VersionedCustomQuestion extends MySqlModel {
     versionedSectionId: number,
     sectionType: 'BASE' | 'CUSTOM'
   ): Promise<VersionedCustomQuestion[]> {
-    const sql = `SELECT * FROM versionedCustomQuestions 
-    WHERE versionedSectionType = ? AND versionedSectionId = ?
-    ORDER BY pinnedVersionedQuestionType ASC, pinnedVersionedQuestionId ASC`;
+    const sql = `SELECT vcq.* FROM versionedCustomQuestions as vcq
+    JOIN versionedTemplateCustomizations as vtc
+      ON vcq.versionedTemplateCustomizationId = vtc.id 
+    WHERE vcq.versionedSectionType = ? 
+      AND vcq.versionedSectionId = ?
+      AND vtc.active = 1
+    ORDER BY vcq.pinnedVersionedQuestionType ASC, vcq.pinnedVersionedQuestionId ASC`;
     const results = await VersionedCustomQuestion.query(
       context, sql, [sectionType, versionedSectionId.toString()], reference
     );

--- a/src/models/VersionedQuestionCustomization.ts
+++ b/src/models/VersionedQuestionCustomization.ts
@@ -238,6 +238,7 @@ export class VersionedQuestionCustomization extends MySqlModel {
   /**
  * Find the active versioned question customization for a given template and affiliation.
  * Used to surface customization guidance in the plan guidance panel.
+ * 
  *
  * @param reference The reference to use for logging errors.
  * @param context The Apollo context.

--- a/src/models/VersionedQuestionCustomization.ts
+++ b/src/models/VersionedQuestionCustomization.ts
@@ -235,7 +235,7 @@ export class VersionedQuestionCustomization extends MySqlModel {
     return Array.isArray(results) && results.length > 0 ? results.map(r => new VersionedQuestionCustomization(r)) : [];
   }
 
-  /**
+/**
  * Find the active versioned question customization for a given template and affiliation.
  * Used to surface customization guidance in the plan guidance panel.
  * 

--- a/src/models/VersionedQuestionCustomization.ts
+++ b/src/models/VersionedQuestionCustomization.ts
@@ -234,4 +234,39 @@ export class VersionedQuestionCustomization extends MySqlModel {
     );
     return Array.isArray(results) && results.length > 0 ? results.map(r => new VersionedQuestionCustomization(r)) : [];
   }
+
+  /**
+ * Find the active versioned question customization for a given template and affiliation.
+ * Used to surface customization guidance in the plan guidance panel.
+ *
+ * @param reference The reference to use for logging errors.
+ * @param context The Apollo context.
+ * @param templateId The base template id.
+ * @param affiliationId The affiliation id.
+ * @param versionedQuestionId The versioned question id.
+ * @returns The active versioned question customization, or undefined if none exists.
+ */
+  static async findActiveByTemplateAffiliationAndQuestion(
+    reference: string,
+    context: MyContext,
+    affiliationId: string,
+    versionedQuestionId: number
+  ): Promise<VersionedQuestionCustomization | undefined> {
+    const results = await VersionedQuestionCustomization.query(
+      context,
+      `SELECT vqc.* FROM ${VersionedQuestionCustomization.tableName} AS vqc
+     JOIN versionedTemplateCustomizations AS vtc
+       ON vqc.versionedTemplateCustomizationId = vtc.id
+     WHERE vtc.active = 1
+       AND vtc.affiliationId = ?
+       AND vqc.versionedQuestionId = ?
+     LIMIT 1`,
+      [affiliationId, versionedQuestionId.toString()],
+      reference
+    );
+    return Array.isArray(results) && results.length > 0
+      ? new VersionedQuestionCustomization(results[0])
+      : undefined;
+  }
+
 }

--- a/src/models/VersionedSectionCustomization.ts
+++ b/src/models/VersionedSectionCustomization.ts
@@ -231,4 +231,38 @@ export class VersionedSectionCustomization extends MySqlModel {
     );
     return Array.isArray(results) && results.length > 0 ? results.map(r => new VersionedSectionCustomization(r)) : [];
   }
+
+
+  /**
+ * Find the active versioned section customization for a given affiliation and section.
+ * Used to surface customization guidance in the plan guidance panel.
+ *
+ * @param reference The reference to use for logging errors.
+ * @param context The Apollo context.
+ * @param affiliationId The affiliation id.
+ * @param versionedSectionId The versioned section id.
+ * @returns The active versioned section customization, or undefined if none exists.
+ */
+  static async findActiveByTemplateAffiliationAndSection(
+    reference: string,
+    context: MyContext,
+    affiliationId: string,
+    versionedSectionId: number
+  ): Promise<VersionedSectionCustomization | undefined> {
+    const results = await VersionedSectionCustomization.query(
+      context,
+      `SELECT vsc.* FROM ${VersionedSectionCustomization.tableName} AS vsc
+     JOIN versionedTemplateCustomizations AS vtc
+       ON vsc.versionedTemplateCustomizationId = vtc.id
+     WHERE vtc.active = 1
+       AND vtc.affiliationId = ?
+       AND vsc.versionedSectionId = ?
+     LIMIT 1`,
+      [affiliationId, versionedSectionId.toString()],
+      reference
+    );
+    return Array.isArray(results) && results.length > 0
+      ? new VersionedSectionCustomization(results[0])
+      : undefined;
+  }
 }

--- a/src/models/VersionedTemplate.ts
+++ b/src/models/VersionedTemplate.ts
@@ -115,8 +115,10 @@ export class VersionedTemplateSearchResult {
       'FROM versionedTemplates vt',
       'LEFT JOIN users u ON u.id = vt.modifiedById',
       'LEFT JOIN affiliations a ON a.uri = vt.ownerId',
-      'LEFT JOIN versionedTemplateCustomizations vtc ON vtc.currentVersionedTemplateId = vt.id',
-      'AND vtc.affiliationId = ?'
+      'LEFT JOIN versionedTemplateCustomizations vtc',
+      'ON vtc.currentVersionedTemplateId = vt.id',
+      'AND vtc.affiliationId=?',
+      'AND vtc.active = 1'
     ].join(' ');
 
     values.unshift(userAffiliationId);

--- a/src/models/__tests__/CustomQuestion.spec.ts
+++ b/src/models/__tests__/CustomQuestion.spec.ts
@@ -726,4 +726,129 @@ describe("CustomQuestion", () => {
       expect(result).toBeUndefined();
     });
   });
+
+  describe("findByPosition", () => {
+    const expectedSql = `
+    SELECT * FROM customQuestions 
+    WHERE templateCustomizationId = ?
+      AND sectionType = ?
+      AND sectionId = ?
+      AND pinnedQuestionType <=> ?
+      AND pinnedQuestionId <=> ?
+    LIMIT 1
+  `;
+
+    it("should find a CustomQuestion by position with pinnedQuestion values", async () => {
+      const mockQuery = jest.spyOn(MySqlModel, "query").mockResolvedValue([
+        {
+          id: 1,
+          templateCustomizationId: 100,
+          sectionType: PinnedSectionTypeEnum.BASE,
+          sectionId: 200,
+          pinnedQuestionType: PinnedQuestionTypeEnum.BASE,
+          pinnedQuestionId: 300,
+          json: {
+            type: "text",
+            attributes: { maxLength: 100 },
+            meta: { schemaVersion: "1.0" }
+          },
+          questionText: "Test Question",
+        },
+      ]);
+
+      const result = await CustomQuestion.findByPosition(
+        "test.ref",
+        mockContext,
+        100,
+        PinnedSectionTypeEnum.BASE,
+        200,
+        PinnedQuestionTypeEnum.BASE,
+        300
+      );
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        mockContext,
+        expectedSql,
+        ["100", PinnedSectionTypeEnum.BASE, "200", PinnedQuestionTypeEnum.BASE, "300"],
+        "test.ref"
+      );
+      expect(result).toBeInstanceOf(CustomQuestion);
+      expect(result.id).toBe(1);
+      expect(result.templateCustomizationId).toBe(100);
+      expect(result.sectionId).toBe(200);
+      expect(result.pinnedQuestionId).toBe(300);
+    });
+
+    it("should return null when no record is found", async () => {
+      jest.spyOn(MySqlModel, "query").mockResolvedValue([]);
+
+      const result = await CustomQuestion.findByPosition(
+        "test.ref",
+        mockContext,
+        100,
+        PinnedSectionTypeEnum.BASE,
+        200,
+        PinnedQuestionTypeEnum.BASE,
+        300
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should handle null pinnedQuestionType and pinnedQuestionId", async () => {
+      const mockQuery = jest.spyOn(MySqlModel, "query").mockResolvedValue([
+        {
+          id: 2,
+          templateCustomizationId: 100,
+          sectionType: PinnedSectionTypeEnum.BASE,
+          sectionId: 200,
+          pinnedQuestionType: null,
+          pinnedQuestionId: null,
+          json: {
+            type: "text",
+            attributes: { maxLength: 100 },
+            meta: { schemaVersion: "1.0" }
+          },
+          questionText: "First Question",
+        },
+      ]);
+
+      const result = await CustomQuestion.findByPosition(
+        "test.ref",
+        mockContext,
+        100,
+        PinnedSectionTypeEnum.BASE,
+        200,
+        null,
+        null
+      );
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        mockContext,
+        expectedSql,
+        ["100", PinnedSectionTypeEnum.BASE, "200", null, null],
+        "test.ref"
+      );
+      expect(result).toBeInstanceOf(CustomQuestion);
+      expect(result.id).toBe(2);
+      expect(result.pinnedQuestionType).toBeUndefined();
+      expect(result.pinnedQuestionId).toBeNull();
+    });
+
+    it("should return null when query result is not an array", async () => {
+      jest.spyOn(MySqlModel, "query").mockResolvedValue(null);
+
+      const result = await CustomQuestion.findByPosition(
+        "test.ref",
+        mockContext,
+        100,
+        PinnedSectionTypeEnum.BASE,
+        200,
+        null,
+        null
+      );
+
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/src/models/__tests__/TemplateCustomization.spec.ts
+++ b/src/models/__tests__/TemplateCustomization.spec.ts
@@ -4,8 +4,8 @@ import {
   TemplateCustomizationStatus,
   TemplateCustomizationOverview,
 } from '../TemplateCustomization';
-import { VersionedTemplate } from '../VersionedTemplate';
 import { VersionedTemplateCustomization } from '../VersionedTemplateCustomization';
+import * as publishHelpers from '../../services/templateCustomizationPublishHelpers';
 import { MyContext } from '../../context';
 
 describe('TemplateCustomization', () => {
@@ -129,154 +129,6 @@ describe('TemplateCustomization', () => {
     });
   });
 
-  describe('publish()', () => {
-    it('should add error when id is not set', async () => {
-      const customization = new TemplateCustomization({
-        affiliationId: 'affil-123',
-        templateId: 1,
-        currentVersionedTemplateId: 10,
-        status: 'DRAFT',
-        migrationStatus: 'OK',
-        errors: {}
-      });
-
-      const result = await customization.publish(mockContext);
-
-      expect(result.errors.general).toBe('Customization has never been saved');
-    });
-
-    it('should add error when validation fails', async () => {
-      const customization = new TemplateCustomization({
-        id: 1,
-        affiliationId: null,
-        templateId: 1,
-        currentVersionedTemplateId: 10,
-        status: 'DRAFT',
-        migrationStatus: 'OK',
-        errors: {}
-      });
-
-      const result = await customization.publish(mockContext);
-
-      expect(result.errors.affiliationId).toBe('Affiliation can\'t be blank');
-    });
-
-    it('should add error when the customization is already published', async () => {
-      const customization = new TemplateCustomization({
-        id: 1,
-        affiliationId: null,
-        templateId: 1,
-        currentVersionedTemplateId: 10,
-        status: 'PUBLISHED',
-        latestPublishedVersionId: 100,
-        latestPublishedDate: '2026-01-01 12:13:14',
-        migrationStatus: 'OK',
-        errors: {}
-      });
-
-      const result = await customization.publish(mockContext);
-
-      expect(result.errors.general).toBe('Customization is already published!');
-    });
-
-    it('should add error when drift is detected', async () => {
-      const customization = new TemplateCustomization({
-        id: 1,
-        affiliationId: 'affil-123',
-        templateId: 1,
-        currentVersionedTemplateId: 10,
-        latestPublishedVersionId: null,
-        status: 'DRAFT',
-        migrationStatus: 'OK',
-        errors: {}
-      });
-
-      const mockTemplate = { id: 15 } as undefined as VersionedTemplate;
-      jest.spyOn(VersionedTemplate, 'findActiveByTemplateId').mockResolvedValue(mockTemplate);
-
-      const result = await customization.publish(mockContext);
-
-      expect(result.errors.general).toBe('Unable to create version');
-    });
-
-    it('should add error when versioned customization creation fails', async () => {
-      const customization = new TemplateCustomization({
-        id: 1,
-        affiliationId: 'affil-123',
-        templateId: 1,
-        currentVersionedTemplateId: 10,
-        status: 'DRAFT',
-        migrationStatus: 'OK',
-        errors: {}
-      });
-
-      const mockTemplate = { id: 10 } as undefined as VersionedTemplate;
-      const createSpy = jest.spyOn(VersionedTemplateCustomization.prototype, 'create').mockResolvedValue(null);
-      jest.spyOn(VersionedTemplate, 'findActiveByTemplateId').mockResolvedValue(mockTemplate);
-
-      await customization.publish(mockContext);
-
-      expect(createSpy).toHaveBeenCalled();
-    });
-
-    it('should add error when update fails after successful version creation', async () => {
-      const customization = new TemplateCustomization({
-        id: 1,
-        affiliationId: 'affil-123',
-        templateId: 1,
-        currentVersionedTemplateId: 10,
-        status: 'DRAFT',
-        migrationStatus: 'OK',
-        errors: {}
-      });
-
-      const mockVersionedCustomization = {
-        id: 100,
-        created: new Date()
-      } as undefined as VersionedTemplateCustomization;
-      const mockTemplate = { id: 10 } as undefined as VersionedTemplate;
-      jest.spyOn(VersionedTemplate, 'findActiveByTemplateId').mockResolvedValue(mockTemplate);
-      jest.spyOn(VersionedTemplateCustomization.prototype, 'create').mockResolvedValue(new VersionedTemplateCustomization(mockVersionedCustomization));
-      customization.update = jest.fn().mockResolvedValue(null);
-
-      const result = await customization.publish(mockContext);
-
-      expect(result.errors.general).toBe('Unable to publish');
-    });
-
-    it('should successfully publish customization', async () => {
-      const customization = new TemplateCustomization({
-        id: 1,
-        affiliationId: 'affil-123',
-        templateId: 1,
-        currentVersionedTemplateId: 10,
-        status: 'DRAFT',
-        migrationStatus: 'OK',
-        errors: {}
-      });
-
-      const mockVersionedCustomization = {
-        id: 100,
-        created: new Date()
-      } as undefined as VersionedTemplateCustomization;
-      const mockUpdatedCustomization = new TemplateCustomization({
-        ...customization,
-        status: TemplateCustomizationStatus.PUBLISHED
-      }) as undefined as TemplateCustomization;
-      const mockTemplate = { id: 10 } as undefined as VersionedTemplate;
-      jest.spyOn(VersionedTemplate, 'findActiveByTemplateId').mockResolvedValue(mockTemplate);
-      jest.spyOn(VersionedTemplateCustomization.prototype, 'create').mockResolvedValue(new VersionedTemplateCustomization(mockVersionedCustomization));
-      customization.update = jest.fn().mockResolvedValue(mockUpdatedCustomization);
-
-      const result = await customization.publish(mockContext);
-
-      expect(customization.status).toBe(TemplateCustomizationStatus.PUBLISHED);
-      expect(customization.isDirty).toBe(false);
-      expect(customization.latestPublishedVersionId).toBe(100);
-      expect(result).toBeInstanceOf(TemplateCustomization);
-    });
-  });
-
   describe('unpublish()', () => {
     it('should add error when id is not set', async () => {
       const customization = new TemplateCustomization({
@@ -391,7 +243,7 @@ describe('TemplateCustomization', () => {
       const mockVersionedCustomization = {
         id: 100,
         active: true,
-        update: jest.fn().mockResolvedValue({id: 100})
+        update: jest.fn().mockResolvedValue({ id: 100 })
       } as undefined as VersionedTemplateCustomization;
       jest.spyOn(VersionedTemplateCustomization, 'findById').mockResolvedValue(mockVersionedCustomization);
       customization.update = jest.fn().mockResolvedValue(null);
@@ -420,7 +272,7 @@ describe('TemplateCustomization', () => {
       const mockVersionedCustomization = {
         id: 100,
         active: true,
-        update: jest.fn().mockResolvedValue({id: 100})
+        update: jest.fn().mockResolvedValue({ id: 100 })
       } as undefined as VersionedTemplateCustomization;
       jest.spyOn(VersionedTemplateCustomization, 'findById').mockResolvedValue(mockVersionedCustomization);
       customization.update = jest.fn().mockResolvedValue(mockUpdatedCustomization);
@@ -432,6 +284,147 @@ describe('TemplateCustomization', () => {
       expect(customization.latestPublishedVersionId).toBeUndefined();
       expect(customization.latestPublishedDate).toBeUndefined();
       expect(result).toBe(mockUpdatedCustomization);
+    });
+  });
+
+  describe('publish()', () => {
+    it('should add error when id is not set', async () => {
+      const customization = new TemplateCustomization({
+        affiliationId: 'affil-123',
+        templateId: 1,
+        currentVersionedTemplateId: 10,
+        status: 'DRAFT',
+        migrationStatus: 'OK',
+        errors: {}
+      });
+
+      const result = await customization.publish(mockContext);
+
+      expect(result.errors.general).toBe('Customization has never been saved');
+    });
+
+    it('should add error when already published and not dirty', async () => {
+      const customization = new TemplateCustomization({
+        id: 1,
+        affiliationId: 'affil-123',
+        templateId: 1,
+        currentVersionedTemplateId: 10,
+        status: 'PUBLISHED',
+        isDirty: false,
+        migrationStatus: 'OK',
+        errors: {}
+      });
+
+      const result = await customization.publish(mockContext);
+
+      expect(result.errors.general).toBe('Customization is already published!');
+    });
+
+    it('should add error when validation fails', async () => {
+      const customization = new TemplateCustomization({
+        id: 1,
+        affiliationId: null,
+        templateId: 1,
+        currentVersionedTemplateId: 10,
+        status: 'DRAFT',
+        migrationStatus: 'OK',
+        errors: {}
+      });
+
+      const result = await customization.publish(mockContext);
+
+      expect(result.errors.affiliationId).toBeDefined();
+    });
+
+    it('should return errors when version creation fails', async () => {
+      const customization = new TemplateCustomization({
+        id: 1,
+        affiliationId: 'affil-123',
+        templateId: 1,
+        currentVersionedTemplateId: 10,
+        status: 'DRAFT',
+        migrationStatus: 'OK',
+        errors: {}
+      });
+
+      const mockFailed = new VersionedTemplateCustomization({ errors: { general: 'DB error' } });
+      jest.spyOn(VersionedTemplateCustomization.prototype, 'create').mockResolvedValue(mockFailed);
+
+      const result = await customization.publish(mockContext);
+
+      expect(result.errors.general).toBe('DB error');
+    });
+
+    it('should rollback and return errors when snapshotting children fails', async () => {
+      const customization = new TemplateCustomization({
+        id: 1,
+        affiliationId: 'affil-123',
+        templateId: 1,
+        currentVersionedTemplateId: 10,
+        status: 'DRAFT',
+        migrationStatus: 'OK',
+        errors: {}
+      });
+
+      const mockCreated = new VersionedTemplateCustomization({ id: 99 });
+      jest.spyOn(VersionedTemplateCustomization.prototype, 'create').mockResolvedValue(mockCreated);
+      jest.spyOn(publishHelpers, 'snapshotCustomizationChildren').mockImplementation(
+        async (_ref, _ctx, custObj) => {
+          custObj.addError('general', 'snapshot failed');
+        }
+      );
+      const rollbackSpy = jest.spyOn(publishHelpers, 'rollbackPublishedSnapshot').mockResolvedValue();
+
+      const result = await customization.publish(mockContext);
+
+      expect(rollbackSpy).toHaveBeenCalledWith(mockContext, 99, customization.latestPublishedVersionId);
+      expect(result.errors.general).toBe('snapshot failed');
+    });
+
+    it('should add error when update fails after successful snapshot', async () => {
+      const customization = new TemplateCustomization({
+        id: 1,
+        affiliationId: 'affil-123',
+        templateId: 1,
+        currentVersionedTemplateId: 10,
+        status: 'DRAFT',
+        migrationStatus: 'OK',
+        errors: {}
+      });
+
+      const mockCreated = new VersionedTemplateCustomization({ id: 99 });
+      jest.spyOn(VersionedTemplateCustomization.prototype, 'create').mockResolvedValue(mockCreated);
+      jest.spyOn(publishHelpers, 'snapshotCustomizationChildren').mockResolvedValue();
+      customization.update = jest.fn().mockResolvedValue(null);
+
+      const result = await customization.publish(mockContext);
+
+      expect(result.errors.general).toBe('Unable to publish');
+    });
+
+    it('should successfully publish customization', async () => {
+      const customization = new TemplateCustomization({
+        id: 1,
+        affiliationId: 'affil-123',
+        templateId: 1,
+        currentVersionedTemplateId: 10,
+        status: 'DRAFT',
+        migrationStatus: 'OK',
+        errors: {}
+      });
+
+      const mockCreated = new VersionedTemplateCustomization({ id: 99, created: new Date('2025-01-01') });
+      jest.spyOn(VersionedTemplateCustomization.prototype, 'create').mockResolvedValue(mockCreated);
+      jest.spyOn(publishHelpers, 'snapshotCustomizationChildren').mockResolvedValue();
+      const mockUpdated = new TemplateCustomization({ ...customization, status: TemplateCustomizationStatus.PUBLISHED });
+      customization.update = jest.fn().mockResolvedValue(mockUpdated);
+
+      const result = await customization.publish(mockContext);
+
+      expect(customization.status).toBe(TemplateCustomizationStatus.PUBLISHED);
+      expect(customization.isDirty).toBe(false);
+      expect(customization.latestPublishedVersionId).toBe(99);
+      expect(result.errors).toEqual({});
     });
   });
 
@@ -461,7 +454,7 @@ describe('TemplateCustomization', () => {
         errors: {}
       });
 
-      const mockExisting = new TemplateCustomization({id: 100});
+      const mockExisting = new TemplateCustomization({ id: 100 });
       const findFirstSpy = jest.spyOn(TemplateCustomization, 'findByAffiliationAndTemplate').mockResolvedValue(mockExisting);
 
       const result = await customization.create(mockContext);
@@ -485,7 +478,7 @@ describe('TemplateCustomization', () => {
         errors: {}
       });
 
-      const mockCreated = new TemplateCustomization({id: 100, ...customization});
+      const mockCreated = new TemplateCustomization({ id: 100, ...customization });
       jest.spyOn(TemplateCustomization, 'findByAffiliationAndTemplate').mockResolvedValue(null);
       const findBySpy = jest.spyOn(TemplateCustomization, 'findById').mockResolvedValue(mockCreated);
       const insertSpy = jest.spyOn(TemplateCustomization, 'insert').mockResolvedValue(100);

--- a/src/models/__tests__/VersionedCustomQuestion.spec.ts
+++ b/src/models/__tests__/VersionedCustomQuestion.spec.ts
@@ -825,7 +825,13 @@ describe("VersionedCustomQuestion", () => {
 
       expect(mockQuery).toHaveBeenCalledWith(
         mockContext,
-        expect.stringContaining("SELECT * FROM versionedCustomQuestions"),
+        expect.stringContaining("SELECT vcq.* FROM versionedCustomQuestions as vcq"),
+        ["300"],
+        "test.ref"
+      );
+      expect(mockQuery).toHaveBeenCalledWith(
+        mockContext,
+        expect.stringContaining("vtc.active = 1"),
         ["300"],
         "test.ref"
       );
@@ -878,7 +884,13 @@ describe("VersionedCustomQuestion", () => {
 
       expect(mockQuery).toHaveBeenCalledWith(
         mockContext,
-        expect.stringContaining("SELECT * FROM versionedCustomQuestions"),
+        expect.stringContaining("SELECT vcq.* FROM versionedCustomQuestions as vcq"),
+        ["BASE", "300"],
+        "test.ref"
+      );
+      expect(mockQuery).toHaveBeenCalledWith(
+        mockContext,
+        expect.stringContaining("vtc.active = 1"),
         ["BASE", "300"],
         "test.ref"
       );

--- a/src/models/__tests__/VersionedQuestionCustomization.spec.ts
+++ b/src/models/__tests__/VersionedQuestionCustomization.spec.ts
@@ -510,4 +510,71 @@ describe("VersionedQuestionCustomization", () => {
       expect(result).toEqual([]);
     });
   });
+
+  describe("findActiveByTemplateAffiliationAndQuestion", () => {
+    const expectedSql = `SELECT vqc.* FROM versionedQuestionCustomizations AS vqc
+     JOIN versionedTemplateCustomizations AS vtc
+       ON vqc.versionedTemplateCustomizationId = vtc.id
+     WHERE vtc.active = 1
+       AND vtc.affiliationId = ?
+       AND vqc.versionedQuestionId = ?
+     LIMIT 1`;
+
+    it("should find the active VersionedQuestionCustomization by affiliation and question", async () => {
+      const mockQuery = jest.spyOn(MySqlModel, "query").mockResolvedValue([
+        {
+          id: 1,
+          versionedTemplateCustomizationId: 100,
+          questionCustomizationId: 200,
+          versionedQuestionId: 300,
+          guidanceText: "Test guidance",
+        },
+      ]);
+
+      const result = await VersionedQuestionCustomization.findActiveByTemplateAffiliationAndQuestion(
+        "test.ref",
+        mockContext,
+        "affil-123",
+        300
+      );
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        mockContext,
+        expectedSql,
+        ["affil-123", "300"],
+        "test.ref"
+      );
+      expect(result).toBeInstanceOf(VersionedQuestionCustomization);
+      expect(result.id).toBe(1);
+      expect(result.versionedTemplateCustomizationId).toBe(100);
+      expect(result.versionedQuestionId).toBe(300);
+      expect(result.guidanceText).toBe("Test guidance");
+    });
+
+    it("should return undefined when not found", async () => {
+      jest.spyOn(MySqlModel, "query").mockResolvedValue([]);
+
+      const result = await VersionedQuestionCustomization.findActiveByTemplateAffiliationAndQuestion(
+        "test.ref",
+        mockContext,
+        "affil-123",
+        300
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined when query result is not an array", async () => {
+      jest.spyOn(MySqlModel, "query").mockResolvedValue(null);
+
+      const result = await VersionedQuestionCustomization.findActiveByTemplateAffiliationAndQuestion(
+        "test.ref",
+        mockContext,
+        "affil-123",
+        300
+      );
+
+      expect(result).toBeUndefined();
+    });
+  });
 });

--- a/src/models/__tests__/VersionedSectionCustomization.spec.ts
+++ b/src/models/__tests__/VersionedSectionCustomization.spec.ts
@@ -499,4 +499,71 @@ describe("VersionedSectionCustomization", () => {
       expect(result).toEqual([]);
     });
   });
+
+  describe("findActiveByTemplateAffiliationAndSection", () => {
+    const expectedSql = `SELECT vsc.* FROM versionedSectionCustomizations AS vsc
+     JOIN versionedTemplateCustomizations AS vtc
+       ON vsc.versionedTemplateCustomizationId = vtc.id
+     WHERE vtc.active = 1
+       AND vtc.affiliationId = ?
+       AND vsc.versionedSectionId = ?
+     LIMIT 1`;
+
+    it("should find the active VersionedSectionCustomization by affiliation and section", async () => {
+      const mockQuery = jest.spyOn(MySqlModel, "query").mockResolvedValue([
+        {
+          id: 1,
+          versionedTemplateCustomizationId: 100,
+          sectionCustomizationId: 200,
+          versionedSectionId: 300,
+          guidance: "Test guidance",
+        },
+      ]);
+
+      const result = await VersionedSectionCustomization.findActiveByTemplateAffiliationAndSection(
+        "test.ref",
+        mockContext,
+        "affil-123",
+        300
+      );
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        mockContext,
+        expectedSql,
+        ["affil-123", "300"],
+        "test.ref"
+      );
+      expect(result).toBeInstanceOf(VersionedSectionCustomization);
+      expect(result.id).toBe(1);
+      expect(result.versionedTemplateCustomizationId).toBe(100);
+      expect(result.versionedSectionId).toBe(300);
+      expect(result.guidance).toBe("Test guidance");
+    });
+
+    it("should return undefined when not found", async () => {
+      jest.spyOn(MySqlModel, "query").mockResolvedValue([]);
+
+      const result = await VersionedSectionCustomization.findActiveByTemplateAffiliationAndSection(
+        "test.ref",
+        mockContext,
+        "affil-123",
+        300
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined when query result is not an array", async () => {
+      jest.spyOn(MySqlModel, "query").mockResolvedValue(null);
+
+      const result = await VersionedSectionCustomization.findActiveByTemplateAffiliationAndSection(
+        "test.ref",
+        mockContext,
+        "affil-123",
+        300
+      );
+
+      expect(result).toBeUndefined();
+    });
+  });
 });

--- a/src/models/__tests__/VersionedTemplate.spec.ts
+++ b/src/models/__tests__/VersionedTemplate.spec.ts
@@ -90,11 +90,15 @@ describe('VersionedTemplateSearchResult', () => {
             'SELECT vt.id, vt.templateId, vt.name, vt.description, vt.version, vt.visibility, vt.bestPractice, ' +
             'vt.modified, vt.modifiedById, TRIM(CONCAT(u.givenName, " ", u.surName)) as modifiedByName, ' +
             'a.id as ownerId, vt.ownerId as ownerURI, a.displayName as ownerDisplayName, ' +
-            'a.searchName as ownerSearchName, vtc.id as versionedTemplateCustomizationId ' +
+            'a.searchName as ownerSearchName, ' +
+            'vtc.id as versionedTemplateCustomizationId ' +
             'FROM versionedTemplates vt ' +
             'LEFT JOIN users u ON u.id = vt.modifiedById ' +
             'LEFT JOIN affiliations a ON a.uri = vt.ownerId ' +
-            'LEFT JOIN versionedTemplateCustomizations vtc ON vtc.currentVersionedTemplateId = vt.id AND vtc.affiliationId = ?';
+            'LEFT JOIN versionedTemplateCustomizations vtc ' +
+            'ON vtc.currentVersionedTemplateId = vt.id ' +
+            'AND vtc.affiliationId=? ' +
+            'AND vtc.active = 1';
       const vals = [affiliationId, TemplateVersionType.PUBLISHED, `%${term.toLowerCase()}%`, `%${term.toLowerCase()}%`];
       const whereFilters = ['vt.active = 1 AND vt.versionType = ?',
                             '(LOWER(vt.name) LIKE ? OR LOWER(a.searchName) LIKE ?)'];

--- a/src/resolvers/__tests__/guidance.spec.ts
+++ b/src/resolvers/__tests__/guidance.spec.ts
@@ -1,0 +1,543 @@
+import casual from "casual";
+
+// Mock the authenticatedResolver HOF before importing resolvers
+jest.mock('../../services/authService', () => ({
+  ...jest.requireActual('../../services/authService'),
+  authenticatedResolver: jest.fn((ref, level, resolver) => resolver),
+}));
+
+import { ApolloServer } from "@apollo/server";
+import { typeDefs } from "../../schema";
+import { resolvers } from '../../resolver';
+
+import { logger } from "../../logger";
+import { JWTAccessToken } from "../../services/tokenService";
+import { Guidance } from '../../models/Guidance';
+import { GuidanceGroup } from '../../models/GuidanceGroup';
+import { Plan } from '../../models/Plan';
+import { Project } from '../../models/Project';
+import { User, UserRole } from "../../models/User";
+import {
+  hasPermissionOnGuidanceGroup,
+  markGuidanceGroupAsDirty,
+  getGuidanceSourcesForPlan,
+} from '../../services/guidanceService';
+import { hasPermissionOnProject } from '../../services/projectService';
+import { buildContext, mockToken } from "../../__mocks__/context";
+
+jest.mock('../../context.ts');
+jest.mock('../../datasources/cache');
+
+jest.mock('../../models/Guidance');
+jest.mock('../../models/GuidanceGroup');
+jest.mock('../../models/Plan', () => ({
+  Plan: { findById: jest.fn() },
+}));
+jest.mock('../../models/Project', () => ({
+  Project: { findById: jest.fn() },
+}));
+jest.mock('../../services/guidanceService');
+jest.mock('../../services/projectService');
+
+let testServer: ApolloServer;
+let affiliationId: string;
+let adminToken: JWTAccessToken;
+let researcherToken: JWTAccessToken;
+let query: string;
+
+async function executeQuery(
+  query: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  variables: any,
+  token: JWTAccessToken
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<any> {
+  const context = buildContext(logger, token, null);
+  return await testServer.executeOperation(
+    { query, variables },
+    { contextValue: context },
+  );
+}
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+
+  testServer = new ApolloServer({ typeDefs, resolvers });
+
+  affiliationId = casual.url;
+
+  adminToken = await mockToken();
+  adminToken.affiliationId = affiliationId;
+  adminToken.role = UserRole.ADMIN;
+
+  researcherToken = await mockToken();
+  researcherToken.affiliationId = affiliationId;
+  researcherToken.role = UserRole.RESEARCHER;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('guidance resolvers', () => {
+  let user: User;
+
+  beforeEach(async () => {
+    user = new User({
+      id: casual.integer(1, 999),
+      givenName: casual.first_name,
+      surName: casual.last_name,
+      role: UserRole.ADMIN,
+      affiliationId,
+    });
+    (user.getEmail as jest.Mock) = jest.fn().mockResolvedValue(casual.email);
+  });
+
+  // ============================================================================
+  // Query: guidanceByGroup
+  // ============================================================================
+  describe('Query.guidanceByGroup', () => {
+    beforeEach(() => {
+      query = `
+        query guidanceByGroup($guidanceGroupId: Int!) {
+          guidanceByGroup(guidanceGroupId: $guidanceGroupId) {
+            id
+            guidanceGroupId
+            guidanceText
+            tagId
+          }
+        }
+      `;
+    });
+
+    it('should return guidance items when admin has permission', async () => {
+      const mockGuidanceItems = [
+        { id: 1, guidanceGroupId: 10, guidanceText: 'Test guidance 1', tagId: 1 },
+        { id: 2, guidanceGroupId: 10, guidanceText: 'Test guidance 2', tagId: 2 },
+      ];
+
+      (hasPermissionOnGuidanceGroup as jest.Mock).mockResolvedValue(true);
+      (Guidance.findByGuidanceGroupId as jest.Mock).mockResolvedValue(mockGuidanceItems);
+
+      const result = await executeQuery(query, { guidanceGroupId: 10 }, adminToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.guidanceByGroup).toHaveLength(2);
+      expect(result.body.singleResult.data.guidanceByGroup[0].id).toEqual(1);
+      expect(result.body.singleResult.data.guidanceByGroup[1].id).toEqual(2);
+      expect(Guidance.findByGuidanceGroupId).toHaveBeenCalledWith(
+        'guidanceByGroup resolver',
+        expect.any(Object),
+        10
+      );
+    });
+
+    it('should return guidance items for non-admin when guidance group is published', async () => {
+      const mockGuidanceItems = [
+        { id: 1, guidanceGroupId: 10, guidanceText: 'Published guidance', tagId: 1 },
+      ];
+      const mockGuidanceGroup = { id: 10, affiliationId, latestPublishedDate: '2025-01-01' };
+
+      (hasPermissionOnGuidanceGroup as jest.Mock).mockResolvedValue(false);
+      (GuidanceGroup.findById as jest.Mock).mockResolvedValue(mockGuidanceGroup);
+      (Guidance.findByGuidanceGroupId as jest.Mock).mockResolvedValue(mockGuidanceItems);
+
+      const result = await executeQuery(query, { guidanceGroupId: 10 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.guidanceByGroup).toHaveLength(1);
+      expect(result.body.singleResult.data.guidanceByGroup[0].guidanceText).toEqual('Published guidance');
+    });
+
+    it('should return Forbidden when non-admin and guidance group is not published', async () => {
+      const mockGuidanceGroup = {
+        id: 10,
+        affiliationId,
+        latestPublishedDate: null,
+        latestPublishedVersionId: null,
+      };
+
+      (hasPermissionOnGuidanceGroup as jest.Mock).mockResolvedValue(false);
+      (GuidanceGroup.findById as jest.Mock).mockResolvedValue(mockGuidanceGroup);
+
+      const result = await executeQuery(query, { guidanceGroupId: 10 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toEqual('Forbidden');
+    });
+  });
+
+  // ============================================================================
+  // Query: guidance
+  // ============================================================================
+  describe('Query.guidance', () => {
+    beforeEach(() => {
+      query = `
+        query guidance($guidanceId: Int!) {
+          guidance(guidanceId: $guidanceId) {
+            id
+            guidanceGroupId
+            guidanceText
+            tagId
+          }
+        }
+      `;
+    });
+
+    it('should return guidance when admin has permission', async () => {
+      const mockGuidanceItem = { id: 5, guidanceGroupId: 10, guidanceText: 'Test guidance', tagId: 1 };
+      const mockGuidanceGroup = { id: 10, affiliationId, latestPublishedDate: '2025-01-01' };
+
+      (Guidance.findById as jest.Mock).mockResolvedValue(mockGuidanceItem);
+      (hasPermissionOnGuidanceGroup as jest.Mock).mockResolvedValue(true);
+      (GuidanceGroup.findById as jest.Mock).mockResolvedValue(mockGuidanceGroup);
+
+      const result = await executeQuery(query, { guidanceId: 5 }, adminToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.guidance.id).toEqual(5);
+      expect(result.body.singleResult.data.guidance.guidanceText).toEqual('Test guidance');
+    });
+
+    it('should return NotFound when admin has permission but guidance does not exist', async () => {
+      (Guidance.findById as jest.Mock).mockResolvedValue(null);
+      (hasPermissionOnGuidanceGroup as jest.Mock).mockResolvedValue(true);
+      (GuidanceGroup.findById as jest.Mock).mockResolvedValue({ id: 10, affiliationId });
+
+      const result = await executeQuery(query, { guidanceId: 999 }, adminToken);
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toEqual('Guidance not found');
+    });
+
+    it('should return guidance for non-admin when guidance group is published', async () => {
+      const mockGuidanceItem = { id: 5, guidanceGroupId: 10, guidanceText: 'Public guidance', tagId: 1 };
+      const mockGuidanceGroup = { id: 10, affiliationId, latestPublishedDate: '2025-01-01' };
+
+      (Guidance.findById as jest.Mock).mockResolvedValue(mockGuidanceItem);
+      (hasPermissionOnGuidanceGroup as jest.Mock).mockResolvedValue(false);
+      (GuidanceGroup.findById as jest.Mock).mockResolvedValue(mockGuidanceGroup);
+
+      const result = await executeQuery(query, { guidanceId: 5 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.guidance.id).toEqual(5);
+    });
+
+    it('should return Forbidden for non-admin when guidance group is not published', async () => {
+      const mockGuidanceItem = { id: 5, guidanceGroupId: 10, guidanceText: 'Unpublished', tagId: 1 };
+      const mockGuidanceGroup = {
+        id: 10,
+        affiliationId,
+        latestPublishedDate: null,
+        latestPublishedVersionId: null,
+      };
+
+      (Guidance.findById as jest.Mock).mockResolvedValue(mockGuidanceItem);
+      (hasPermissionOnGuidanceGroup as jest.Mock).mockResolvedValue(false);
+      (GuidanceGroup.findById as jest.Mock).mockResolvedValue(mockGuidanceGroup);
+
+      const result = await executeQuery(query, { guidanceId: 5 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toEqual('Forbidden');
+    });
+  });
+
+  // ============================================================================
+  // Query: guidanceSourcesForPlan
+  // ============================================================================
+  describe('Query.guidanceSourcesForPlan', () => {
+    beforeEach(() => {
+      query = `
+        query guidanceSourcesForPlan($planId: Int!, $versionedSectionId: Int, $versionedQuestionId: Int) {
+          guidanceSourcesForPlan(planId: $planId, versionedSectionId: $versionedSectionId, versionedQuestionId: $versionedQuestionId) {
+            id
+            type
+            label
+            shortName
+            orgURI
+            hasGuidance
+            items {
+              id
+              title
+              guidanceText
+            }
+          }
+        }
+      `;
+    });
+
+    it('should return guidance sources when user has project permission', async () => {
+      const mockPlan = { id: 1, projectId: 100 };
+      const mockProject = { id: 100 };
+      const mockSources = [
+        {
+          id: 'source-1',
+          type: 'BEST_PRACTICE',
+          label: 'DMP Tool Best Practices',
+          shortName: 'DMP Tool',
+          orgURI: 'https://dmptool.org',
+          hasGuidance: true,
+          items: [{ id: 1, title: 'Data Storage', guidanceText: 'Store data securely' }],
+        },
+      ];
+
+      (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
+      (Project.findById as jest.Mock).mockResolvedValue(mockProject);
+      (hasPermissionOnProject as jest.Mock).mockResolvedValue(true);
+      (getGuidanceSourcesForPlan as jest.Mock).mockResolvedValue(mockSources);
+
+      const result = await executeQuery(
+        query,
+        { planId: 1, versionedSectionId: 5, versionedQuestionId: 10 },
+        researcherToken
+      );
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.guidanceSourcesForPlan).toHaveLength(1);
+      expect(result.body.singleResult.data.guidanceSourcesForPlan[0].id).toEqual('source-1');
+      expect(result.body.singleResult.data.guidanceSourcesForPlan[0].type).toEqual('BEST_PRACTICE');
+      expect(result.body.singleResult.data.guidanceSourcesForPlan[0].items[0].guidanceText).toEqual('Store data securely');
+      expect(getGuidanceSourcesForPlan).toHaveBeenCalledWith(
+        expect.any(Object),
+        1,
+        5,
+        10,
+        undefined
+      );
+    });
+
+    it('should return NotFound when plan does not exist', async () => {
+      (Plan.findById as jest.Mock).mockResolvedValue(null);
+
+      const result = await executeQuery(query, { planId: 999 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toEqual('Plan with id 999 not found');
+    });
+
+    it('should return Forbidden when user does not have permission on project', async () => {
+      const mockPlan = { id: 1, projectId: 100 };
+      const mockProject = { id: 100 };
+
+      (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
+      (Project.findById as jest.Mock).mockResolvedValue(mockProject);
+      (hasPermissionOnProject as jest.Mock).mockResolvedValue(false);
+
+      const result = await executeQuery(query, { planId: 1 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toEqual('Forbidden');
+    });
+  });
+
+  // ============================================================================
+  // Mutation: addGuidance
+  // ============================================================================
+  describe('Mutation.addGuidance', () => {
+    beforeEach(() => {
+      query = `
+        mutation addGuidance($input: AddGuidanceInput!) {
+          addGuidance(input: $input) {
+            id
+            guidanceGroupId
+            guidanceText
+            tagId
+            errors {
+              general
+            }
+          }
+        }
+      `;
+    });
+
+    it('should create guidance when admin has permission', async () => {
+      const mockCreated = { id: 99, guidanceGroupId: 10, guidanceText: 'New guidance', tagId: 2 };
+
+      (hasPermissionOnGuidanceGroup as jest.Mock).mockResolvedValue(true);
+      (Guidance.prototype.create as jest.Mock).mockResolvedValue({ id: 99 });
+      (Guidance.findById as jest.Mock).mockResolvedValue(mockCreated);
+      (markGuidanceGroupAsDirty as jest.Mock).mockResolvedValue(undefined);
+
+      const vars = { input: { guidanceGroupId: 10, guidanceText: 'New guidance', tagId: 2 } };
+      const result = await executeQuery(query, vars, adminToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.addGuidance.id).toEqual(99);
+      expect(result.body.singleResult.data.addGuidance.guidanceText).toEqual('New guidance');
+      expect(markGuidanceGroupAsDirty).toHaveBeenCalledWith(expect.any(Object), 10);
+    });
+
+    it('should return Forbidden when admin does not have permission', async () => {
+      (hasPermissionOnGuidanceGroup as jest.Mock).mockResolvedValue(false);
+
+      const vars = { input: { guidanceGroupId: 10, guidanceText: 'New guidance', tagId: 2 } };
+      const result = await executeQuery(query, vars, adminToken);
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toEqual('Forbidden');
+    });
+
+    it('should return error when guidance creation fails', async () => {
+      // Use a mockImplementation so the Guidance instance has a proper errors object
+      // and addError correctly mutates it (auto-mock doesn't run the real constructor).
+      const instanceErrors: Record<string, string> = {};
+      const mockInstance = {
+        guidanceGroupId: 10,
+        guidanceText: 'New guidance',
+        tagId: 2,
+        errors: instanceErrors,
+        addError: jest.fn().mockImplementation((field: string, msg: string) => {
+          instanceErrors[field] = msg;
+        }),
+        create: jest.fn().mockResolvedValue({ id: null, errors: {} }),
+      };
+
+      (hasPermissionOnGuidanceGroup as jest.Mock).mockResolvedValue(true);
+      (Guidance as unknown as jest.Mock).mockImplementationOnce(() => mockInstance);
+
+      const vars = { input: { guidanceGroupId: 10, guidanceText: 'New guidance', tagId: 2 } };
+      const result = await executeQuery(query, vars, adminToken);
+
+      expect(result.body.singleResult.data.addGuidance.errors.general).toEqual('Unable to create the guidance');
+    });
+  });
+
+  // ============================================================================
+  // Mutation: updateGuidance
+  // ============================================================================
+  describe('Mutation.updateGuidance', () => {
+    beforeEach(() => {
+      query = `
+        mutation updateGuidance($input: UpdateGuidanceInput!) {
+          updateGuidance(input: $input) {
+            id
+            guidanceGroupId
+            guidanceText
+            tagId
+            errors {
+              general
+            }
+          }
+        }
+      `;
+    });
+
+    it('should update guidance when admin has permission', async () => {
+      const mockGuidance = {
+        id: 5,
+        guidanceGroupId: 10,
+        guidanceText: 'Old guidance',
+        tagId: 1,
+        errors: {},
+        hasErrors: () => false,
+        update: jest.fn().mockResolvedValue({ id: 5 }),
+      };
+      const mockUpdated = { id: 5, guidanceGroupId: 10, guidanceText: 'Updated guidance', tagId: 2 };
+
+      (Guidance.findById as jest.Mock)
+        .mockResolvedValueOnce(mockGuidance)
+        .mockResolvedValueOnce(mockUpdated);
+      (hasPermissionOnGuidanceGroup as jest.Mock).mockResolvedValue(true);
+      (markGuidanceGroupAsDirty as jest.Mock).mockResolvedValue(undefined);
+
+      const vars = { input: { guidanceId: 5, guidanceText: 'Updated guidance', tagId: 2 } };
+      const result = await executeQuery(query, vars, adminToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.updateGuidance.id).toEqual(5);
+      expect(result.body.singleResult.data.updateGuidance.guidanceText).toEqual('Updated guidance');
+      expect(markGuidanceGroupAsDirty).toHaveBeenCalledWith(expect.any(Object), 10);
+    });
+
+    it('should return NotFound when guidance does not exist', async () => {
+      (Guidance.findById as jest.Mock).mockResolvedValue(null);
+      (hasPermissionOnGuidanceGroup as jest.Mock).mockResolvedValue(true);
+
+      const vars = { input: { guidanceId: 999, guidanceText: 'Updated', tagId: 1 } };
+      const result = await executeQuery(query, vars, adminToken);
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toEqual('Guidance not found');
+    });
+
+    it('should return Forbidden when admin does not have permission', async () => {
+      const mockGuidance = { id: 5, guidanceGroupId: 10 };
+
+      (Guidance.findById as jest.Mock).mockResolvedValue(mockGuidance);
+      (hasPermissionOnGuidanceGroup as jest.Mock).mockResolvedValue(false);
+
+      const vars = { input: { guidanceId: 5, guidanceText: 'Updated', tagId: 1 } };
+      const result = await executeQuery(query, vars, adminToken);
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toEqual('Forbidden');
+    });
+  });
+
+  // ============================================================================
+  // Mutation: removeGuidance
+  // ============================================================================
+  describe('Mutation.removeGuidance', () => {
+    beforeEach(() => {
+      query = `
+        mutation removeGuidance($guidanceId: Int!) {
+          removeGuidance(guidanceId: $guidanceId) {
+            id
+            guidanceGroupId
+            guidanceText
+            errors {
+              general
+            }
+          }
+        }
+      `;
+    });
+
+    it('should delete guidance when admin has permission', async () => {
+      const mockGuidance = {
+        id: 5,
+        guidanceGroupId: 10,
+        guidanceText: 'To be deleted',
+        errors: {},
+        hasErrors: () => false,
+        delete: jest.fn(),
+      };
+      const mockDeleted = { id: 5, guidanceGroupId: 10, guidanceText: 'To be deleted' };
+
+      (Guidance.findById as jest.Mock).mockResolvedValue(mockGuidance);
+      (hasPermissionOnGuidanceGroup as jest.Mock).mockResolvedValue(true);
+      mockGuidance.delete.mockResolvedValue(mockDeleted);
+      (markGuidanceGroupAsDirty as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await executeQuery(query, { guidanceId: 5 }, adminToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.removeGuidance.id).toEqual(5);
+      expect(markGuidanceGroupAsDirty).toHaveBeenCalledWith(expect.any(Object), 10);
+    });
+
+    it('should return NotFound when guidance does not exist', async () => {
+      (Guidance.findById as jest.Mock).mockResolvedValue(null);
+      (hasPermissionOnGuidanceGroup as jest.Mock).mockResolvedValue(true);
+
+      const result = await executeQuery(query, { guidanceId: 999 }, adminToken);
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toEqual('Guidance not found');
+    });
+
+    it('should return Forbidden when admin does not have permission', async () => {
+      const mockGuidance = { id: 5, guidanceGroupId: 10 };
+
+      (Guidance.findById as jest.Mock).mockResolvedValue(mockGuidance);
+      (hasPermissionOnGuidanceGroup as jest.Mock).mockResolvedValue(false);
+
+      const result = await executeQuery(query, { guidanceId: 5 }, adminToken);
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toEqual('Forbidden');
+    });
+  });
+});

--- a/src/resolvers/__tests__/questionCustomization.spec.ts
+++ b/src/resolvers/__tests__/questionCustomization.spec.ts
@@ -15,7 +15,7 @@ import { resolvers } from '../../resolver';
 import { logger } from "../../logger";
 import { JWTAccessToken } from "../../services/tokenService";
 import { QuestionCustomization } from '../../models/QuestionCustomization';
-import { CustomQuestion } from '../../models/CustomQuestion';
+import { CustomQuestion, PinnedQuestionTypeEnum } from '../../models/CustomQuestion';
 import { VersionedQuestion } from '../../models/VersionedQuestion';
 import { PinnedSectionTypeEnum } from '../../models/CustomSection';
 import { User, UserRole } from "../../models/User";
@@ -810,13 +810,14 @@ describe('questionCustomization resolver', () => {
       `;
     });
 
-    it('should move custom section successfully', async () => {
+    it('should move custom question successfully when no occupant exists', async () => {
       const input = {
         customQuestionId: 1,
         sectionType: 'BASE',
         sectionId: 2,
         pinnedQuestionType: 'BASE',
-        pinnedQuestionId: 10
+        pinnedQuestionId: 10,
+        direction: 'DOWN'
       };
       const mockCustomization = {
         id: 1,
@@ -832,26 +833,30 @@ describe('questionCustomization resolver', () => {
       const mockMoved = {
         ...mockCustomization,
         pinnedQuestionType: PinnedSectionTypeEnum.BASE,
-        pinnedQuestionId: 10
+        pinnedQuestionId: 10,
+        hasErrors: jest.fn().mockReturnValue(false)
       };
 
       (CustomQuestion.findById as jest.Mock).mockResolvedValue(mockCustomization);
       (getValidatedCustomization as jest.Mock).mockResolvedValue(mockParent);
+      (CustomQuestion.findByPosition as jest.Mock).mockResolvedValue(null);
       mockCustomization.update.mockResolvedValue(mockMoved);
 
       const result = await executeQuery(query, { input }, adminToken);
 
       expect(result.body.singleResult.data.moveCustomQuestion.id).toEqual(1);
+      expect(CustomQuestion.findByPosition).toHaveBeenCalledTimes(1);
       expect(markTemplateCustomizationAsDirty).toHaveBeenCalled();
     });
 
-    it('should throw NotFoundError when custom section is not found', async () => {
+    it('should throw NotFoundError when custom question is not found', async () => {
       const input = {
         customQuestionId: 999,
         sectionType: 'BASE',
         sectionId: 2,
         pinnedQuestionType: 'BASE',
-        pinnedQuestionId: 10
+        pinnedQuestionId: 10,
+        direction: 'DOWN'
       };
 
       (CustomQuestion.findById as jest.Mock).mockResolvedValue(null);
@@ -863,17 +868,20 @@ describe('questionCustomization resolver', () => {
       expect(result.body.singleResult.errors[0].message).toEqual('Not Found');
     });
 
-    it('should handle null QuestionType and QuestionId', async () => {
+    it('should handle null pinnedQuestionType and pinnedQuestionId', async () => {
       const input = {
         customQuestionId: 1,
         sectionType: 'BASE',
         sectionId: 2,
         pinnedQuestionType: null,
-        pinnedQuestionId: null
+        pinnedQuestionId: null,
+        direction: 'DOWN'
       };
       const mockCustomization = {
         id: 1,
         templateCustomizationId: 10,
+        pinnedQuestionType: null,
+        pinnedQuestionId: null,
         hasErrors: jest.fn().mockReturnValue(false),
         update: jest.fn()
       } as undefined as CustomQuestion;
@@ -882,18 +890,217 @@ describe('questionCustomization resolver', () => {
         ...mockCustomization,
         sectionType: PinnedSectionTypeEnum.BASE,
         sectionId: 2,
-        pinnedSectionType: null,
-        pinnedSectionId: null
+        pinnedQuestionType: null,
+        pinnedQuestionId: null,
+        hasErrors: jest.fn().mockReturnValue(false)
       } as undefined as CustomQuestion;
 
       (CustomQuestion.findById as jest.Mock).mockResolvedValue(mockCustomization);
       (getValidatedCustomization as jest.Mock).mockResolvedValue(mockParent);
+      (CustomQuestion.findByPosition as jest.Mock).mockResolvedValue(null);
       jest.spyOn(mockCustomization, 'update').mockResolvedValue(mockMoved);
 
       await executeQuery(query, { input }, adminToken);
 
       expect(mockCustomization.pinnedQuestionType).toBeNull();
       expect(mockCustomization.pinnedQuestionId).toBeNull();
+    });
+
+    it('should swap positions with occupant when moving DOWN', async () => {
+      const input = {
+        customQuestionId: 1,
+        sectionType: 'BASE',
+        sectionId: 2,
+        pinnedQuestionType: 'BASE',
+        pinnedQuestionId: 5,
+        direction: 'DOWN'
+      };
+      const mockCustomization = {
+        id: 1,
+        templateCustomizationId: 10,
+        sectionType: PinnedSectionTypeEnum.BASE,
+        sectionId: 2,
+        pinnedQuestionType: null,
+        pinnedQuestionId: null,
+        hasErrors: jest.fn().mockReturnValue(false),
+        update: jest.fn()
+      };
+      const mockOccupant = {
+        id: 2,
+        templateCustomizationId: 10,
+        sectionType: PinnedSectionTypeEnum.BASE,
+        sectionId: 2,
+        pinnedQuestionType: PinnedQuestionTypeEnum.BASE,
+        pinnedQuestionId: 5,
+        hasErrors: jest.fn().mockReturnValue(false),
+        update: jest.fn()
+      };
+      const mockParent = { id: 10, isDirty: false };
+      const mockTempMoved = {
+        ...mockCustomization,
+        hasErrors: jest.fn().mockReturnValue(false)
+      };
+      const mockMoved = {
+        ...mockCustomization,
+        pinnedQuestionType: PinnedSectionTypeEnum.BASE,
+        pinnedQuestionId: 5,
+        hasErrors: jest.fn().mockReturnValue(false)
+      };
+      const mockSwapped = {
+        ...mockOccupant,
+        hasErrors: jest.fn().mockReturnValue(false)
+      };
+
+      (CustomQuestion.findById as jest.Mock).mockResolvedValue(mockCustomization);
+      (getValidatedCustomization as jest.Mock).mockResolvedValue(mockParent);
+      (CustomQuestion.findByPosition as jest.Mock).mockResolvedValue(mockOccupant);
+      mockCustomization.update
+        .mockResolvedValueOnce(mockTempMoved)
+        .mockResolvedValueOnce(mockMoved);
+      mockOccupant.update.mockResolvedValue(mockSwapped);
+
+      const result = await executeQuery(query, { input }, adminToken);
+
+      expect(result.body.singleResult.data.moveCustomQuestion.id).toEqual(1);
+      expect(mockCustomization.update).toHaveBeenCalledTimes(2);
+      expect(mockOccupant.update).toHaveBeenCalledTimes(1);
+      expect(mockOccupant.pinnedQuestionType).toEqual(PinnedQuestionTypeEnum.CUSTOM);
+      expect(mockOccupant.pinnedQuestionId).toEqual(1);
+      expect(markTemplateCustomizationAsDirty).toHaveBeenCalled();
+    });
+
+    it('should swap positions with occupant when moving UP', async () => {
+      const originalSectionType = PinnedSectionTypeEnum.BASE;
+      const originalSectionId = 2;
+      const originalPinnedQuestionType = PinnedQuestionTypeEnum.BASE;
+      const originalPinnedQuestionId = 5;
+      const input = {
+        customQuestionId: 1,
+        sectionType: 'BASE',
+        sectionId: 2,
+        pinnedQuestionType: null,
+        pinnedQuestionId: null,
+        direction: 'UP'
+      };
+      const mockCustomization = {
+        id: 1,
+        templateCustomizationId: 10,
+        sectionType: originalSectionType,
+        sectionId: originalSectionId,
+        pinnedQuestionType: originalPinnedQuestionType,
+        pinnedQuestionId: originalPinnedQuestionId,
+        hasErrors: jest.fn().mockReturnValue(false),
+        update: jest.fn()
+      };
+      const mockOccupant = {
+        id: 2,
+        sectionType: null,
+        sectionId: null,
+        pinnedQuestionType: null,
+        pinnedQuestionId: null,
+        hasErrors: jest.fn().mockReturnValue(false),
+        update: jest.fn()
+      };
+      const mockParent = { id: 10, isDirty: false };
+      const mockTempMoved = {
+        ...mockCustomization,
+        hasErrors: jest.fn().mockReturnValue(false)
+      };
+      const mockMoved = {
+        ...mockCustomization,
+        pinnedQuestionType: null,
+        pinnedQuestionId: null,
+        hasErrors: jest.fn().mockReturnValue(false)
+      };
+      const mockSwapped = {
+        ...mockOccupant,
+        hasErrors: jest.fn().mockReturnValue(false)
+      };
+
+      (CustomQuestion.findById as jest.Mock).mockResolvedValue(mockCustomization);
+      (getValidatedCustomization as jest.Mock).mockResolvedValue(mockParent);
+      (CustomQuestion.findByPosition as jest.Mock).mockResolvedValue(mockOccupant);
+      mockCustomization.update
+        .mockResolvedValueOnce(mockTempMoved)
+        .mockResolvedValueOnce(mockMoved);
+      mockOccupant.update.mockResolvedValue(mockSwapped);
+
+      const result = await executeQuery(query, { input }, adminToken);
+
+      expect(result.body.singleResult.data.moveCustomQuestion.id).toEqual(1);
+      expect(mockOccupant.sectionType).toEqual(originalSectionType);
+      expect(mockOccupant.sectionId).toEqual(originalSectionId);
+      expect(mockOccupant.pinnedQuestionType).toEqual(originalPinnedQuestionType);
+      expect(mockOccupant.pinnedQuestionId).toEqual(originalPinnedQuestionId);
+      expect(markTemplateCustomizationAsDirty).toHaveBeenCalled();
+    });
+
+    it('should re-anchor tail question when moving UP with no occupant', async () => {
+      const originalSectionType = PinnedSectionTypeEnum.BASE;
+      const originalSectionId = 2;
+      const originalPinnedQuestionType = PinnedQuestionTypeEnum.CUSTOM;
+      const originalPinnedQuestionId = 3;
+      const input = {
+        customQuestionId: 1,
+        sectionType: 'BASE',
+        sectionId: 2,
+        pinnedQuestionType: null,
+        pinnedQuestionId: null,
+        direction: 'UP'
+      };
+      const mockCustomization = {
+        id: 1,
+        templateCustomizationId: 10,
+        sectionType: originalSectionType,
+        sectionId: originalSectionId,
+        pinnedQuestionType: originalPinnedQuestionType,
+        pinnedQuestionId: originalPinnedQuestionId,
+        hasErrors: jest.fn().mockReturnValue(false),
+        update: jest.fn()
+      };
+      const mockTailQuestion = {
+        id: 3,
+        sectionType: null,
+        sectionId: null,
+        pinnedQuestionType: null,
+        pinnedQuestionId: null,
+        hasErrors: jest.fn().mockReturnValue(false),
+        update: jest.fn()
+      };
+      const mockParent = { id: 10, isDirty: false };
+      const mockTempMoved = {
+        ...mockCustomization,
+        hasErrors: jest.fn().mockReturnValue(false)
+      };
+      const mockMoved = {
+        ...mockCustomization,
+        hasErrors: jest.fn().mockReturnValue(false)
+      };
+      const mockReanchored = {
+        ...mockTailQuestion,
+        hasErrors: jest.fn().mockReturnValue(false)
+      };
+
+      (CustomQuestion.findById as jest.Mock).mockResolvedValue(mockCustomization);
+      (getValidatedCustomization as jest.Mock).mockResolvedValue(mockParent);
+      (CustomQuestion.findByPosition as jest.Mock)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(mockTailQuestion);
+      mockCustomization.update
+        .mockResolvedValueOnce(mockTempMoved)
+        .mockResolvedValueOnce(mockMoved);
+      mockTailQuestion.update.mockResolvedValue(mockReanchored);
+
+      const result = await executeQuery(query, { input }, adminToken);
+
+      expect(result.body.singleResult.data.moveCustomQuestion.id).toEqual(1);
+      expect(CustomQuestion.findByPosition).toHaveBeenCalledTimes(2);
+      expect(mockTailQuestion.update).toHaveBeenCalledTimes(1);
+      expect(mockTailQuestion.sectionType).toEqual(originalSectionType);
+      expect(mockTailQuestion.sectionId).toEqual(originalSectionId);
+      expect(mockTailQuestion.pinnedQuestionType).toEqual(originalPinnedQuestionType);
+      expect(mockTailQuestion.pinnedQuestionId).toEqual(originalPinnedQuestionId);
+      expect(markTemplateCustomizationAsDirty).toHaveBeenCalled();
     });
   });
 });

--- a/src/resolvers/guidance.ts
+++ b/src/resolvers/guidance.ts
@@ -95,7 +95,7 @@ export const resolvers: Resolvers = {
     // ============================================================================
     guidanceSourcesForPlan: async (
       _,
-      { planId, versionedSectionId, versionedQuestionId },
+      { planId, versionedSectionId, versionedQuestionId, customSectionId },
       context: MyContext
     ): Promise<GuidanceSource[]> => {
       const reference = 'guidanceSourcesForPlan resolver';
@@ -113,7 +113,8 @@ export const resolvers: Resolvers = {
               context,
               planId,
               versionedSectionId,
-              versionedQuestionId
+              versionedQuestionId,
+              customSectionId
             );
 
             return sources;

--- a/src/resolvers/guidance.ts
+++ b/src/resolvers/guidance.ts
@@ -291,10 +291,10 @@ export const resolvers: Resolvers = {
             });
 
             const created = await planGuidanceAffiliation.create(context);
-            if (created && created.hasErrors()) {
+            if (created && !created.hasErrors()) {
               return created; // Successfully created
             } else {
-              if (!created.errors['general']) {
+              if (!created?.errors?.general) {
                 created.addError("general", "Unable to add plan guidance affiliation");
               }
               return created;

--- a/src/resolvers/questionCustomization.ts
+++ b/src/resolvers/questionCustomization.ts
@@ -455,8 +455,8 @@ export const resolvers: Resolvers = {
       ): Promise<CustomQuestion> => {
         const ref = 'moveCustomQuestion resolver';
         const { customQuestionId, sectionType, sectionId, pinnedQuestionType, pinnedQuestionId, direction } = input;
-
         const customization: CustomQuestion = await CustomQuestion.findById(ref, context, customQuestionId);
+
         if (!customization) throw NotFoundError();
 
         const parent: TemplateCustomization = await getValidatedCustomization(
@@ -486,7 +486,7 @@ export const resolvers: Resolvers = {
         const originalPinnedQuestionId = customization.pinnedQuestionId;
 
         if (occupant && occupant.id !== customQuestionId) {
-          // Step 1: Temporarily free A's slot
+          // Step 1: Temporarily free A's slot to a temporary position that won't conflict with any existing question
           customization.pinnedQuestionType = null;
           customization.pinnedQuestionId = null;
           const tempMoved = await customization.update(context);
@@ -494,7 +494,8 @@ export const resolvers: Resolvers = {
             throw new Error(`Failed to temporarily move question: ${JSON.stringify(tempMoved.errors)}`);
           }
 
-          // Step 2: Place occupant depending on direction
+          // Step 2: Place occupant depending on direction (UP or DOWN). When A moves down to sit where B was, 
+          // then B gets re-pinned from BASE to A. When A moves up to sit where B was, then B gets pinned from BASE to A's original position.
           if (direction === 'DOWN') {
             occupant.sectionType = newSectionType;
             occupant.sectionId = sectionId;

--- a/src/resolvers/questionCustomization.ts
+++ b/src/resolvers/questionCustomization.ts
@@ -453,32 +453,101 @@ export const resolvers: Resolvers = {
         { input }: { input: MoveCustomQuestionInput },
         context: MyContext
       ): Promise<CustomQuestion> => {
+        console.log("***moveCustomQuestion input", { input }); // --- IGNORE ---
         const ref = 'moveCustomQuestion resolver';
-        const { customQuestionId, sectionType, sectionId, pinnedQuestionType, pinnedQuestionId } = input;
+        const { customQuestionId, sectionType, sectionId, pinnedQuestionType, pinnedQuestionId, direction } = input;
 
-        const customization: CustomQuestion = await CustomQuestion.findById(
-          ref,
-          context,
-          customQuestionId
-        );
+        const customization: CustomQuestion = await CustomQuestion.findById(ref, context, customQuestionId);
         if (!customization) throw NotFoundError();
 
-        // Fetch the parent template customization and verify the user has access
         const parent: TemplateCustomization = await getValidatedCustomization(
-          ref,
-          context,
-          customization.templateCustomizationId
+          ref, context, customization.templateCustomizationId
         );
 
         const newPinType: PinnedQuestionTypeEnum = PinnedQuestionTypeEnum[pinnedQuestionType];
-        // Section info cannot be null, but pinned question info can
-        customization.sectionType = PinnedSectionTypeEnum[sectionType];
-        customization.sectionId = sectionId;
-        customization.pinnedQuestionType = isNullOrUndefined(newPinType) ? null : newPinType;
-        customization.pinnedQuestionId = isNullOrUndefined(pinnedQuestionId) ? null : pinnedQuestionId;
-        const moved: CustomQuestion = await customization.update(context);
+        const newSectionType = PinnedSectionTypeEnum[sectionType];
+        const newPinnedQuestionType = isNullOrUndefined(newPinType) ? null : newPinType;
+        const newPinnedQuestionId = isNullOrUndefined(pinnedQuestionId) ? null : pinnedQuestionId;
 
-        // If it was successfully moved, update the parent's isDirty flag
+        // Check if another question already occupies this exact position
+        const occupant = await CustomQuestion.findByPosition(
+          ref,
+          context,
+          parent.id,
+          newSectionType,
+          sectionId,
+          newPinnedQuestionType,
+          newPinnedQuestionId
+        );
+
+        // Save customization's original position before any changes
+        const originalSectionType = customization.sectionType;
+        const originalSectionId = customization.sectionId;
+        const originalPinnedQuestionType = customization.pinnedQuestionType;
+        const originalPinnedQuestionId = customization.pinnedQuestionId;
+
+        if (occupant && occupant.id !== customQuestionId) {
+          // Step 1: Temporarily free A's slot
+          customization.pinnedQuestionType = null;
+          customization.pinnedQuestionId = null;
+          const tempMoved = await customization.update(context);
+          if (tempMoved.hasErrors()) {
+            throw new Error(`Failed to temporarily move question: ${JSON.stringify(tempMoved.errors)}`);
+          }
+
+          // Step 2: Place occupant depending on direction
+          if (direction === 'DOWN') {
+            occupant.sectionType = newSectionType;
+            occupant.sectionId = sectionId;
+            occupant.pinnedQuestionType = PinnedQuestionTypeEnum.CUSTOM;
+            occupant.pinnedQuestionId = customQuestionId;
+          } else {
+            occupant.sectionType = originalSectionType;
+            occupant.sectionId = originalSectionId;
+            occupant.pinnedQuestionType = originalPinnedQuestionType;
+            occupant.pinnedQuestionId = originalPinnedQuestionId;
+          }
+
+          const swapped = await occupant.update(context);
+          if (swapped.hasErrors()) {
+            throw new Error(`Failed to swap occupant: ${JSON.stringify(swapped.errors)}`);
+          }
+        } else if (direction === 'UP') {
+          // No occupant at target, but something may be chained after A
+          const tailQuestion = await CustomQuestion.findByPosition(
+            ref, context, parent.id,
+            originalSectionType, originalSectionId,
+            PinnedQuestionTypeEnum.CUSTOM, customQuestionId
+          );
+
+          if (tailQuestion) {
+            // ✅ Must temporarily free A's current slot FIRST before B can move into it
+            customization.pinnedQuestionType = null;
+            customization.pinnedQuestionId = null;
+            const tempMoved = await customization.update(context);
+            if (tempMoved.hasErrors()) {
+              throw new Error(`Failed to temporarily move question: ${JSON.stringify(tempMoved.errors)}`);
+            }
+
+            // Now B can safely move to A's vacated slot
+            tailQuestion.sectionType = originalSectionType;
+            tailQuestion.sectionId = originalSectionId;
+            tailQuestion.pinnedQuestionType = originalPinnedQuestionType;
+            tailQuestion.pinnedQuestionId = originalPinnedQuestionId;
+            const reanch = await tailQuestion.update(context);
+            if (reanch.hasErrors()) {
+              throw new Error(`Failed to re-anchor tail question: ${JSON.stringify(reanch.errors)}`);
+            }
+          }
+        }
+
+        // Step 3: Move A into its final target position
+        customization.sectionType = newSectionType;
+        customization.sectionId = sectionId;
+        customization.pinnedQuestionType = newPinnedQuestionType;
+        customization.pinnedQuestionId = newPinnedQuestionId;
+        const moved = await customization.update(context);
+
         if (moved && !moved.hasErrors() && !parent.isDirty) {
           await markTemplateCustomizationAsDirty(ref, context, parent.id, moved);
         }

--- a/src/resolvers/questionCustomization.ts
+++ b/src/resolvers/questionCustomization.ts
@@ -453,7 +453,6 @@ export const resolvers: Resolvers = {
         { input }: { input: MoveCustomQuestionInput },
         context: MyContext
       ): Promise<CustomQuestion> => {
-        console.log("***moveCustomQuestion input", { input }); // --- IGNORE ---
         const ref = 'moveCustomQuestion resolver';
         const { customQuestionId, sectionType, sectionId, pinnedQuestionType, pinnedQuestionId, direction } = input;
 
@@ -521,7 +520,7 @@ export const resolvers: Resolvers = {
           );
 
           if (tailQuestion) {
-            // ✅ Must temporarily free A's current slot FIRST before B can move into it
+            // Must temporarily free A's current slot FIRST before B can move into it
             customization.pinnedQuestionType = null;
             customization.pinnedQuestionId = null;
             const tempMoved = await customization.update(context);

--- a/src/resolvers/versionedQuestion.ts
+++ b/src/resolvers/versionedQuestion.ts
@@ -102,9 +102,11 @@ export const resolvers: Resolvers = {
 
           return ordered;
         }
+        // Unauthorized
         throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {
         if (err instanceof GraphQLError) throw err;
+        
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
         throw InternalServerError();
       }

--- a/src/resolvers/versionedQuestion.ts
+++ b/src/resolvers/versionedQuestion.ts
@@ -41,7 +41,6 @@ export const resolvers: Resolvers = {
             VersionedCustomQuestion.findByVersionedSectionIdAndType(reference, context, versionedSectionId, 'BASE')
           ]);
 
-          // Fetch answers for both sets
           const baseIds = baseQuestions.map(q => q.id);
           const customIds = customQuestions.map(q => q.id);
 
@@ -53,20 +52,26 @@ export const resolvers: Resolvers = {
           const baseAnswersMap = new Set(baseAnswers.map(a => a.versionedQuestionId));
           const customAnswersMap = new Set(customAnswers.map(a => a.versionedCustomQuestionId));
 
-          return [
-            ...baseQuestions.map(q => ({
-              id: q.id,
-              questionText: q.questionText,
-              requirementText: q.requirementText,
-              guidanceText: q.guidanceText,
-              sampleText: q.sampleText,
-              required: q.required,
-              hasAnswer: baseAnswersMap.has(q.id),
-              questionType: 'BASE' as CustomizableObjectOwnership,
-              versionedQuestionId: q.id,
-              customQuestionId: undefined,
-            })),
-            ...customQuestions.map(q => ({
+          // Build ordered list starting with base questions
+          const ordered: PublishedQuestionResult[] = baseQuestions.map(q => ({
+            id: q.id,
+            questionText: q.questionText,
+            requirementText: q.requirementText,
+            guidanceText: q.guidanceText,
+            sampleText: q.sampleText,
+            required: q.required,
+            hasAnswer: baseAnswersMap.has(q.id),
+            questionType: 'BASE' as CustomizableObjectOwnership,
+            versionedQuestionId: q.id,
+            customQuestionId: undefined,
+          }));
+
+          // Sort custom questions by id (same as injectCustomQuestions)
+          const sortedCustom = [...customQuestions].sort((a, b) => a.id - b.id);
+
+          // Splice each custom question in after its pinned question
+          for (const q of sortedCustom) {
+            const result: PublishedQuestionResult = {
               id: q.id,
               questionText: q.questionText,
               requirementText: q.requirementText,
@@ -77,15 +82,29 @@ export const resolvers: Resolvers = {
               questionType: 'CUSTOM' as CustomizableObjectOwnership,
               versionedQuestionId: undefined,
               customQuestionId: q.id,
-            })),
+            };
 
-          ];
+            if (q.pinnedVersionedQuestionId === null) {
+              // No pin — goes first
+              ordered.unshift(result);
+            } else {
+              const pinIdx = ordered.findIndex(o =>
+                o.questionType === q.pinnedVersionedQuestionType && o.id === q.pinnedVersionedQuestionId
+              );
+              if (pinIdx !== -1) {
+                ordered.splice(pinIdx + 1, 0, result);
+              } else {
+                // Pinned question not found — append to end
+                ordered.push(result);
+              }
+            }
+          }
+
+          return ordered;
         }
-        // Unauthorized!
         throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {
         if (err instanceof GraphQLError) throw err;
-
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
         throw InternalServerError();
       }

--- a/src/schemas/guidance.ts
+++ b/src/schemas/guidance.ts
@@ -7,7 +7,7 @@ export const typeDefs = gql`
     "Get a specific Guidance item by ID"
     guidance(guidanceId: Int!): Guidance
     "Get all guidance sources for a plan, optionally filtered by section"
-    guidanceSourcesForPlan(planId: Int!, versionedSectionId: Int, versionedQuestionId: Int): [GuidanceSource!]!
+    guidanceSourcesForPlan(planId: Int!, versionedSectionId: Int, versionedQuestionId: Int, customSectionId: Int): [GuidanceSource!]!
   }
 
   extend type Mutation {

--- a/src/schemas/questionCustomization.ts
+++ b/src/schemas/questionCustomization.ts
@@ -214,5 +214,15 @@ export const typeDefs = gql`
     pinnedQuestionType: CustomizableObjectOwnership
     "The identifier of the question this new custom question should appear after (null means it is the first question in the section)"
     pinnedQuestionId: Int
+    "Direction to move the question relative to the pinnedQuestion (UP or DOWN)"
+    direction: MoveCustomQuestionDirection!
+  }
+
+  "Direction to move a custom question relative to the pinned question"
+  enum MoveCustomQuestionDirection {
+    "Move the question above the pinned question"
+    UP
+    "Move the question below the pinned question"
+    DOWN
   }
 `;

--- a/src/services/__tests__/guidanceService.spec.ts
+++ b/src/services/__tests__/guidanceService.spec.ts
@@ -3,7 +3,6 @@ import { buildMockContextWithToken } from "../../__mocks__/context";
 import { logger } from "../../logger";
 import {
   mockPlan,
-  mockUser,
   mockVersionedTemplate,
   mockUserSelections,
   mockBestPracticeGuidance,
@@ -19,9 +18,12 @@ import { GuidanceGroup } from "../../models/GuidanceGroup";
 import { PlanGuidance } from "../../models/Guidance";
 import { VersionedGuidance } from "../../models/VersionedGuidance";
 import { Plan } from "../../models/Plan";
-import { User } from "../../models/User";
 import { VersionedTemplate } from "../../models/VersionedTemplate";
 import { VersionedSection } from "../../models/VersionedSection";
+import { VersionedQuestion } from "../../models/VersionedQuestion";
+import { VersionedSectionCustomization } from "../../models/VersionedSectionCustomization";
+import { VersionedQuestionCustomization } from "../../models/VersionedQuestionCustomization";
+import { VersionedCustomSection } from "../../models/VersionedCustomSection";
 import { Affiliation } from "../../models/Affiliation";
 import { isSuperAdmin } from "../authService";
 
@@ -126,6 +128,24 @@ jest.mock("../../models/VersionedSection", () => ({
 
 jest.mock("../../models/VersionedQuestion", () => ({
   VersionedQuestion: {
+    findById: jest.fn(),
+  },
+}));
+
+jest.mock("../../models/VersionedSectionCustomization", () => ({
+  VersionedSectionCustomization: {
+    findActiveByTemplateAffiliationAndSection: jest.fn(),
+  },
+}));
+
+jest.mock("../../models/VersionedQuestionCustomization", () => ({
+  VersionedQuestionCustomization: {
+    findActiveByTemplateAffiliationAndQuestion: jest.fn(),
+  },
+}));
+
+jest.mock("../../models/VersionedCustomSection", () => ({
+  VersionedCustomSection: {
     findById: jest.fn(),
   },
 }));
@@ -561,35 +581,54 @@ describe("getGuidanceSourcesForPlan", () => {
     expect(result).toEqual([]);
   });
 
-  it("returns [] if user not found", async () => {
-    (Plan.findById as jest.Mock).mockResolvedValue({ versionedTemplateId: 1 });
-    (User.findById as jest.Mock).mockResolvedValue(null);
+  it("returns [] if versionedTemplateId is missing from plan", async () => {
+    (Plan.findById as jest.Mock).mockResolvedValue({ id: 1 }); // no versionedTemplateId
     const result = await guidanceService.getGuidanceSourcesForPlan(context, 1);
     expect(result).toEqual([]);
   });
 
-  it("returns [] if tags are empty", async () => {
-    (Plan.findById as jest.Mock).mockResolvedValue({ versionedTemplateId: 1 });
-    (User.findById as jest.Mock).mockResolvedValue({ affiliationId: "affil" });
-    
-    (PlanGuidance.query as jest.Mock).mockResolvedValue([]);
-    
-    const result = await guidanceService.getGuidanceSourcesForPlan(context, 1);
+  it("returns [] when section has no tags and no guidanceText", async () => {
+    (Plan.findById as jest.Mock).mockResolvedValue({ id: 1, versionedTemplateId: 1 });
+    (PlanGuidance.query as jest.Mock).mockResolvedValue([]); // empty tags
+    (VersionedSection.findById as jest.Mock).mockResolvedValue({ guidance: null });
+    (VersionedSectionCustomization.findActiveByTemplateAffiliationAndSection as jest.Mock).mockResolvedValue(null);
+    (VersionedTemplate.findById as jest.Mock).mockResolvedValue({ ownerId: null });
+    (PlanGuidance.findByPlanAndUserId as jest.Mock).mockResolvedValue([]);
+
+    const result = await guidanceService.getGuidanceSourcesForPlan(context, 1, 1);
     expect(result).toEqual([]);
   });
 
-  it("returns expected guidance sources for a populated plan", async () => {
+  it("returns [] if versionedQuestionId is provided but question not found", async () => {
     (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
-    (User.findById as jest.Mock).mockResolvedValue(mockUser);
+    (VersionedQuestion.findById as jest.Mock).mockResolvedValue(null);
+
+    const result = await guidanceService.getGuidanceSourcesForPlan(
+      context, mockPlan.id, undefined, 10
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] if customSectionId is provided but custom section not found", async () => {
+    (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
+    (VersionedCustomSection.findById as jest.Mock).mockResolvedValue(null);
+
+    const result = await guidanceService.getGuidanceSourcesForPlan(
+      context, mockPlan.id, undefined, undefined, 5
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("returns expected guidance sources for a populated plan with versionedSectionId", async () => {
+    (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
     (VersionedTemplate.findById as jest.Mock).mockResolvedValue(mockVersionedTemplate);
-    (VersionedSection.findById as jest.Mock).mockResolvedValue({ guidance: null }); // Mock section without guidance
+    (VersionedSection.findById as jest.Mock).mockResolvedValue({ guidance: null });
+    (VersionedSectionCustomization.findActiveByTemplateAffiliationAndSection as jest.Mock).mockResolvedValue(null);
     (PlanGuidance.findByPlanAndUserId as jest.Mock).mockResolvedValue(mockUserSelections);
-    
     (PlanGuidance.query as jest.Mock).mockResolvedValue([
       { id: 1, name: "Data Sharing" },
       { id: 2, name: "Preservation" }
     ]);
-
     (VersionedGuidance.findBestPracticeByTagIds as jest.Mock).mockResolvedValue(mockBestPracticeGuidance);
     (VersionedGuidance.findByAffiliationAndTagIds as jest.Mock).mockImplementation((_, __, uri) => {
       if (uri === "https://ror.org/03yrm5c26") return Promise.resolve(mockTagBasedGuidanceCDL);
@@ -597,7 +636,6 @@ describe("getGuidanceSourcesForPlan", () => {
       if (uri === "https://ror.org/01cwqze88") return Promise.resolve(mockTagBasedGuidanceNIH);
       return Promise.resolve([]);
     });
-
     (Affiliation.findByURI as jest.Mock).mockImplementation((_, __, uri) => {
       if (uri === "https://ror.org/03yrm5c26") return Promise.resolve(mockAffiliationCDL);
       if (uri === "https://ror.org/021nxhr62") return Promise.resolve(mockAffiliationNSF);
@@ -605,31 +643,138 @@ describe("getGuidanceSourcesForPlan", () => {
       return Promise.resolve(null);
     });
 
-    const result = await guidanceService.getGuidanceSourcesForPlan(context, mockPlan.id, 1); // Pass versionedSectionId
+    const result = await guidanceService.getGuidanceSourcesForPlan(context, mockPlan.id, 1);
 
     expect(result).toHaveLength(4);
-    
-    // Check that all expected sources are present (order may vary)
     expect(result).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        id: "bestPractice",
-        type: "BEST_PRACTICE",
-        orgURI: "bestPractice",
-      }),
-      expect.objectContaining({
-        id: "affiliation-https://ror.org/03yrm5c26",
-        orgURI: "https://ror.org/03yrm5c26",
-      }),
-      expect.objectContaining({
-        id: "affiliation-https://ror.org/021nxhr62",
-        type: "TEMPLATE_OWNER",
-        orgURI: "https://ror.org/021nxhr62",
-      }),
-      expect.objectContaining({
-        id: "affiliation-https://ror.org/01cwqze88",
-        type: "USER_SELECTED",
-        orgURI: "https://ror.org/01cwqze88",
-      }),
+      expect.objectContaining({ id: "bestPractice", type: "BEST_PRACTICE" }),
+      expect.objectContaining({ id: "affiliation-https://ror.org/03yrm5c26" }),
+      expect.objectContaining({ id: "affiliation-https://ror.org/021nxhr62", type: "TEMPLATE_OWNER" }),
+      expect.objectContaining({ id: "affiliation-https://ror.org/01cwqze88", type: "USER_SELECTED" }),
     ]));
+  });
+
+  it("returns guidance sources for the versionedQuestionId path", async () => {
+    (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
+    (VersionedQuestion.findById as jest.Mock).mockResolvedValue({
+      id: 10, versionedSectionId: 5, guidanceText: null,
+    });
+    (PlanGuidance.query as jest.Mock).mockResolvedValue([{ id: 1, name: "Data Sharing" }]);
+    (VersionedQuestionCustomization.findActiveByTemplateAffiliationAndQuestion as jest.Mock).mockResolvedValue(null);
+    (VersionedTemplate.findById as jest.Mock).mockResolvedValue(mockVersionedTemplate);
+    (PlanGuidance.findByPlanAndUserId as jest.Mock).mockResolvedValue([]);
+    (VersionedGuidance.findBestPracticeByTagIds as jest.Mock).mockResolvedValue(mockBestPracticeGuidance);
+    (VersionedGuidance.findByAffiliationAndTagIds as jest.Mock).mockResolvedValue([]);
+
+    const result = await guidanceService.getGuidanceSourcesForPlan(
+      context, mockPlan.id, undefined, 10
+    );
+
+    expect(VersionedQuestion.findById).toHaveBeenCalled();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: "bestPractice", type: "BEST_PRACTICE" });
+  });
+
+  it("returns template owner source when section has guidanceText and no tags", async () => {
+    (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
+    (PlanGuidance.query as jest.Mock).mockResolvedValue([]); // no tags
+    (VersionedSection.findById as jest.Mock).mockResolvedValue({ guidance: "Template-level guidance" });
+    (VersionedSectionCustomization.findActiveByTemplateAffiliationAndSection as jest.Mock).mockResolvedValue(null);
+    (VersionedTemplate.findById as jest.Mock).mockResolvedValue(mockVersionedTemplate);
+    (PlanGuidance.findByPlanAndUserId as jest.Mock).mockResolvedValue([
+      { affiliationId: mockVersionedTemplate.ownerId },
+    ]);
+    (Affiliation.findByURI as jest.Mock).mockResolvedValue(mockAffiliationNSF);
+
+    const result = await guidanceService.getGuidanceSourcesForPlan(context, mockPlan.id, 1);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: "TEMPLATE_OWNER",
+      orgURI: mockVersionedTemplate.ownerId,
+      hasGuidance: true,
+    });
+    expect(result[0].items[0].guidanceText).toEqual("Template-level guidance");
+  });
+
+  it("includes USER_SELECTED empty pill sources for user selections with no guidance when no tags", async () => {
+    (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
+    (PlanGuidance.query as jest.Mock).mockResolvedValue([]); // no tags
+    (VersionedSection.findById as jest.Mock).mockResolvedValue({ guidance: null });
+    (VersionedSectionCustomization.findActiveByTemplateAffiliationAndSection as jest.Mock).mockResolvedValue(null);
+    (VersionedTemplate.findById as jest.Mock).mockResolvedValue({ ownerId: null });
+    (PlanGuidance.findByPlanAndUserId as jest.Mock).mockResolvedValue([
+      { affiliationId: "https://ror.org/01cwqze88" },
+    ]);
+    (Affiliation.findByURI as jest.Mock).mockResolvedValue(mockAffiliationNIH);
+
+    const result = await guidanceService.getGuidanceSourcesForPlan(context, mockPlan.id, 1);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: "USER_SELECTED",
+      orgURI: "https://ror.org/01cwqze88",
+      items: [],
+      hasGuidance: false,
+    });
+  });
+
+  it("prepends section customization guidanceText to user affiliation items", async () => {
+    const userAffiliationUri = "https://ror.org/03yrm5c26"; // CDL
+    const localContext = { ...context, token: { ...context.token, affiliationId: userAffiliationUri } };
+
+    (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
+    (PlanGuidance.query as jest.Mock).mockResolvedValue([{ id: 1, name: "Data Sharing" }]);
+    (VersionedSection.findById as jest.Mock).mockResolvedValue({ guidance: null });
+    (VersionedSectionCustomization.findActiveByTemplateAffiliationAndSection as jest.Mock).mockResolvedValue({
+      guidance: "Customized section guidance",
+    });
+    (VersionedTemplate.findById as jest.Mock).mockResolvedValue(mockVersionedTemplate);
+    (PlanGuidance.findByPlanAndUserId as jest.Mock).mockResolvedValue([
+      { affiliationId: userAffiliationUri },
+    ]);
+    (VersionedGuidance.findBestPracticeByTagIds as jest.Mock).mockResolvedValue([]);
+    (VersionedGuidance.findByAffiliationAndTagIds as jest.Mock).mockResolvedValue([
+      { tagId: 1, guidanceText: "CDL tag guidance" },
+    ]);
+    (Affiliation.findByURI as jest.Mock).mockResolvedValue(mockAffiliationCDL);
+
+    const result = await guidanceService.getGuidanceSourcesForPlan(
+      localContext as MyContext, mockPlan.id, 1
+    );
+
+    const userSource = result.find(s => s.id === `affiliation-${userAffiliationUri}`);
+    expect(userSource).toBeDefined();
+    expect(userSource.type).toEqual("USER_AFFILIATION");
+    expect(userSource.items[0].guidanceText).toEqual("Customized section guidance");
+  });
+
+  it("does not prepend guidanceText to template owner items when customSectionId is used", async () => {
+    const localContext = { ...context, token: { ...context.token, affiliationId: "https://unrelated.org" } };
+
+    (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
+    (VersionedCustomSection.findById as jest.Mock).mockResolvedValue({
+      id: 5, guidance: "Custom section guidance",
+    });
+    (PlanGuidance.query as jest.Mock).mockResolvedValue([{ id: 1, name: "Data Sharing" }]);
+    (VersionedTemplate.findById as jest.Mock).mockResolvedValue(mockVersionedTemplate);
+    (PlanGuidance.findByPlanAndUserId as jest.Mock).mockResolvedValue([
+      { affiliationId: mockVersionedTemplate.ownerId },
+    ]);
+    (VersionedGuidance.findBestPracticeByTagIds as jest.Mock).mockResolvedValue([]);
+    (VersionedGuidance.findByAffiliationAndTagIds as jest.Mock).mockResolvedValue([
+      { tagId: 1, guidanceText: "NSF tag guidance" },
+    ]);
+    (Affiliation.findByURI as jest.Mock).mockResolvedValue(mockAffiliationNSF);
+
+    const result = await guidanceService.getGuidanceSourcesForPlan(
+      localContext as MyContext, mockPlan.id, undefined, undefined, 5
+    );
+
+    const templateOwnerSource = result.find(s => s.type === "TEMPLATE_OWNER");
+    expect(templateOwnerSource).toBeDefined();
+    // guidanceText must NOT be prepended for template owner when customSectionId is provided
+    expect(templateOwnerSource.items).toHaveLength(1);
+    expect(templateOwnerSource.items[0].guidanceText).toEqual("NSF tag guidance");
   });
 });

--- a/src/services/__tests__/guidanceService.spec.ts
+++ b/src/services/__tests__/guidanceService.spec.ts
@@ -575,19 +575,19 @@ describe("getGuidanceSourcesForPlan", () => {
     jest.clearAllMocks();
   });
 
-  it("returns [] if plan not found", async () => {
+  it("should return [] if plan not found", async () => {
     (Plan.findById as jest.Mock).mockResolvedValue(null);
     const result = await guidanceService.getGuidanceSourcesForPlan(context, 1);
     expect(result).toEqual([]);
   });
 
-  it("returns [] if versionedTemplateId is missing from plan", async () => {
+  it("should return [] if versionedTemplateId is missing from plan", async () => {
     (Plan.findById as jest.Mock).mockResolvedValue({ id: 1 }); // no versionedTemplateId
     const result = await guidanceService.getGuidanceSourcesForPlan(context, 1);
     expect(result).toEqual([]);
   });
 
-  it("returns [] when section has no tags and no guidanceText", async () => {
+  it("should return [] when section has no tags and no guidanceText", async () => {
     (Plan.findById as jest.Mock).mockResolvedValue({ id: 1, versionedTemplateId: 1 });
     (PlanGuidance.query as jest.Mock).mockResolvedValue([]); // empty tags
     (VersionedSection.findById as jest.Mock).mockResolvedValue({ guidance: null });
@@ -599,7 +599,7 @@ describe("getGuidanceSourcesForPlan", () => {
     expect(result).toEqual([]);
   });
 
-  it("returns [] if versionedQuestionId is provided but question not found", async () => {
+  it("should return [] if versionedQuestionId is provided but question not found", async () => {
     (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
     (VersionedQuestion.findById as jest.Mock).mockResolvedValue(null);
 
@@ -609,7 +609,7 @@ describe("getGuidanceSourcesForPlan", () => {
     expect(result).toEqual([]);
   });
 
-  it("returns [] if customSectionId is provided but custom section not found", async () => {
+  it("should return [] if customSectionId is provided but custom section not found", async () => {
     (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
     (VersionedCustomSection.findById as jest.Mock).mockResolvedValue(null);
 
@@ -619,7 +619,7 @@ describe("getGuidanceSourcesForPlan", () => {
     expect(result).toEqual([]);
   });
 
-  it("returns expected guidance sources for a populated plan with versionedSectionId", async () => {
+  it("should return expected guidance sources for a populated plan with versionedSectionId", async () => {
     (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
     (VersionedTemplate.findById as jest.Mock).mockResolvedValue(mockVersionedTemplate);
     (VersionedSection.findById as jest.Mock).mockResolvedValue({ guidance: null });
@@ -654,7 +654,7 @@ describe("getGuidanceSourcesForPlan", () => {
     ]));
   });
 
-  it("returns guidance sources for the versionedQuestionId path", async () => {
+  it("should return guidance sources for the versionedQuestionId path", async () => {
     (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
     (VersionedQuestion.findById as jest.Mock).mockResolvedValue({
       id: 10, versionedSectionId: 5, guidanceText: null,
@@ -675,7 +675,7 @@ describe("getGuidanceSourcesForPlan", () => {
     expect(result[0]).toMatchObject({ id: "bestPractice", type: "BEST_PRACTICE" });
   });
 
-  it("returns template owner source when section has guidanceText and no tags", async () => {
+  it("should return template owner source when section has guidanceText and no tags", async () => {
     (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
     (PlanGuidance.query as jest.Mock).mockResolvedValue([]); // no tags
     (VersionedSection.findById as jest.Mock).mockResolvedValue({ guidance: "Template-level guidance" });
@@ -697,7 +697,7 @@ describe("getGuidanceSourcesForPlan", () => {
     expect(result[0].items[0].guidanceText).toEqual("Template-level guidance");
   });
 
-  it("includes USER_SELECTED empty pill sources for user selections with no guidance when no tags", async () => {
+  it("should include USER_SELECTED empty pill sources for user selections with no guidance when no tags", async () => {
     (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
     (PlanGuidance.query as jest.Mock).mockResolvedValue([]); // no tags
     (VersionedSection.findById as jest.Mock).mockResolvedValue({ guidance: null });
@@ -719,7 +719,7 @@ describe("getGuidanceSourcesForPlan", () => {
     });
   });
 
-  it("prepends section customization guidanceText to user affiliation items", async () => {
+  it("should prepend section customization guidanceText to user affiliation items", async () => {
     const userAffiliationUri = "https://ror.org/03yrm5c26"; // CDL
     const localContext = { ...context, token: { ...context.token, affiliationId: userAffiliationUri } };
 
@@ -749,7 +749,7 @@ describe("getGuidanceSourcesForPlan", () => {
     expect(userSource.items[0].guidanceText).toEqual("Customized section guidance");
   });
 
-  it("does not prepend guidanceText to template owner items when customSectionId is used", async () => {
+  it("should not prepend guidanceText to template owner items when customSectionId is used", async () => {
     const localContext = { ...context, token: { ...context.token, affiliationId: "https://unrelated.org" } };
 
     (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);

--- a/src/services/__tests__/templateCustomizationPublishHelpers.spec.ts
+++ b/src/services/__tests__/templateCustomizationPublishHelpers.spec.ts
@@ -4,8 +4,6 @@ import { VersionedSection } from "../../models/VersionedSection";
 import { VersionedQuestion } from "../../models/VersionedQuestion";
 import { VersionedCustomSection } from "../../models/VersionedCustomSection";
 import { VersionedCustomQuestion } from "../../models/VersionedCustomQuestion";
-import { VersionedSectionCustomization } from "../../models/VersionedSectionCustomization";
-import { VersionedQuestionCustomization } from "../../models/VersionedQuestionCustomization";
 import { CustomSection, PinnedSectionTypeEnum } from "../../models/CustomSection";
 import { CustomQuestion } from "../../models/CustomQuestion";
 import { SectionCustomization } from "../../models/SectionCustomization";

--- a/src/services/__tests__/templateCustomizationPublishHelpers.spec.ts
+++ b/src/services/__tests__/templateCustomizationPublishHelpers.spec.ts
@@ -1,0 +1,220 @@
+import { MyContext } from "../../context";
+import { VersionedTemplateCustomization } from "../../models/VersionedTemplateCustomization";
+import { VersionedSection } from "../../models/VersionedSection";
+import { VersionedQuestion } from "../../models/VersionedQuestion";
+import { VersionedCustomSection } from "../../models/VersionedCustomSection";
+import { VersionedCustomQuestion } from "../../models/VersionedCustomQuestion";
+import { VersionedSectionCustomization } from "../../models/VersionedSectionCustomization";
+import { VersionedQuestionCustomization } from "../../models/VersionedQuestionCustomization";
+import { CustomSection, PinnedSectionTypeEnum } from "../../models/CustomSection";
+import { CustomQuestion } from "../../models/CustomQuestion";
+import { SectionCustomization } from "../../models/SectionCustomization";
+import { QuestionCustomization } from "../../models/QuestionCustomization";
+import {
+  PublishableCustomization,
+  snapshotCustomizationChildren,
+  rollbackPublishedSnapshot,
+} from "../templateCustomizationPublishHelpers";
+import { User, UserRole } from "../../models/User";
+import casual from "casual";
+import { buildMockContextWithToken } from "../../__mocks__/context";
+import { logger } from "../../logger";
+
+jest.mock("../../models/VersionedTemplateCustomization");
+jest.mock("../../models/VersionedSection");
+jest.mock("../../models/VersionedQuestion");
+jest.mock("../../models/VersionedCustomSection");
+jest.mock("../../models/VersionedCustomQuestion");
+jest.mock("../../models/VersionedSectionCustomization");
+jest.mock("../../models/VersionedQuestionCustomization");
+jest.mock("../../models/CustomSection");
+jest.mock("../../models/CustomQuestion");
+jest.mock("../../models/SectionCustomization");
+jest.mock("../../models/QuestionCustomization");
+
+describe("templateCustomizationPublishHelpers", () => {
+  let mockContext: MyContext;
+  const reference = "test-reference";
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const user = new User({
+      id: casual.integer(1, 999),
+      givenName: casual.first_name,
+      surName: casual.last_name,
+      role: UserRole.ADMIN,
+      affiliationId: casual.url,
+    });
+    (user.getEmail as jest.Mock) = jest.fn().mockResolvedValue(casual.email);
+    mockContext = await buildMockContextWithToken(logger, user);
+  });
+
+  describe("snapshotCustomizationChildren", () => {
+    let customization: PublishableCustomization;
+    let created: VersionedTemplateCustomization;
+
+    beforeEach(() => {
+      customization = {
+        id: 1,
+        currentVersionedTemplateId: 10,
+        addError: jest.fn(),
+        hasErrors: jest.fn().mockReturnValue(false),
+      };
+      created = new VersionedTemplateCustomization({ id: 99 });
+    });
+
+    it("should do nothing when there are no custom sections, questions, or customizations", async () => {
+      (CustomSection.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+      (CustomQuestion.findByCustomizationAndSectionType as jest.Mock).mockResolvedValue([]);
+      (SectionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+      (QuestionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+
+      await snapshotCustomizationChildren(reference, mockContext, customization, created);
+
+      expect(customization.addError).not.toHaveBeenCalled();
+    });
+
+    it("should add error when versioning a custom section fails", async () => {
+      const mockSection = { id: 5, name: "My Section" };
+      (CustomSection.findByCustomizationId as jest.Mock).mockResolvedValue([mockSection]);
+      (CustomQuestion.findByCustomizationAndSectionId as jest.Mock).mockResolvedValue([]);
+      (CustomQuestion.findByCustomizationAndSectionType as jest.Mock).mockResolvedValue([]);
+      (SectionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+      (QuestionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+
+      const failedSection = new VersionedCustomSection({ errors: { general: "DB error" } });
+      (failedSection.hasErrors as jest.Mock) = jest.fn().mockReturnValue(true);
+      jest.spyOn(VersionedCustomSection.prototype, "create").mockResolvedValue(failedSection);
+
+      await snapshotCustomizationChildren(reference, mockContext, customization, created);
+
+      expect(customization.addError).toHaveBeenCalledWith(
+        "general",
+        `Unable to version custom section: ${mockSection.name}`
+      );
+    });
+
+    it("should add error when versioning a custom question in a custom section fails", async () => {
+      const mockSection = { id: 5, name: "My Section" };
+      const mockQuestion = {
+        id: 10,
+        sectionType: PinnedSectionTypeEnum.CUSTOM,
+        sectionId: 5,
+        pinnedQuestionType: null,
+        pinnedQuestionId: null,
+        questionText: "Q?",
+        json: "{}",
+        requirementText: null,
+        guidanceText: null,
+        sampleText: null,
+        useSampleTextAsDefault: false,
+        required: false,
+      };
+      (CustomSection.findByCustomizationId as jest.Mock).mockResolvedValue([mockSection]);
+      (CustomQuestion.findByCustomizationAndSectionId as jest.Mock).mockResolvedValue([mockQuestion]);
+      (CustomQuestion.findByCustomizationAndSectionType as jest.Mock).mockResolvedValue([]);
+      (SectionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+      (QuestionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+
+      const okSection = new VersionedCustomSection({ id: 50 });
+      (okSection.hasErrors as jest.Mock) = jest.fn().mockReturnValue(false);
+      jest.spyOn(VersionedCustomSection.prototype, "create").mockResolvedValue(okSection);
+      const failedQuestion = new VersionedCustomQuestion({ errors: { general: "DB error" } });
+      (failedQuestion.hasErrors as jest.Mock) = jest.fn().mockReturnValue(true);
+      jest.spyOn(VersionedCustomQuestion.prototype, "create").mockResolvedValue(failedQuestion);
+
+      await snapshotCustomizationChildren(reference, mockContext, customization, created);
+
+      expect(customization.addError).toHaveBeenCalledWith(
+        "general",
+        `Unable to version custom question in section: ${mockSection.name}`
+      );
+    });
+
+    it("should add error when versioning a section customization and versioned section lookup fails", async () => {
+      const mockSectionCust = { id: 7, sectionId: 20, guidance: "Some guidance" };
+      (CustomSection.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+      (CustomQuestion.findByCustomizationAndSectionType as jest.Mock).mockResolvedValue([]);
+      (SectionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([mockSectionCust]);
+      (QuestionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+      (VersionedSection.query as jest.Mock).mockResolvedValue([]);
+
+      await snapshotCustomizationChildren(reference, mockContext, customization, created);
+
+      expect(customization.addError).toHaveBeenCalledWith(
+        "general",
+        `Unable to find versioned section for sectionId: ${mockSectionCust.sectionId}`
+      );
+    });
+
+    it("should add error when versioning a question customization and versioned question lookup fails", async () => {
+      const mockQuestionCust = { id: 8, questionId: 30, guidanceText: null, sampleText: null };
+      (CustomSection.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+      (CustomQuestion.findByCustomizationAndSectionType as jest.Mock).mockResolvedValue([]);
+      (SectionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+      (QuestionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([mockQuestionCust]);
+      (VersionedQuestion.query as jest.Mock).mockResolvedValue([]);
+
+      await snapshotCustomizationChildren(reference, mockContext, customization, created);
+
+      expect(customization.addError).toHaveBeenCalledWith(
+        "general",
+        `Unable to find versioned question for questionId: ${mockQuestionCust.questionId}`
+      );
+    });
+
+    it("should successfully snapshot all children without errors", async () => {
+      (CustomSection.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+      (CustomQuestion.findByCustomizationAndSectionType as jest.Mock).mockResolvedValue([]);
+      (SectionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+      (QuestionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+
+      await snapshotCustomizationChildren(reference, mockContext, customization, created);
+
+      expect(customization.addError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("rollbackPublishedSnapshot", () => {
+    it("should delete the snapshot and cascade to child rows without restoring a prior version", async () => {
+      (VersionedTemplateCustomization.delete as jest.Mock).mockResolvedValue(true);
+
+      await rollbackPublishedSnapshot(mockContext, 99, undefined);
+
+      expect(VersionedTemplateCustomization.delete).toHaveBeenCalledWith(
+        mockContext,
+        VersionedTemplateCustomization.tableName,
+        99,
+        "rollbackPublishedSnapshot"
+      );
+      expect(VersionedTemplateCustomization.findById).not.toHaveBeenCalled();
+    });
+
+    it("should re-activate the prior published version when priorPublishedVersionId is provided", async () => {
+      (VersionedTemplateCustomization.delete as jest.Mock).mockResolvedValue(true);
+
+      const priorVer = new VersionedTemplateCustomization({ id: 50, active: false });
+      priorVer.update = jest.fn().mockResolvedValue({ ...priorVer, active: true });
+      (VersionedTemplateCustomization.findById as jest.Mock).mockResolvedValue(priorVer);
+
+      await rollbackPublishedSnapshot(mockContext, 99, 50);
+
+      expect(VersionedTemplateCustomization.findById).toHaveBeenCalledWith(
+        "rollbackPublishedSnapshot",
+        mockContext,
+        50
+      );
+      expect(priorVer.active).toBe(true);
+      expect(priorVer.update).toHaveBeenCalledWith(mockContext, true);
+    });
+
+    it("should not attempt to restore prior version when findById returns null", async () => {
+      (VersionedTemplateCustomization.delete as jest.Mock).mockResolvedValue(true);
+      (VersionedTemplateCustomization.findById as jest.Mock).mockResolvedValue(null);
+
+      await rollbackPublishedSnapshot(mockContext, 99, 50);
+
+      expect(VersionedTemplateCustomization.findById).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/services/__tests__/templateCustomizationPublishHelpers.spec.ts
+++ b/src/services/__tests__/templateCustomizationPublishHelpers.spec.ts
@@ -8,6 +8,8 @@ import { CustomSection, PinnedSectionTypeEnum } from "../../models/CustomSection
 import { CustomQuestion } from "../../models/CustomQuestion";
 import { SectionCustomization } from "../../models/SectionCustomization";
 import { QuestionCustomization } from "../../models/QuestionCustomization";
+import { VersionedSectionCustomization } from "../../models/VersionedSectionCustomization";
+import { VersionedQuestionCustomization } from "../../models/VersionedQuestionCustomization";
 import {
   PublishableCustomization,
   snapshotCustomizationChildren,
@@ -161,11 +163,95 @@ describe("templateCustomizationPublishHelpers", () => {
       );
     });
 
-    it("should successfully snapshot all children without errors", async () => {
+    it("should add error when versioning a BASE custom question fails", async () => {
+      const mockQuestion = {
+        id: 20,
+        sectionType: PinnedSectionTypeEnum.BASE,
+        sectionId: 7,
+        pinnedQuestionType: null,
+        pinnedQuestionId: null,
+        questionText: "Q?",
+        json: "{}",
+        requirementText: null,
+        guidanceText: null,
+        sampleText: null,
+        useSampleTextAsDefault: false,
+        required: false,
+      };
+      (CustomSection.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+      (CustomQuestion.findByCustomizationAndSectionType as jest.Mock).mockResolvedValue([mockQuestion]);
+      (SectionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+      (QuestionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+
+      const failedQuestion = new VersionedCustomQuestion({ errors: { general: "DB error" } });
+      (failedQuestion.hasErrors as jest.Mock) = jest.fn().mockReturnValue(true);
+      jest.spyOn(VersionedCustomQuestion.prototype, "create").mockResolvedValue(failedQuestion);
+
+      await snapshotCustomizationChildren(reference, mockContext, customization, created);
+
+      expect(customization.addError).toHaveBeenCalledWith(
+        "general",
+        `Unable to version custom question for base section id: ${mockQuestion.sectionId}`
+      );
+    });
+
+    it("should add error when VersionedSectionCustomization creation fails after section lookup succeeds", async () => {
+      const mockSectionCust = { id: 7, sectionId: 20, guidance: "Some guidance" };
+      (CustomSection.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+      (CustomQuestion.findByCustomizationAndSectionType as jest.Mock).mockResolvedValue([]);
+      (SectionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([mockSectionCust]);
+      (QuestionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+      (VersionedSection.query as jest.Mock).mockResolvedValue([{ id: 100 }]);
+
+      const failedSectionCust = new VersionedSectionCustomization({ errors: { general: "DB error" } });
+      (failedSectionCust.hasErrors as jest.Mock) = jest.fn().mockReturnValue(true);
+      jest.spyOn(VersionedSectionCustomization.prototype, "create").mockResolvedValue(failedSectionCust);
+
+      await snapshotCustomizationChildren(reference, mockContext, customization, created);
+
+      expect(customization.addError).toHaveBeenCalledWith(
+        "general",
+        `Unable to version section customization for sectionId: ${mockSectionCust.sectionId}`
+      );
+    });
+
+    it("should add error when VersionedQuestionCustomization creation fails after question lookup succeeds", async () => {
+      const mockQuestionCust = { id: 8, questionId: 30, guidanceText: null, sampleText: null };
       (CustomSection.findByCustomizationId as jest.Mock).mockResolvedValue([]);
       (CustomQuestion.findByCustomizationAndSectionType as jest.Mock).mockResolvedValue([]);
       (SectionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([]);
-      (QuestionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+      (QuestionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([mockQuestionCust]);
+      (VersionedQuestion.query as jest.Mock).mockResolvedValue([{ id: 200 }]);
+
+      const failedQuestionCust = new VersionedQuestionCustomization({ errors: { general: "DB error" } });
+      (failedQuestionCust.hasErrors as jest.Mock) = jest.fn().mockReturnValue(true);
+      jest.spyOn(VersionedQuestionCustomization.prototype, "create").mockResolvedValue(failedQuestionCust);
+
+      await snapshotCustomizationChildren(reference, mockContext, customization, created);
+
+      expect(customization.addError).toHaveBeenCalledWith(
+        "general",
+        `Unable to version question customization for questionId: ${mockQuestionCust.questionId}`
+      );
+    });
+
+    it("should successfully snapshot all children including section and question customizations", async () => {
+      const mockSectionCust = { id: 7, sectionId: 20, guidance: "Some guidance" };
+      const mockQuestionCust = { id: 8, questionId: 30, guidanceText: null, sampleText: null };
+      (CustomSection.findByCustomizationId as jest.Mock).mockResolvedValue([]);
+      (CustomQuestion.findByCustomizationAndSectionType as jest.Mock).mockResolvedValue([]);
+      (SectionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([mockSectionCust]);
+      (QuestionCustomization.findByCustomizationId as jest.Mock).mockResolvedValue([mockQuestionCust]);
+      (VersionedSection.query as jest.Mock).mockResolvedValue([{ id: 100 }]);
+      (VersionedQuestion.query as jest.Mock).mockResolvedValue([{ id: 200 }]);
+
+      const okSectionCust = new VersionedSectionCustomization({ id: 70 });
+      (okSectionCust.hasErrors as jest.Mock) = jest.fn().mockReturnValue(false);
+      jest.spyOn(VersionedSectionCustomization.prototype, "create").mockResolvedValue(okSectionCust);
+
+      const okQuestionCust = new VersionedQuestionCustomization({ id: 80 });
+      (okQuestionCust.hasErrors as jest.Mock) = jest.fn().mockReturnValue(false);
+      jest.spyOn(VersionedQuestionCustomization.prototype, "create").mockResolvedValue(okQuestionCust);
 
       await snapshotCustomizationChildren(reference, mockContext, customization, created);
 

--- a/src/services/__tests__/templateCustomizationService.spec.ts
+++ b/src/services/__tests__/templateCustomizationService.spec.ts
@@ -1,7 +1,8 @@
 import { MyContext } from "../../context";
 import {
   TemplateCustomization,
-  TemplateCustomizationMigrationStatus
+  TemplateCustomizationMigrationStatus,
+  TemplateCustomizationStatus,
 } from "../../models/TemplateCustomization";
 import {
   handleFunderTemplateRepublication,

--- a/src/services/__tests__/templateCustomizationService.spec.ts
+++ b/src/services/__tests__/templateCustomizationService.spec.ts
@@ -2,7 +2,6 @@ import { MyContext } from "../../context";
 import {
   TemplateCustomization,
   TemplateCustomizationMigrationStatus,
-  TemplateCustomizationStatus,
 } from "../../models/TemplateCustomization";
 import {
   handleFunderTemplateRepublication,

--- a/src/services/guidanceService.ts
+++ b/src/services/guidanceService.ts
@@ -22,7 +22,6 @@ const GuidanceSourceType = {
   TEMPLATE_OWNER: 'TEMPLATE_OWNER' as const,
   USER_AFFILIATION: 'USER_AFFILIATION' as const,
   USER_SELECTED: 'USER_SELECTED' as const,
-  CUSTOMIZATION: 'CUSTOMIZATION' as const,
 };
 
 
@@ -329,7 +328,6 @@ export async function getGuidanceSourcesForPlan(
     // Get section tag IDs and section-level guidance
     let tagsMap: Record<number, string>;
     let guidanceText: string | null = null;
-    let templateOwnerGuidanceText: string | null = null;
 
     // If there is a versionedQuestionId provided, get tags and guidance for that question's section
     if (versionedQuestionId) {
@@ -357,7 +355,8 @@ export async function getGuidanceSourcesForPlan(
     }
 
 
-    // Fetch any active customization guidance for this section/question for the user's affiliation (which will override any template-level guidance)
+    // Fetch any active customization guidance for this section/question for the user's affiliation.
+    // This is displayed alongside the template owner's guidance.
     let customizationGuidanceText: string | null = null;
     if (userAffiliationUri) {
       if (versionedQuestionId) {

--- a/src/services/guidanceService.ts
+++ b/src/services/guidanceService.ts
@@ -574,21 +574,22 @@ export async function getGuidanceSourcesForPlan(
             });
           }
 
-          if (items.length > 0) {
-            guidanceSources.push({
-              id: `affiliation-${templateOwnerUri}`,
-              type: GuidanceSourceType.TEMPLATE_OWNER,
-              label: affiliation.displayName || affiliation.name,
-              shortName: (affiliation.acronyms && affiliation.acronyms[0]) ||
-                affiliation.displayName ||
-                affiliation.name,
-              orgURI: templateOwnerUri,
-              items,
-              hasGuidance: true
-            });
+          // Always include template owner as a source, even with no guidance for a custom section
+          // so that the Guidance Panel can show "no guidance available"
+          guidanceSources.push({
+            id: `affiliation-${templateOwnerUri}`,
+            type: GuidanceSourceType.TEMPLATE_OWNER,
+            label: affiliation.displayName || affiliation.name,
+            shortName: (affiliation.acronyms && affiliation.acronyms[0]) ||
+              affiliation.displayName ||
+              affiliation.name,
+            orgURI: templateOwnerUri,
+            items,
+            hasGuidance: true
+          });
 
-            processedOrgURIs.add(templateOwnerUri);
-          }
+          processedOrgURIs.add(templateOwnerUri);
+          
         }
       }
     }

--- a/src/services/guidanceService.ts
+++ b/src/services/guidanceService.ts
@@ -7,18 +7,24 @@ import { VersionedGuidanceGroup } from "../models/VersionedGuidanceGroup";
 import { VersionedGuidance } from "../models/VersionedGuidance";
 import { VersionedSection } from "../models/VersionedSection";
 import { VersionedQuestion } from "../models/VersionedQuestion";
+import { VersionedQuestionCustomization } from "../models/VersionedQuestionCustomization";
+import { VersionedSectionCustomization } from "../models/VersionedSectionCustomization";
+import { VersionedCustomSection } from "../models/VersionedCustomSection";
 import { Plan } from "../models/Plan";
 import { VersionedTemplate } from "../models/VersionedTemplate";
 import { prepareObjectForLogs } from "../logger";
 import { getCurrentDate } from "../utils/helpers";
 import { isSuperAdmin } from "./authService";
+import { GuidanceSourceType } from "../types";
 
-export enum GuidanceSourceType {
-  BEST_PRACTICE = 'BEST_PRACTICE',
-  TEMPLATE_OWNER = 'TEMPLATE_OWNER',
-  USER_AFFILIATION = 'USER_AFFILIATION',
-  USER_SELECTED = 'USER_SELECTED'
-}
+const GuidanceSourceType = {
+  BEST_PRACTICE: 'BEST_PRACTICE' as const,
+  TEMPLATE_OWNER: 'TEMPLATE_OWNER' as const,
+  USER_AFFILIATION: 'USER_AFFILIATION' as const,
+  USER_SELECTED: 'USER_SELECTED' as const,
+  CUSTOMIZATION: 'CUSTOMIZATION' as const,
+};
+
 
 export interface GuidanceItem {
   id?: number;
@@ -35,9 +41,9 @@ export interface GuidanceSource {
   items: GuidanceItem[];
   hasGuidance: boolean;
 }
-interface TagRow { 
-  id: number; 
-  name: string 
+interface TagRow {
+  id: number;
+  name: string
 };
 
 
@@ -288,7 +294,8 @@ export async function getGuidanceSourcesForPlan(
   context: MyContext,
   planId: number,
   versionedSectionId?: number,
-  versionedQuestionId?: number
+  versionedQuestionId?: number,
+  customSectionId?: number
 ): Promise<GuidanceSource[]> {
   const reference = 'getGuidanceSourcesForPlan';
 
@@ -322,6 +329,7 @@ export async function getGuidanceSourcesForPlan(
     // Get section tag IDs and section-level guidance
     let tagsMap: Record<number, string>;
     let guidanceText: string | null = null;
+    let templateOwnerGuidanceText: string | null = null;
 
     // If there is a versionedQuestionId provided, get tags and guidance for that question's section
     if (versionedQuestionId) {
@@ -339,6 +347,34 @@ export async function getGuidanceSourcesForPlan(
       tagsMap = await getSectionTags(context, versionedSectionId);
       const section = await VersionedSection.findById(reference, context, versionedSectionId);
       guidanceText = section?.guidance || null; // Section-level guidance
+    } else if (customSectionId) {
+
+      // Custom sections have their own tags and guidance
+      const customSection = await VersionedCustomSection.findById(reference, context, customSectionId);
+      if (!customSection) return [];
+      guidanceText = customSection?.guidance || null;
+      tagsMap = await getSectionTagsMap(context, versionedTemplateId);
+    }
+
+
+    // Fetch any active customization guidance for this section/question for the user's affiliation (which will override any template-level guidance)
+    let customizationGuidanceText: string | null = null;
+    if (userAffiliationUri) {
+      if (versionedQuestionId) {
+        const questionCustomization = await VersionedQuestionCustomization
+          .findActiveByTemplateAffiliationAndQuestion(
+            reference, context, userAffiliationUri, versionedQuestionId
+          );
+        customizationGuidanceText = questionCustomization?.guidanceText || null;
+
+      } else if (versionedSectionId) {
+        const sectionCustomization = await VersionedSectionCustomization
+          .findActiveByTemplateAffiliationAndSection(
+            reference, context, userAffiliationUri, versionedSectionId
+          );
+
+        customizationGuidanceText = sectionCustomization?.guidance || null;
+      }
     }
 
     // Get template owner info
@@ -348,29 +384,71 @@ export async function getGuidanceSourcesForPlan(
     // If there are no tag ids, then just return the guidanceText from the template owner
     const sectionTagIds = Object.keys(tagsMap).map(Number);
     if (sectionTagIds.length === 0) {
-      // If there's guidance text, return it as template owner's guidance
+      const result: GuidanceSource[] = [];
+
+      // Add primary guidance source (customization or template owner)
       if (guidanceText) {
-        if (templateOwnerUri) {
+        // Custom section guidance belongs to the institution, not the template owner
+        if (customSectionId && userAffiliationUri) {
+          const affiliation = await Affiliation.findByURI(reference, context, userAffiliationUri);
+          if (affiliation) {
+            result.push({
+              id: `customization-${userAffiliationUri}`,
+              type: GuidanceSourceType.USER_AFFILIATION,
+              label: affiliation.displayName || affiliation.name,
+              shortName: (affiliation.acronyms && affiliation.acronyms[0]) ||
+                affiliation.displayName || affiliation.name,
+              orgURI: userAffiliationUri,
+              items: [{ guidanceText }],
+              hasGuidance: true
+            });
+          }
+          // Base section/question guidance with no tags belongs to the template owner
+        } else if (templateOwnerUri) {
           const affiliation = await Affiliation.findByURI(reference, context, templateOwnerUri);
           if (affiliation) {
-            return [{
+            result.push({
               id: `affiliation-${templateOwnerUri}`,
               type: GuidanceSourceType.TEMPLATE_OWNER,
               label: affiliation.displayName || affiliation.name,
               shortName: (affiliation.acronyms && affiliation.acronyms[0]) ||
-                affiliation.displayName ||
-                affiliation.name,
+                affiliation.displayName || affiliation.name,
               orgURI: templateOwnerUri,
-              items: [{
-                title: affiliation.displayName || affiliation.name,
-                guidanceText
-              }],
+              items: [{ title: affiliation.displayName || affiliation.name, guidanceText }],
               hasGuidance: true
-            }];
+            });
           }
         }
       }
-      return [];
+
+      // Still load planGuidance selections so those orgs appear as pills ***
+      // This prevents the user from trying to re-add orgs that already have a planGuidance row
+      const userSelections = await PlanGuidance.findByPlanAndUserId(reference, context, planId, userId);
+      const processedOrgURIs = new Set<string>(result.map(s => s.orgURI));
+
+      for (const selection of userSelections) {
+        const affiliationUri = selection.affiliationId;
+        if (!affiliationUri || processedOrgURIs.has(affiliationUri)) continue;
+
+        const affiliation = await Affiliation.findByURI(reference, context, affiliationUri);
+        if (!affiliation) continue;
+
+        // Include with empty items — they're selected but have no guidance for this custom section.
+        // They still need to appear as pills so the modal shows them as "already added".
+        result.push({
+          id: `affiliation-${affiliationUri}`,
+          type: GuidanceSourceType.USER_SELECTED,
+          label: affiliation.displayName || affiliation.name,
+          shortName: (affiliation.acronyms && affiliation.acronyms[0]) ||
+            affiliation.displayName || affiliation.name,
+          orgURI: affiliationUri,
+          items: [],
+          hasGuidance: false
+        });
+        processedOrgURIs.add(affiliationUri);
+      }
+
+      return result; // Includes all selected orgs
     }
 
     // Get user-selected affiliations from planGuidance table
@@ -435,6 +513,17 @@ export async function getGuidanceSourcesForPlan(
 
           const items = groupGuidanceByTag(tagBasedGuidance, sectionTagIds, tagsMap);
 
+          // For custom sections, the section's guidanceText IS the user's content — prepend it
+          // For versioned sections, customizationGuidanceText is the override — prepend it
+          const customGuidanceText = customSectionId ? guidanceText : customizationGuidanceText;
+          if (customGuidanceText) {
+            items.unshift({
+              title: affiliation.displayName || affiliation.name,
+              guidanceText: customGuidanceText
+            });
+          }
+
+
           if (items.length > 0) {
             guidanceSources.push({
               id: `affiliation-${userAffiliationUri}`,
@@ -476,8 +565,10 @@ export async function getGuidanceSourcesForPlan(
 
           const items = groupGuidanceByTag(tagBasedGuidance, sectionTagIds, tagsMap);
 
-          // If there's section-level guidance, add it FIRST
-          if (guidanceText) {
+          // Only prepend section-level guidanceText for versioned sections.
+          // For custom sections, the section was created by the user's institution —
+          // the template owner has no section-level guidance to contribute here.
+          if (guidanceText && !customSectionId) {
             items.unshift({
               title: affiliation.displayName || affiliation.name,
               guidanceText

--- a/src/services/templateCustomizationPublishHelpers.ts
+++ b/src/services/templateCustomizationPublishHelpers.ts
@@ -1,0 +1,236 @@
+import { MyContext } from "../context";
+import { VersionedTemplateCustomization } from "../models/VersionedTemplateCustomization";
+import { VersionedSection } from "../models/VersionedSection";
+import { VersionedQuestion } from "../models/VersionedQuestion";
+import { VersionedCustomSection } from "../models/VersionedCustomSection";
+import { VersionedCustomQuestion } from "../models/VersionedCustomQuestion";
+import { VersionedSectionCustomization } from "../models/VersionedSectionCustomization";
+import { VersionedQuestionCustomization } from "../models/VersionedQuestionCustomization";
+import { CustomSection, PinnedSectionTypeEnum } from "../models/CustomSection";
+import { CustomQuestion } from "../models/CustomQuestion";
+import { SectionCustomization } from "../models/SectionCustomization";
+import { QuestionCustomization } from "../models/QuestionCustomization";
+
+/**
+ * A minimal interface representing the shape of a TemplateCustomization that
+ * the helpers need to read from and write errors onto. Using an interface here
+ * (rather than importing the class) avoids a circular dependency:
+ *   TemplateCustomization → helpers → TemplateCustomization
+ */
+export interface PublishableCustomization {
+  id?: number;
+  currentVersionedTemplateId: number;
+  addError(field: string, message: string): void;
+  hasErrors(): boolean;
+}
+
+/**
+ * Snapshot all child customization records into their versioned counterparts.
+ * Any failure adds an error onto the customization object rather than throwing.
+ *
+ * @param reference The reference string for logging.
+ * @param context The Apollo context.
+ * @param customization The TemplateCustomization being published.
+ * @param created The newly created VersionedTemplateCustomization snapshot.
+ */
+export const snapshotCustomizationChildren = async (
+  reference: string,
+  context: MyContext,
+  customization: PublishableCustomization,
+  created: VersionedTemplateCustomization
+): Promise<void> => {
+  // Snapshot custom sections and their questions into versioned equivalents
+  const customSections = await CustomSection.findByCustomizationId(
+    reference, context, customization.id);
+
+  for (const section of customSections) {
+    const versionedSection = new VersionedCustomSection({
+      versionedTemplateCustomizationId: created.id,
+      customSectionId: section.id,
+      pinnedVersionedSectionType: section.pinnedSectionType,
+      pinnedVersionedSectionId: section.pinnedSectionId,
+      name: section.name,
+      introduction: section.introduction,
+      requirements: section.requirements,
+      guidance: section.guidance,
+    });
+    const createdSection = await versionedSection.create(context);
+
+    if (!createdSection || createdSection.hasErrors()) {
+      customization.addError('general', `Unable to version custom section: ${section.name}`);
+      continue;
+    }
+
+    // Snapshot custom questions belonging to this custom section
+    const customQuestions = await CustomQuestion.findByCustomizationAndSectionId(
+      reference, context, customization.id, PinnedSectionTypeEnum.CUSTOM, section.id);
+
+    for (const question of customQuestions) {
+      const versionedQuestion = new VersionedCustomQuestion({
+        versionedTemplateCustomizationId: created.id,
+        customQuestionId: question.id,
+        versionedSectionType: question.sectionType,
+        versionedSectionId: question.sectionId,
+        pinnedVersionedQuestionType: question.pinnedQuestionType ?? null,
+        pinnedVersionedQuestionId: question.pinnedQuestionId ?? null,
+        questionText: question.questionText,
+        json: question.json,
+        requirementText: question.requirementText ?? null,
+        guidanceText: question.guidanceText ?? null,
+        sampleText: question.sampleText ?? null,
+        useSampleTextAsDefault: question.useSampleTextAsDefault ?? false,
+        required: question.required ?? false,
+      });
+      const createdQuestion = await versionedQuestion.create(context);
+
+      if (!createdQuestion || createdQuestion.hasErrors()) {
+        customization.addError(
+          'general',
+          `Unable to version custom question in section: ${section.name}`
+        );
+      }
+    }
+  }
+
+  // Snapshot custom questions attached to BASE sections (not covered by the loop above)
+  const baseCustomQuestions = await CustomQuestion.findByCustomizationAndSectionType(
+    reference, context, customization.id, PinnedSectionTypeEnum.BASE);
+
+  for (const question of baseCustomQuestions) {
+    const versionedQuestion = new VersionedCustomQuestion({
+      versionedTemplateCustomizationId: created.id,
+      customQuestionId: question.id,
+      versionedSectionType: question.sectionType,
+      versionedSectionId: question.sectionId,
+      pinnedVersionedQuestionType: question.pinnedQuestionType ?? null,
+      pinnedVersionedQuestionId: question.pinnedQuestionId ?? null,
+      questionText: question.questionText,
+      json: question.json,
+      requirementText: question.requirementText ?? null,
+      guidanceText: question.guidanceText ?? null,
+      sampleText: question.sampleText ?? null,
+      useSampleTextAsDefault: question.useSampleTextAsDefault ?? false,
+      required: question.required ?? false,
+    });
+    const createdQuestion = await versionedQuestion.create(context);
+
+    if (!createdQuestion || createdQuestion.hasErrors()) {
+      customization.addError(
+        'general',
+        `Unable to version custom question for base section id: ${question.sectionId}`
+      );
+    }
+  }
+
+  // Snapshot sectionCustomizations into versionedSectionCustomizations
+  const sectionCustomizations = await SectionCustomization.findByCustomizationId(
+    reference, context, customization.id);
+
+  for (const sectionCust of sectionCustomizations) {
+    const versionedSectionRows = await VersionedSection.query(
+      context,
+      `SELECT id FROM versionedSections
+         WHERE sectionId = ? AND versionedTemplateId = ? LIMIT 1`,
+      [sectionCust.sectionId.toString(), customization.currentVersionedTemplateId.toString()],
+      reference
+    );
+
+    if (!versionedSectionRows?.length) {
+      customization.addError(
+        'general',
+        `Unable to find versioned section for sectionId: ${sectionCust.sectionId}`
+      );
+      continue;
+    }
+
+    const versionedSectionCust = new VersionedSectionCustomization({
+      versionedTemplateCustomizationId: created.id,
+      sectionCustomizationId: sectionCust.id,
+      versionedSectionId: versionedSectionRows[0].id,
+      guidance: sectionCust.guidance,
+      createdById: context.token?.id,
+      modifiedById: context.token?.id,
+    });
+    const createdSectionCust = await versionedSectionCust.create(context);
+
+    if (!createdSectionCust || createdSectionCust.hasErrors()) {
+      customization.addError(
+        'general',
+        `Unable to version section customization for sectionId: ${sectionCust.sectionId}`
+      );
+    }
+  }
+
+  // Snapshot questionCustomizations into versionedQuestionCustomizations
+  const questionCustomizations = await QuestionCustomization.findByCustomizationId(
+    reference, context, customization.id);
+
+  for (const questionCust of questionCustomizations) {
+    const versionedQuestionRows = await VersionedQuestion.query(
+      context,
+      `SELECT id FROM versionedQuestions
+         WHERE questionId = ? AND versionedTemplateId = ? LIMIT 1`,
+      [questionCust.questionId.toString(), customization.currentVersionedTemplateId.toString()],
+      reference
+    );
+
+    if (!versionedQuestionRows?.length) {
+      customization.addError(
+        'general',
+        `Unable to find versioned question for questionId: ${questionCust.questionId}`
+      );
+      continue;
+    }
+
+    const versionedQuestionCust = new VersionedQuestionCustomization({
+      versionedTemplateCustomizationId: created.id,
+      questionCustomizationId: questionCust.id,
+      versionedQuestionId: versionedQuestionRows[0].id,
+      guidanceText: questionCust.guidanceText ?? null,
+      sampleText: questionCust.sampleText ?? null,
+      createdById: context.token?.id,
+      modifiedById: context.token?.id,
+    });
+    const createdQuestionCust = await versionedQuestionCust.create(context);
+
+    if (!createdQuestionCust || createdQuestionCust.hasErrors()) {
+      customization.addError(
+        'general',
+        `Unable to version question customization for questionId: ${questionCust.questionId}`
+      );
+    }
+  }
+};
+
+/**
+ * Roll back an incomplete published snapshot by deleting the snapshot record.
+ * The child tables (versionedCustomSections, versionedCustomQuestions,
+ * versionedSectionCustomizations, versionedQuestionCustomizations) are cleaned
+ * up automatically via ON DELETE CASCADE on their versionedTemplateCustomizationId
+ * FK constraints. Also re-activates the prior published version if one existed.
+ *
+ * @param context The Apollo context.
+ * @param createdVersionId The id of the incomplete VersionedTemplateCustomization.
+ * @param priorPublishedVersionId The id of the version to re-activate, if any.
+ */
+export const rollbackPublishedSnapshot = async (
+  context: MyContext,
+  createdVersionId: number,
+  priorPublishedVersionId: number | undefined
+): Promise<void> => {
+  const ref = 'rollbackPublishedSnapshot';
+  await VersionedTemplateCustomization.delete(
+    context,
+    VersionedTemplateCustomization.tableName,
+    createdVersionId,
+    ref
+  );
+  if (priorPublishedVersionId) {
+    const priorVer = await VersionedTemplateCustomization.findById(
+      ref, context, priorPublishedVersionId);
+    if (priorVer) {
+      priorVer.active = true;
+      await priorVer.update(context, true);
+    }
+  }
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1311,10 +1311,19 @@ export type MetadataStandardSearchResults = PaginatedQueryResults & {
   totalCount?: Maybe<Scalars['Int']['output']>;
 };
 
+/** Direction to move a custom question relative to the pinned question */
+export type MoveCustomQuestionDirection =
+  /** Move the question below the pinned question */
+  | 'DOWN'
+  /** Move the question above the pinned question */
+  | 'UP';
+
 /** Move a custom question to a different position within the section (null means move to the top of the section) */
 export type MoveCustomQuestionInput = {
   /** the id of the custom question to move */
   customQuestionId: Scalars['Int']['input'];
+  /** Direction to move the question relative to the pinnedQuestion (UP or DOWN) */
+  direction: MoveCustomQuestionDirection;
   /** The identifier of the question this new custom question should appear after (null means it is the first question in the section) */
   pinnedQuestionId?: InputMaybe<Scalars['Int']['input']>;
   /** The type of the question this new custom question should appear after (null means it is the first question in the section) */
@@ -3359,6 +3368,7 @@ export type QueryGuidanceGroupsArgs = {
 
 
 export type QueryGuidanceSourcesForPlanArgs = {
+  customSectionId?: InputMaybe<Scalars['Int']['input']>;
   planId: Scalars['Int']['input'];
   versionedQuestionId?: InputMaybe<Scalars['Int']['input']>;
   versionedSectionId?: InputMaybe<Scalars['Int']['input']>;
@@ -5846,6 +5856,7 @@ export type ResolversTypes = {
   MetadataStandard: ResolverTypeWrapper<MetadataStandard>;
   MetadataStandardErrors: ResolverTypeWrapper<MetadataStandardErrors>;
   MetadataStandardSearchResults: ResolverTypeWrapper<MetadataStandardSearchResults>;
+  MoveCustomQuestionDirection: MoveCustomQuestionDirection;
   MoveCustomQuestionInput: MoveCustomQuestionInput;
   MoveCustomSectionInput: MoveCustomSectionInput;
   Mutation: ResolverTypeWrapper<Record<PropertyKey, never>>;


### PR DESCRIPTION
## Description

- Added a new data-migration script to add `ON DELETE CASCADE` to `versionedTemplateCustomizationId FKs on all four child tables. Previously these had no cascade, requiring manual deletion in application code when rolling back a published snapshot.
- Added another new data-migration script to add `ON DELETE CASCADE` to `templateCustomizations` to ensure that when one is deleted, all associated versioned records are also deleted to prevent any orphaned references.
- Added `findByPosition` function to `CustomQuestion` to assist with reordering of custom questions
- Added `findActiveByTemplateAffiliationAndQuestion` to `VersionedQuestionCustomization` and `findActiveByTemplateAffiliationAndSection` to `VersionedSectionCustomization` to help surface custom guidance
- Added `MoveCustomQuestionDirection` enum to `questionCustomization` schema to help with updating ordering of questions
- Added new `templateCustomizationPublishHelpers.ts` service to help update snapshot child customization records when publishing a templateCustomization
- Updated the `publish` function in `TemplateCustomization` to `snapshotCustomizationChildren` and `rollbackPublishedSnapshot` helper functions to snapshot all child records into published versions
- Updated `findByVersionedCustomSectionId` and `findByVersionedSectionIdAndType` in `VersionedCustomQuestion` to only grab records related to `active` `versionedTemplateCustomization`
- Updated `guidanceSourcesForPlan` resolver in `guidance` resolver to pass in `customSectionId`
- Updated `moveCustomQuestion` resolver in `questionCustomization` resolver to help with accurate reordering. Added `direction` variable to help with that
- Updated `getGuidanceSourcesForPlan` function in `guidanceService`

Fixes # ([171](https://github.com/CDLUC3/dmptool-doc/issues/171))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested and tested with updated unit tests


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules