### PR TITLE
Added publishedCustomQuestion to get custom questions, and updated th…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated sql query in `findActiveByTemplateAffiliationAndQuestion` function in `VersionedQuestionCustomization` model to include `affiliationId` so that we can get the name of the org that made the customization [#173]
+- Updated `publishedQuestion` resolver in `versionedQuestion.ts` to return customization info, including customized sample answer and name of org that made the customization [#173]
+- Updated `VersionedQuestion` schema to include `customizationId`, `customizationGuidanceText`, `customizationSampleText` and `customizationOwnerAffiliation` fields [#173]
 - Updated `guidanceSourcesForPlan` query to pass in `customQuestionId` and updated `getGuidanceSourcesForPlan` service to add `customQuestion` guidance [#172]
 - Updated renovate config to rebase when behind the base branch
 - Updated `Answer` model with `versionedCustomSectionId` and `versionedCustomQuestionId`, and added new `findFilledAnswersByCustomQuestionIds` and `findByPlanIdAndVersionedCustomQuestionId` functions, and updated `isValid` function to account for new id fields, and updated `create` function to check both `versionedQuestionId` and `versionedCustomQuestionId` for already existing answer [#159]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated `answerByVersionedQuestionId` query and `addAnswer` mutation to pass in `versionedCustomSectionId` and `versionedCustomQuestionid` variables so that we can get and save the correct answers [#173]
 - Updated sql query in `findActiveByTemplateAffiliationAndQuestion` function in `VersionedQuestionCustomization` model to include `affiliationId` so that we can get the name of the org that made the customization [#173]
 - Updated `publishedQuestion` resolver in `versionedQuestion.ts` to return customization info, including customized sample answer and name of org that made the customization [#173]
 - Updated `VersionedQuestion` schema to include `customizationId`, `customizationGuidanceText`, `customizationSampleText` and `customizationOwnerAffiliation` fields [#173]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.1.0
 
 ### Added
-- Added `publishedCustomQuestion` query resolver and added to schema [#172]
+- Added `publishedCustomQuestion` query resolver and added to schema [#173]
 - Added `ON DELETE CASCADE` sql migration script for deletion of `versionedTemplateCustomization` and `templateCustomization` FKs [#171]
 - Added `findByPosition` function to `CustomQuestion` to assist with reordering of custom questions [#171]
 - Added `findActiveByTemplateAffiliationAndQuestion` to `VersionedQuestionCustomization` and `findActiveByTemplateAffiliationAndSection` to `VersionedSectionCustomization` to help surface custom guidance [#171]
@@ -60,7 +60,7 @@
 - Updated sql query in `findActiveByTemplateAffiliationAndQuestion` function in `VersionedQuestionCustomization` model to include `affiliationId` so that we can get the name of the org that made the customization [#173]
 - Updated `publishedQuestion` resolver in `versionedQuestion.ts` to return customization info, including customized sample answer and name of org that made the customization [#173]
 - Updated `VersionedQuestion` schema to include `customizationId`, `customizationGuidanceText`, `customizationSampleText` and `customizationOwnerAffiliation` fields [#173]
-- Updated `guidanceSourcesForPlan` query to pass in `customQuestionId` and updated `getGuidanceSourcesForPlan` service to add `customQuestion` guidance [#172]
+- Updated `guidanceSourcesForPlan` query to pass in `customQuestionId` and updated `getGuidanceSourcesForPlan` service to add `customQuestion` guidance [#173]
 - Updated renovate config to rebase when behind the base branch
 - Updated `Answer` model with `versionedCustomSectionId` and `versionedCustomQuestionId`, and added new `findFilledAnswersByCustomQuestionIds` and `findByPlanIdAndVersionedCustomQuestionId` functions, and updated `isValid` function to account for new id fields, and updated `create` function to check both `versionedQuestionId` and `versionedCustomQuestionId` for already existing answer [#159]
 - Updated `publishedQuestions` query in `versionedQuestion` resolver to return both `BASE` and `CUSTOM` versioned questions for the given versionedSectionId. Also, added `publishedCustomQuestions` query to return the `customQuestions` associated with a `customSection` [#159]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.1.0
 
 ### Added
+- Added `publishedCustomQuestion` query resolver and added to schema [#172]
 - Added `ON DELETE CASCADE` sql migration script for deletion of `versionedTemplateCustomization` and `templateCustomization` FKs [#171]
 - Added `findByPosition` function to `CustomQuestion` to assist with reordering of custom questions [#171]
 - Added `findActiveByTemplateAffiliationAndQuestion` to `VersionedQuestionCustomization` and `findActiveByTemplateAffiliationAndSection` to `VersionedSectionCustomization` to help surface custom guidance [#171]
@@ -56,7 +57,7 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
-feature/171/JS-update-guidance-resolver-to-include-custom-guidance
+- Updated `guidanceSourcesForPlan` query to pass in `customQuestionId` and updated `getGuidanceSourcesForPlan` service to add `customQuestion` guidance [#172]
 - Updated renovate config to rebase when behind the base branch
 - Updated `Answer` model with `versionedCustomSectionId` and `versionedCustomQuestionId`, and added new `findFilledAnswersByCustomQuestionIds` and `findByPlanIdAndVersionedCustomQuestionId` functions, and updated `isValid` function to account for new id fields, and updated `create` function to check both `versionedQuestionId` and `versionedCustomQuestionId` for already existing answer [#159]
 - Updated `publishedQuestions` query in `versionedQuestion` resolver to return both `BASE` and `CUSTOM` versioned questions for the given versionedSectionId. Also, added `publishedCustomQuestions` query to return the `customQuestions` associated with a `customSection` [#159]

--- a/data-migrations/2026-04-08-update-chk-answer-question-type.sql
+++ b/data-migrations/2026-04-08-update-chk-answer-question-type.sql
@@ -1,0 +1,31 @@
+-- The answers table now includes versionedCustomSectionId and versionedCustomQuestionId. We can have three valid combinations of these four fields:
+-- 1) Base question in a base section: versionedSectionId and versionedQuestionId are non-null, versionedCustomSectionId and versionedCustomQuestionId are null
+-- 2) Custom question in a custom section: versionedCustomSectionId and versionedCustomQuestionId are non-null, versionedSectionId and versionedQuestionId are null
+-- 3) Custom question pinned to a base section: versionedSectionId and versionedCustomQuestionId are non-null, versionedQuestionId and versionedCustomSectionId are null
+ALTER TABLE `answers`
+  DROP CONSTRAINT `chk_answer_question_type`,
+  ADD CONSTRAINT `chk_answer_question_type` CHECK (
+    -- Base question in a base section
+    (
+      versionedSectionId IS NOT NULL AND
+      versionedQuestionId IS NOT NULL AND
+      versionedCustomSectionId IS NULL AND
+      versionedCustomQuestionId IS NULL
+    )
+    OR
+    -- Custom question in a custom section
+    (
+      versionedCustomSectionId IS NOT NULL AND
+      versionedCustomQuestionId IS NOT NULL AND
+      versionedSectionId IS NULL AND
+      versionedQuestionId IS NULL
+    )
+    OR
+    -- Custom question pinned to a base section
+    (
+      versionedSectionId IS NOT NULL AND
+      versionedCustomQuestionId IS NOT NULL AND
+      versionedQuestionId IS NULL AND
+      versionedCustomSectionId IS NULL
+    )
+  );

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,6 +78,7 @@ services:
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
       - DEBUG=${DEBUG:-0}
       - SERVICES=ses,sqs,lambda,ssm,logs,events,dynamodb
+      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN}
     volumes:
       - "./docker/localstack:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,7 +78,6 @@ services:
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
       - DEBUG=${DEBUG:-0}
       - SERVICES=ses,sqs,lambda,ssm,logs,events,dynamodb
-      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN}
     volumes:
       - "./docker/localstack:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/src/models/Answer.ts
+++ b/src/models/Answer.ts
@@ -44,12 +44,14 @@ export class Answer extends MySqlModel {
   async isValid(): Promise<boolean> {
     await super.isValid();
     const hasBase = !!this.versionedSectionId && !!this.versionedQuestionId;
-    const hasCustom = !!this.versionedCustomSectionId && !!this.versionedCustomQuestionId;
+    const hasCustomInCustomSection = !!this.versionedCustomSectionId && !!this.versionedCustomQuestionId;
+    const hasCustomInBaseSection = !!this.versionedSectionId && !!this.versionedCustomQuestionId;
 
-    if (!hasBase && !hasCustom) {
+    // three valid combinations: 1) base section and question, 2) custom section and custom question, 3) base section and custom question (for when a custom question is added to a base section)
+    if (!hasBase && !hasCustomInCustomSection && !hasCustomInBaseSection) {
       this.addError('general', 'Answer must belong to either a base or custom section and question');
     }
-    if (hasBase && hasCustom) {
+    if (hasBase && hasCustomInCustomSection) {
       this.addError('general', 'Answer cannot belong to both a base and custom section simultaneously');
     }
 
@@ -131,7 +133,7 @@ export class Answer extends MySqlModel {
       return row;
     });
 
-// Only stringify and re-assign if we actually changed something
+    // Only stringify and re-assign if we actually changed something
     if (modified) {
       this.json = JSON.stringify(parsedJSON);
     }
@@ -157,8 +159,12 @@ export class Answer extends MySqlModel {
       } else {
         // Save the record and then fetch it
         const newId = await Answer.insert(context, Answer.tableName, this, reference);
-        const response = await Answer.findById(reference, context, newId);
-        return response;
+        if (!newId) {
+          this.addError('general', 'Failed to save answer');
+        } else {
+          const response = await Answer.findById(reference, context, newId);
+          return response;
+        }
       }
     }
     // Otherwise return as-is with all the errors

--- a/src/models/VersionedQuestionCustomization.ts
+++ b/src/models/VersionedQuestionCustomization.ts
@@ -235,18 +235,18 @@ export class VersionedQuestionCustomization extends MySqlModel {
     return Array.isArray(results) && results.length > 0 ? results.map(r => new VersionedQuestionCustomization(r)) : [];
   }
 
-/**
- * Find the active versioned question customization for a given template and affiliation.
- * Used to surface customization guidance in the plan guidance panel.
- * 
- *
- * @param reference The reference to use for logging errors.
- * @param context The Apollo context.
- * @param templateId The base template id.
- * @param affiliationId The affiliation id.
- * @param versionedQuestionId The versioned question id.
- * @returns The active versioned question customization, or undefined if none exists.
- */
+  /**
+   * Find the active versioned question customization for a given template and affiliation.
+   * Used to surface customization guidance in the plan guidance panel.
+   * 
+   *
+   * @param reference The reference to use for logging errors.
+   * @param context The Apollo context.
+   * @param templateId The base template id.
+   * @param affiliationId The affiliation id.
+   * @param versionedQuestionId The versioned question id.
+   * @returns The active versioned question customization, or undefined if none exists.
+   */
   static async findActiveByTemplateAffiliationAndQuestion(
     reference: string,
     context: MyContext,
@@ -255,7 +255,8 @@ export class VersionedQuestionCustomization extends MySqlModel {
   ): Promise<VersionedQuestionCustomization | undefined> {
     const results = await VersionedQuestionCustomization.query(
       context,
-      `SELECT vqc.* FROM ${VersionedQuestionCustomization.tableName} AS vqc
+      `SELECT vqc.*, vtc.affiliationId as customizationAffiliationId
+      FROM ${VersionedQuestionCustomization.tableName} AS vqc
      JOIN versionedTemplateCustomizations AS vtc
        ON vqc.versionedTemplateCustomizationId = vtc.id
      WHERE vtc.active = 1

--- a/src/models/__tests__/Answer.spec.ts
+++ b/src/models/__tests__/Answer.spec.ts
@@ -492,6 +492,8 @@ describe('create', () => {
     (Answer.findByPlanIdAndVersionedQuestionId as jest.Mock) = mockFindByPlanIdAndVersionedQuestionId;
     mockFindByPlanIdAndVersionedQuestionId.mockResolvedValueOnce(null);
 
+    insertQuery.mockResolvedValueOnce(casual.integer(1, 9999));
+
     const mockFindById = jest.fn();
     (Answer.findById as jest.Mock) = mockFindById;
     mockFindById.mockResolvedValueOnce(answer);

--- a/src/models/__tests__/VersionedQuestionCustomization.spec.ts
+++ b/src/models/__tests__/VersionedQuestionCustomization.spec.ts
@@ -512,7 +512,8 @@ describe("VersionedQuestionCustomization", () => {
   });
 
   describe("findActiveByTemplateAffiliationAndQuestion", () => {
-    const expectedSql = `SELECT vqc.* FROM versionedQuestionCustomizations AS vqc
+    const expectedSql = `SELECT vqc.*, vtc.affiliationId as customizationAffiliationId
+      FROM versionedQuestionCustomizations AS vqc
      JOIN versionedTemplateCustomizations AS vtc
        ON vqc.versionedTemplateCustomizationId = vtc.id
      WHERE vtc.active = 1

--- a/src/resolvers/__tests__/guidance.spec.ts
+++ b/src/resolvers/__tests__/guidance.spec.ts
@@ -250,8 +250,8 @@ describe('guidance resolvers', () => {
   describe('Query.guidanceSourcesForPlan', () => {
     beforeEach(() => {
       query = `
-        query guidanceSourcesForPlan($planId: Int!, $versionedSectionId: Int, $versionedQuestionId: Int) {
-          guidanceSourcesForPlan(planId: $planId, versionedSectionId: $versionedSectionId, versionedQuestionId: $versionedQuestionId) {
+        query guidanceSourcesForPlan($planId: Int!, $versionedSectionId: Int, $versionedQuestionId: Int, $customSectionId: Int, $customQuestionId: Int) {
+          guidanceSourcesForPlan(planId: $planId, versionedSectionId: $versionedSectionId, versionedQuestionId: $versionedQuestionId, customSectionId: $customSectionId, customQuestionId: $customQuestionId) {
             id
             type
             label
@@ -304,6 +304,7 @@ describe('guidance resolvers', () => {
         1,
         5,
         10,
+        undefined,
         undefined
       );
     });
@@ -329,6 +330,56 @@ describe('guidance resolvers', () => {
 
       expect(result.body.singleResult.errors).toBeDefined();
       expect(result.body.singleResult.errors[0].message).toEqual('Forbidden');
+    });
+
+    it('should call getGuidanceSourcesForPlan with customSectionId when provided', async () => {
+      const mockPlan = { id: 1, projectId: 100 };
+      const mockProject = { id: 100 };
+
+      (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
+      (Project.findById as jest.Mock).mockResolvedValue(mockProject);
+      (hasPermissionOnProject as jest.Mock).mockResolvedValue(true);
+      (getGuidanceSourcesForPlan as jest.Mock).mockResolvedValue([]);
+
+      await executeQuery(
+        query,
+        { planId: 1, customSectionId: 7 },
+        researcherToken
+      );
+
+      expect(getGuidanceSourcesForPlan).toHaveBeenCalledWith(
+        expect.any(Object),
+        1,
+        undefined,
+        undefined,
+        7,
+        undefined
+      );
+    });
+
+    it('should call getGuidanceSourcesForPlan with customQuestionId when provided', async () => {
+      const mockPlan = { id: 1, projectId: 100 };
+      const mockProject = { id: 100 };
+
+      (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
+      (Project.findById as jest.Mock).mockResolvedValue(mockProject);
+      (hasPermissionOnProject as jest.Mock).mockResolvedValue(true);
+      (getGuidanceSourcesForPlan as jest.Mock).mockResolvedValue([]);
+
+      await executeQuery(
+        query,
+        { planId: 1, versionedSectionId: 5, customQuestionId: 42 },
+        researcherToken
+      );
+
+      expect(getGuidanceSourcesForPlan).toHaveBeenCalledWith(
+        expect.any(Object),
+        1,
+        5,
+        undefined,
+        undefined,
+        42
+      );
     });
   });
 

--- a/src/resolvers/__tests__/versionedQuestion.spec.ts
+++ b/src/resolvers/__tests__/versionedQuestion.spec.ts
@@ -18,6 +18,7 @@ import { Answer } from '../../models/Answer';
 import { VersionedQuestionCondition } from '../../models/VersionedQuestionCondition';
 import { VersionedTemplate } from '../../models/VersionedTemplate';
 import { VersionedTemplateCustomization } from '../../models/VersionedTemplateCustomization';
+import { VersionedQuestionCustomization } from '../../models/VersionedQuestionCustomization';
 import { Affiliation } from '../../models/Affiliation';
 import { UserRole } from "../../models/User";
 import { buildContext, mockToken } from "../../__mocks__/context";
@@ -29,6 +30,7 @@ jest.mock('../../models/VersionedQuestion');
 jest.mock('../../models/VersionedCustomQuestion');
 jest.mock('../../models/Answer');
 jest.mock('../../models/VersionedQuestionCondition');
+jest.mock('../../models/VersionedQuestionCustomization');
 
 let testServer: ApolloServer;
 let affiliationId: string;
@@ -112,6 +114,7 @@ describe('versionedQuestion resolvers', () => {
 
       (VersionedQuestion.findById as jest.Mock).mockResolvedValue(mockQuestion);
       (VersionedQuestionCondition.findByVersionedQuestionId as jest.Mock).mockResolvedValue([]);
+      (VersionedQuestionCustomization.findActiveByTemplateAffiliationAndQuestion as jest.Mock).mockResolvedValue(null);
 
       const result = await executeQuery(query, { versionedQuestionId: 1 }, researcherToken);
 
@@ -123,10 +126,96 @@ describe('versionedQuestion resolvers', () => {
         expect.any(Object),
         1
       );
+      expect(VersionedQuestionCustomization.findActiveByTemplateAffiliationAndQuestion).toHaveBeenCalledWith(
+        'publishedQuestion resolver',
+        expect.any(Object),
+        affiliationId,
+        1
+      );
+    });
+
+    it('should return customization fields when a customization exists', async () => {
+      const mockQuestion = {
+        id: 1,
+        questionText: 'What is your data management plan?',
+        requirementText: 'Required by funder',
+        guidanceText: 'Original guidance',
+        sampleText: 'Original sample',
+        required: true,
+        versionedTemplateId: 10,
+        versionedSectionId: 5,
+      };
+      const mockCustomization = {
+        id: 99,
+        guidanceText: 'Org custom guidance',
+        sampleText: 'Org custom sample',
+      };
+
+      (VersionedQuestion.findById as jest.Mock).mockResolvedValue(mockQuestion);
+      (VersionedQuestionCondition.findByVersionedQuestionId as jest.Mock).mockResolvedValue([]);
+      (VersionedQuestionCustomization.findActiveByTemplateAffiliationAndQuestion as jest.Mock).mockResolvedValue(mockCustomization);
+
+      const custQuery = `
+        query publishedQuestion($versionedQuestionId: Int!) {
+          publishedQuestion(versionedQuestionId: $versionedQuestionId) {
+            id
+            guidanceText
+            sampleText
+            customizationId
+            customizationGuidanceText
+            customizationSampleText
+          }
+        }
+      `;
+
+      const result = await executeQuery(custQuery, { versionedQuestionId: 1 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      const q = result.body.singleResult.data.publishedQuestion;
+      expect(q.id).toEqual(1);
+      expect(q.guidanceText).toEqual('Original guidance');
+      expect(q.sampleText).toEqual('Original sample');
+      expect(q.customizationId).toEqual(99);
+      expect(q.customizationGuidanceText).toEqual('Org custom guidance');
+      expect(q.customizationSampleText).toEqual('Org custom sample');
+    });
+
+    it('should return null customization fields when no customization exists', async () => {
+      const mockQuestion = {
+        id: 1,
+        questionText: 'Test question',
+        required: false,
+        versionedTemplateId: 10,
+        versionedSectionId: 5,
+      };
+
+      (VersionedQuestion.findById as jest.Mock).mockResolvedValue(mockQuestion);
+      (VersionedQuestionCondition.findByVersionedQuestionId as jest.Mock).mockResolvedValue([]);
+      (VersionedQuestionCustomization.findActiveByTemplateAffiliationAndQuestion as jest.Mock).mockResolvedValue(null);
+
+      const custQuery = `
+        query publishedQuestion($versionedQuestionId: Int!) {
+          publishedQuestion(versionedQuestionId: $versionedQuestionId) {
+            id
+            customizationId
+            customizationGuidanceText
+            customizationSampleText
+          }
+        }
+      `;
+
+      const result = await executeQuery(custQuery, { versionedQuestionId: 1 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      const q = result.body.singleResult.data.publishedQuestion;
+      expect(q.customizationId).toBeNull();
+      expect(q.customizationGuidanceText).toBeNull();
+      expect(q.customizationSampleText).toBeNull();
     });
 
     it('should return null when question is not found', async () => {
       (VersionedQuestion.findById as jest.Mock).mockResolvedValue(null);
+      (VersionedQuestionCustomization.findActiveByTemplateAffiliationAndQuestion as jest.Mock).mockResolvedValue(null);
 
       const result = await executeQuery(query, { versionedQuestionId: 999 }, researcherToken);
 
@@ -156,6 +245,7 @@ describe('versionedQuestion resolvers', () => {
 
       (VersionedQuestion.findById as jest.Mock).mockResolvedValue(mockQuestion);
       (VersionedQuestionCondition.findByVersionedQuestionId as jest.Mock).mockResolvedValue(mockConditions);
+      (VersionedQuestionCustomization.findActiveByTemplateAffiliationAndQuestion as jest.Mock).mockResolvedValue(null);
 
       const result = await executeQuery(query, { versionedQuestionId: 1 }, researcherToken);
 
@@ -182,6 +272,7 @@ describe('versionedQuestion resolvers', () => {
 
       (VersionedQuestion.findById as jest.Mock).mockResolvedValue(mockQuestion);
       (VersionedQuestionCondition.findByVersionedQuestionId as jest.Mock).mockResolvedValue([]);
+      (VersionedQuestionCustomization.findActiveByTemplateAffiliationAndQuestion as jest.Mock).mockResolvedValue(null);
       jest.spyOn(VersionedTemplate, 'findById').mockResolvedValue(mockTemplate as unknown as VersionedTemplate);
       jest.spyOn(Affiliation, 'findByURI').mockResolvedValue(mockAffiliation as unknown as Affiliation);
 
@@ -206,6 +297,73 @@ describe('versionedQuestion resolvers', () => {
         expect.any(Object),
         10
       );
+    });
+
+    it('should resolve customizationOwnerAffiliation via chained resolver', async () => {
+      const mockQuestion = {
+        id: 1,
+        questionText: 'Test question',
+        required: false,
+        versionedTemplateId: 10,
+        versionedSectionId: 5,
+      };
+      const mockCustomization = { id: 99, guidanceText: 'Custom guidance', sampleText: null };
+      const mockAffiliation = { uri: affiliationId, name: 'Org University', displayName: 'Org University' };
+
+      (VersionedQuestion.findById as jest.Mock).mockResolvedValue(mockQuestion);
+      (VersionedQuestionCondition.findByVersionedQuestionId as jest.Mock).mockResolvedValue([]);
+      (VersionedQuestionCustomization.findActiveByTemplateAffiliationAndQuestion as jest.Mock).mockResolvedValue(mockCustomization);
+      jest.spyOn(Affiliation, 'findByURI').mockResolvedValue(mockAffiliation as unknown as Affiliation);
+
+      const custOwnerQuery = `
+        query publishedQuestion($versionedQuestionId: Int!) {
+          publishedQuestion(versionedQuestionId: $versionedQuestionId) {
+            id
+            customizationOwnerAffiliation {
+              uri
+              name
+            }
+          }
+        }
+      `;
+
+      const result = await executeQuery(custOwnerQuery, { versionedQuestionId: 1 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.publishedQuestion.customizationOwnerAffiliation.name).toEqual('Org University');
+      expect(Affiliation.findByURI).toHaveBeenCalledWith(
+        'VersionedQuestion.customizationOwnerAffiliation resolver',
+        expect.any(Object),
+        affiliationId
+      );
+    });
+
+    it('should return null customizationOwnerAffiliation when no customization exists', async () => {
+      const mockQuestion = {
+        id: 1,
+        questionText: 'Test question',
+        required: false,
+        versionedTemplateId: 10,
+        versionedSectionId: 5,
+      };
+
+      (VersionedQuestion.findById as jest.Mock).mockResolvedValue(mockQuestion);
+      (VersionedQuestionCondition.findByVersionedQuestionId as jest.Mock).mockResolvedValue([]);
+      (VersionedQuestionCustomization.findActiveByTemplateAffiliationAndQuestion as jest.Mock).mockResolvedValue(null);
+
+      const custOwnerQuery = `
+        query publishedQuestion($versionedQuestionId: Int!) {
+          publishedQuestion(versionedQuestionId: $versionedQuestionId) {
+            id
+            customizationOwnerAffiliation { uri }
+          }
+        }
+      `;
+
+      const result = await executeQuery(custOwnerQuery, { versionedQuestionId: 1 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.publishedQuestion.customizationOwnerAffiliation).toBeNull();
     });
   });
 

--- a/src/resolvers/__tests__/versionedQuestion.spec.ts
+++ b/src/resolvers/__tests__/versionedQuestion.spec.ts
@@ -1,0 +1,557 @@
+import casual from "casual";
+
+// Mock the authenticatedResolver HOF before importing resolvers
+jest.mock('../../services/authService', () => ({
+  ...jest.requireActual('../../services/authService'),
+  authenticatedResolver: jest.fn((ref, level, resolver) => resolver),
+}));
+
+import { ApolloServer } from "@apollo/server";
+import { typeDefs } from "../../schema";
+import { resolvers } from '../../resolver';
+
+import { logger } from "../../logger";
+import { JWTAccessToken } from "../../services/tokenService";
+import { VersionedQuestion } from '../../models/VersionedQuestion';
+import { VersionedCustomQuestion } from '../../models/VersionedCustomQuestion';
+import { Answer } from '../../models/Answer';
+import { VersionedQuestionCondition } from '../../models/VersionedQuestionCondition';
+import { VersionedTemplate } from '../../models/VersionedTemplate';
+import { VersionedTemplateCustomization } from '../../models/VersionedTemplateCustomization';
+import { Affiliation } from '../../models/Affiliation';
+import { User, UserRole } from "../../models/User";
+import { buildContext, mockToken } from "../../__mocks__/context";
+
+jest.mock('../../context.ts');
+jest.mock('../../datasources/cache');
+
+jest.mock('../../models/VersionedQuestion');
+jest.mock('../../models/VersionedCustomQuestion');
+jest.mock('../../models/Answer');
+jest.mock('../../models/VersionedQuestionCondition');
+
+let testServer: ApolloServer;
+let affiliationId: string;
+let researcherToken: JWTAccessToken;
+let query: string;
+
+async function executeQuery(
+  query: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  variables: any,
+  token: JWTAccessToken
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<any> {
+  const context = buildContext(logger, token, null);
+  return await testServer.executeOperation(
+    { query, variables },
+    { contextValue: context },
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function executeQueryAnon(query: string, variables: any): Promise<any> {
+  const context = buildContext(logger, null, null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return await testServer.executeOperation({ query, variables }, { contextValue: context }) as any;
+}
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+
+  testServer = new ApolloServer({ typeDefs, resolvers });
+
+  affiliationId = casual.url;
+
+  researcherToken = await mockToken();
+  researcherToken.affiliationId = affiliationId;
+  researcherToken.role = UserRole.RESEARCHER;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('versionedQuestion resolvers', () => {
+  let user: User;
+
+  beforeEach(() => {
+    user = new User({
+      id: casual.integer(1, 999),
+      givenName: casual.first_name,
+      surName: casual.last_name,
+      role: UserRole.RESEARCHER,
+      affiliationId,
+    });
+  });
+
+  // ============================================================================
+  // Query: publishedQuestion
+  // ============================================================================
+  describe('Query.publishedQuestion', () => {
+    beforeEach(() => {
+      query = `
+        query publishedQuestion($versionedQuestionId: Int!) {
+          publishedQuestion(versionedQuestionId: $versionedQuestionId) {
+            id
+            questionText
+            requirementText
+            guidanceText
+            sampleText
+            required
+            versionedTemplateId
+            versionedSectionId
+            versionedQuestionConditions {
+              id
+            }
+          }
+        }
+      `;
+    });
+
+    it('should return the question when found', async () => {
+      const mockQuestion = {
+        id: 1,
+        questionText: 'What is your data management plan?',
+        requirementText: 'Required by funder',
+        guidanceText: 'Some guidance',
+        sampleText: 'Sample answer',
+        required: true,
+        versionedTemplateId: 10,
+        versionedSectionId: 5,
+      };
+
+      (VersionedQuestion.findById as jest.Mock).mockResolvedValue(mockQuestion);
+      (VersionedQuestionCondition.findByVersionedQuestionId as jest.Mock).mockResolvedValue([]);
+
+      const result = await executeQuery(query, { versionedQuestionId: 1 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.publishedQuestion.id).toEqual(1);
+      expect(result.body.singleResult.data.publishedQuestion.questionText).toEqual('What is your data management plan?');
+      expect(VersionedQuestion.findById).toHaveBeenCalledWith(
+        'publishedQuestion resolver',
+        expect.any(Object),
+        1
+      );
+    });
+
+    it('should return null when question is not found', async () => {
+      (VersionedQuestion.findById as jest.Mock).mockResolvedValue(null);
+
+      const result = await executeQuery(query, { versionedQuestionId: 999 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.publishedQuestion).toBeNull();
+    });
+
+    it('should return Authentication error when no token is provided', async () => {
+      const result = await executeQueryAnon(query, { versionedQuestionId: 1 });
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toEqual('Unauthorized');
+    });
+
+    it('should resolve versionedQuestionConditions via chained resolver', async () => {
+      const mockQuestion = {
+        id: 1,
+        questionText: 'Test question',
+        required: false,
+        versionedTemplateId: 10,
+        versionedSectionId: 5,
+      };
+      const mockConditions = [
+        { id: 11 },
+        { id: 12 },
+      ];
+
+      (VersionedQuestion.findById as jest.Mock).mockResolvedValue(mockQuestion);
+      (VersionedQuestionCondition.findByVersionedQuestionId as jest.Mock).mockResolvedValue(mockConditions);
+
+      const result = await executeQuery(query, { versionedQuestionId: 1 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.publishedQuestion.versionedQuestionConditions).toHaveLength(2);
+      expect(result.body.singleResult.data.publishedQuestion.versionedQuestionConditions[0].id).toEqual(11);
+      expect(VersionedQuestionCondition.findByVersionedQuestionId).toHaveBeenCalledWith(
+        'Chained VersionedQuestion.versionedQuestionConditions',
+        expect.any(Object),
+        1
+      );
+    });
+
+    it('should resolve ownerAffiliation via chained resolver', async () => {
+      const mockQuestion = {
+        id: 1,
+        questionText: 'Test question',
+        required: false,
+        versionedTemplateId: 10,
+        versionedSectionId: 5,
+      };
+      const mockTemplate = { id: 10, ownerId: 'https://ror.org/abc' };
+      const mockAffiliation = { uri: 'https://ror.org/abc', name: 'Test University', displayName: 'Test University' };
+
+      (VersionedQuestion.findById as jest.Mock).mockResolvedValue(mockQuestion);
+      (VersionedQuestionCondition.findByVersionedQuestionId as jest.Mock).mockResolvedValue([]);
+      jest.spyOn(VersionedTemplate, 'findById').mockResolvedValue(mockTemplate as unknown as VersionedTemplate);
+      jest.spyOn(Affiliation, 'findByURI').mockResolvedValue(mockAffiliation as unknown as Affiliation);
+
+      const ownerQuery = `
+        query publishedQuestion($versionedQuestionId: Int!) {
+          publishedQuestion(versionedQuestionId: $versionedQuestionId) {
+            id
+            ownerAffiliation {
+              uri
+              name
+            }
+          }
+        }
+      `;
+
+      const result = await executeQuery(ownerQuery, { versionedQuestionId: 1 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.publishedQuestion.ownerAffiliation.name).toEqual('Test University');
+      expect(VersionedTemplate.findById).toHaveBeenCalledWith(
+        'VersionedQuestion.ownerAffiliation resolver',
+        expect.any(Object),
+        10
+      );
+    });
+  });
+
+  // ============================================================================
+  // Query: publishedCustomQuestion
+  // ============================================================================
+  describe('Query.publishedCustomQuestion', () => {
+    beforeEach(() => {
+      query = `
+        query publishedCustomQuestion($versionedCustomQuestionId: Int!) {
+          publishedCustomQuestion(versionedCustomQuestionId: $versionedCustomQuestionId) {
+            id
+            questionText
+            requirementText
+            guidanceText
+            sampleText
+            required
+            json
+            versionedTemplateCustomizationId
+          }
+        }
+      `;
+    });
+
+    it('should return the custom question when found', async () => {
+      const mockCustomQuestion = {
+        id: 5,
+        questionText: 'Custom question text',
+        requirementText: 'Custom requirement',
+        guidanceText: 'Custom guidance',
+        sampleText: 'Custom sample',
+        required: false,
+        json: '{"type":"textArea"}',
+        versionedTemplateCustomizationId: 20,
+      };
+
+      (VersionedCustomQuestion.findById as jest.Mock).mockResolvedValue(mockCustomQuestion);
+
+      const result = await executeQuery(query, { versionedCustomQuestionId: 5 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.publishedCustomQuestion.id).toEqual(5);
+      expect(result.body.singleResult.data.publishedCustomQuestion.questionText).toEqual('Custom question text');
+      expect(result.body.singleResult.data.publishedCustomQuestion.json).toEqual('{"type":"textArea"}');
+      expect(VersionedCustomQuestion.findById).toHaveBeenCalledWith(
+        'publishedCustomQuestion resolver',
+        expect.any(Object),
+        5
+      );
+    });
+
+    it('should return null when custom question is not found', async () => {
+      (VersionedCustomQuestion.findById as jest.Mock).mockResolvedValue(null);
+
+      const result = await executeQuery(query, { versionedCustomQuestionId: 999 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.publishedCustomQuestion).toBeNull();
+    });
+
+    it('should return Authentication error when no token is provided', async () => {
+      const result = await executeQueryAnon(query, { versionedCustomQuestionId: 5 });
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toEqual('Unauthorized');
+    });
+
+    it('should resolve ownerAffiliation via chained resolver', async () => {
+      const mockCustomQuestion = {
+        id: 5,
+        questionText: 'Custom question',
+        required: false,
+        json: '{"type":"textArea"}',
+        versionedTemplateCustomizationId: 20,
+      };
+      const mockVtc = { id: 20, currentVersionedTemplateId: 10 };
+      const mockTemplate = { id: 10, ownerId: 'https://ror.org/xyz' };
+      const mockAffiliation = { uri: 'https://ror.org/xyz', name: 'Owner Org', displayName: 'Owner Org' };
+
+      (VersionedCustomQuestion.findById as jest.Mock).mockResolvedValue(mockCustomQuestion);
+      jest.spyOn(VersionedTemplateCustomization, 'findById').mockResolvedValue(mockVtc as unknown as VersionedTemplateCustomization);
+      jest.spyOn(VersionedTemplate, 'findById').mockResolvedValue(mockTemplate as unknown as VersionedTemplate);
+      jest.spyOn(Affiliation, 'findByURI').mockResolvedValue(mockAffiliation as unknown as Affiliation);
+
+      const ownerQuery = `
+        query publishedCustomQuestion($versionedCustomQuestionId: Int!) {
+          publishedCustomQuestion(versionedCustomQuestionId: $versionedCustomQuestionId) {
+            id
+            ownerAffiliation {
+              uri
+              name
+            }
+          }
+        }
+      `;
+
+      const result = await executeQuery(ownerQuery, { versionedCustomQuestionId: 5 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.publishedCustomQuestion.ownerAffiliation.name).toEqual('Owner Org');
+      expect(VersionedTemplateCustomization.findById).toHaveBeenCalledWith(
+        'VersionedCustomQuestion.ownerAffiliation resolver',
+        expect.any(Object),
+        20
+      );
+      expect(VersionedTemplate.findById).toHaveBeenCalledWith(
+        'VersionedCustomQuestion.ownerAffiliation resolver',
+        expect.any(Object),
+        10
+      );
+    });
+
+    it('should return null ownerAffiliation when versioned template customization is not found', async () => {
+      const mockCustomQuestion = {
+        id: 5,
+        questionText: 'Custom question',
+        required: false,
+        json: '{"type":"textArea"}',
+        versionedTemplateCustomizationId: 20,
+      };
+
+      (VersionedCustomQuestion.findById as jest.Mock).mockResolvedValue(mockCustomQuestion);
+      jest.spyOn(VersionedTemplateCustomization, 'findById').mockResolvedValue(null);
+
+      const ownerQuery = `
+        query publishedCustomQuestion($versionedCustomQuestionId: Int!) {
+          publishedCustomQuestion(versionedCustomQuestionId: $versionedCustomQuestionId) {
+            id
+            ownerAffiliation { uri }
+          }
+        }
+      `;
+
+      const result = await executeQuery(ownerQuery, { versionedCustomQuestionId: 5 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.publishedCustomQuestion.ownerAffiliation).toBeNull();
+    });
+  });
+
+  // ============================================================================
+  // Query: publishedQuestions
+  // ============================================================================
+  describe('Query.publishedQuestions', () => {
+    beforeEach(() => {
+      query = `
+        query publishedQuestions($planId: Int!, $versionedSectionId: Int!) {
+          publishedQuestions(planId: $planId, versionedSectionId: $versionedSectionId) {
+            id
+            questionText
+            hasAnswer
+            questionType
+            versionedQuestionId
+            customQuestionId
+          }
+        }
+      `;
+    });
+
+    it('should return ordered base and custom questions with answer flags', async () => {
+      const mockBaseQuestions = [
+        { id: 1, questionText: 'Base Q1', required: true },
+        { id: 2, questionText: 'Base Q2', required: false },
+      ];
+      const mockCustomQuestions = [
+        {
+          id: 10,
+          questionText: 'Custom Q1',
+          required: false,
+          pinnedVersionedQuestionId: 1,
+          pinnedVersionedQuestionType: 'BASE',
+        },
+      ];
+      const mockBaseAnswers = [{ versionedQuestionId: 1 }];
+      const mockCustomAnswers = [];
+
+      (VersionedQuestion.findByVersionedSectionId as jest.Mock).mockResolvedValue(mockBaseQuestions);
+      (VersionedCustomQuestion.findByVersionedSectionIdAndType as jest.Mock).mockResolvedValue(mockCustomQuestions);
+      (Answer.findFilledAnswersByQuestionIds as jest.Mock).mockResolvedValue(mockBaseAnswers);
+      (Answer.findFilledAnswersByCustomQuestionIds as jest.Mock).mockResolvedValue(mockCustomAnswers);
+
+      const result = await executeQuery(query, { planId: 1, versionedSectionId: 5 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      const questions = result.body.singleResult.data.publishedQuestions;
+
+      // Base Q1 + Custom Q1 (pinned after Q1) + Base Q2
+      expect(questions).toHaveLength(3);
+      expect(questions[0].id).toEqual(1);
+      expect(questions[0].questionType).toEqual('BASE');
+      expect(questions[0].hasAnswer).toBe(true);
+      expect(questions[0].versionedQuestionId).toEqual(1);
+
+      expect(questions[1].id).toEqual(10);
+      expect(questions[1].questionType).toEqual('CUSTOM');
+      expect(questions[1].hasAnswer).toBe(false);
+      expect(questions[1].customQuestionId).toEqual(10);
+
+      expect(questions[2].id).toEqual(2);
+      expect(questions[2].questionType).toEqual('BASE');
+      expect(questions[2].hasAnswer).toBe(false);
+    });
+
+    it('should place custom question first when pinnedVersionedQuestionId is null', async () => {
+      const mockBaseQuestions = [{ id: 1, questionText: 'Base Q1', required: false }];
+      const mockCustomQuestions = [
+        {
+          id: 10,
+          questionText: 'Unpinned Custom',
+          required: false,
+          pinnedVersionedQuestionId: null,
+          pinnedVersionedQuestionType: null,
+        },
+      ];
+
+      (VersionedQuestion.findByVersionedSectionId as jest.Mock).mockResolvedValue(mockBaseQuestions);
+      (VersionedCustomQuestion.findByVersionedSectionIdAndType as jest.Mock).mockResolvedValue(mockCustomQuestions);
+      (Answer.findFilledAnswersByQuestionIds as jest.Mock).mockResolvedValue([]);
+      (Answer.findFilledAnswersByCustomQuestionIds as jest.Mock).mockResolvedValue([]);
+
+      const result = await executeQuery(query, { planId: 1, versionedSectionId: 5 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      const questions = result.body.singleResult.data.publishedQuestions;
+      expect(questions[0].id).toEqual(10);
+      expect(questions[0].questionType).toEqual('CUSTOM');
+      expect(questions[1].id).toEqual(1);
+    });
+
+    it('should return only base questions when no custom questions exist', async () => {
+      const mockBaseQuestions = [
+        { id: 1, questionText: 'Base Q1', required: true },
+        { id: 2, questionText: 'Base Q2', required: false },
+      ];
+
+      (VersionedQuestion.findByVersionedSectionId as jest.Mock).mockResolvedValue(mockBaseQuestions);
+      (VersionedCustomQuestion.findByVersionedSectionIdAndType as jest.Mock).mockResolvedValue([]);
+      (Answer.findFilledAnswersByQuestionIds as jest.Mock).mockResolvedValue([]);
+      (Answer.findFilledAnswersByCustomQuestionIds as jest.Mock).mockResolvedValue([]);
+
+      const result = await executeQuery(query, { planId: 1, versionedSectionId: 5 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.publishedQuestions).toHaveLength(2);
+      expect(result.body.singleResult.data.publishedQuestions.every(q => q.questionType === 'BASE')).toBe(true);
+    });
+
+    it('should return empty array when no questions exist', async () => {
+      (VersionedQuestion.findByVersionedSectionId as jest.Mock).mockResolvedValue([]);
+      (VersionedCustomQuestion.findByVersionedSectionIdAndType as jest.Mock).mockResolvedValue([]);
+      (Answer.findFilledAnswersByQuestionIds as jest.Mock).mockResolvedValue([]);
+      (Answer.findFilledAnswersByCustomQuestionIds as jest.Mock).mockResolvedValue([]);
+
+      const result = await executeQuery(query, { planId: 1, versionedSectionId: 5 }, researcherToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.publishedQuestions).toHaveLength(0);
+    });
+
+    it('should return Authentication error when no token', async () => {
+      const result = await executeQueryAnon(query, { planId: 1, versionedSectionId: 5 });
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toEqual('Unauthorized');
+    });
+  });
+
+  // ============================================================================
+  // Query: publishedCustomQuestions
+  // ============================================================================
+  describe('Query.publishedCustomQuestions', () => {
+    beforeEach(() => {
+      query = `
+        query publishedCustomQuestions($planId: Int!, $versionedCustomSectionId: Int!) {
+          publishedCustomQuestions(planId: $planId, versionedCustomSectionId: $versionedCustomSectionId) {
+            id
+            questionText
+            hasAnswer
+            questionType
+            customQuestionId
+            json
+          }
+        }
+      `;
+    });
+
+    it('should return custom questions with answer flags', async () => {
+      const mockQuestions = [
+        { id: 10, questionText: 'Custom Q1', required: true, json: '{"type":"textArea"}' },
+        { id: 11, questionText: 'Custom Q2', required: false, json: '{"type":"checkbox"}' },
+      ];
+      const mockAnswers = [{ versionedCustomQuestionId: 10 }];
+
+      (VersionedCustomQuestion.findByVersionedCustomSectionId as jest.Mock).mockResolvedValue(mockQuestions);
+      (Answer.findFilledAnswersByCustomQuestionIds as jest.Mock).mockResolvedValue(mockAnswers);
+
+      const result = await executeQuery(
+        query,
+        { planId: 1, versionedCustomSectionId: 7 },
+        researcherToken
+      );
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      const questions = result.body.singleResult.data.publishedCustomQuestions;
+      expect(questions).toHaveLength(2);
+
+      expect(questions[0].id).toEqual(10);
+      expect(questions[0].questionType).toEqual('CUSTOM');
+      expect(questions[0].hasAnswer).toBe(true);
+      expect(questions[0].customQuestionId).toEqual(10);
+      expect(questions[0].json).toEqual('{"type":"textArea"}');
+
+      expect(questions[1].id).toEqual(11);
+      expect(questions[1].hasAnswer).toBe(false);
+    });
+
+    it('should return empty array when no custom questions exist', async () => {
+      (VersionedCustomQuestion.findByVersionedCustomSectionId as jest.Mock).mockResolvedValue([]);
+      (Answer.findFilledAnswersByCustomQuestionIds as jest.Mock).mockResolvedValue([]);
+
+      const result = await executeQuery(
+        query,
+        { planId: 1, versionedCustomSectionId: 7 },
+        researcherToken
+      );
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(result.body.singleResult.data.publishedCustomQuestions).toHaveLength(0);
+    });
+
+    it('should return Authentication error when no token', async () => {
+      const result = await executeQueryAnon(query, { planId: 1, versionedCustomSectionId: 7 });
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toEqual('Unauthorized');
+    });
+  });
+});

--- a/src/resolvers/__tests__/versionedQuestion.spec.ts
+++ b/src/resolvers/__tests__/versionedQuestion.spec.ts
@@ -19,7 +19,7 @@ import { VersionedQuestionCondition } from '../../models/VersionedQuestionCondit
 import { VersionedTemplate } from '../../models/VersionedTemplate';
 import { VersionedTemplateCustomization } from '../../models/VersionedTemplateCustomization';
 import { Affiliation } from '../../models/Affiliation';
-import { User, UserRole } from "../../models/User";
+import { UserRole } from "../../models/User";
 import { buildContext, mockToken } from "../../__mocks__/context";
 
 jest.mock('../../context.ts');
@@ -73,17 +73,6 @@ afterEach(() => {
 });
 
 describe('versionedQuestion resolvers', () => {
-  let user: User;
-
-  beforeEach(() => {
-    user = new User({
-      id: casual.integer(1, 999),
-      givenName: casual.first_name,
-      surName: casual.last_name,
-      role: UserRole.RESEARCHER,
-      affiliationId,
-    });
-  });
 
   // ============================================================================
   // Query: publishedQuestion

--- a/src/resolvers/answer.ts
+++ b/src/resolvers/answer.ts
@@ -53,8 +53,8 @@ export const resolvers: Resolvers = {
     },
 
     // return the answer for the given versionedQuestionId
-    answerByVersionedQuestionId: async (_, { planId, versionedQuestionId }, context: MyContext): Promise<Answer> => {
-      const reference = 'planSectionAnswers resolver';
+    answerByVersionedQuestionId: async (_, { planId, versionedQuestionId, versionedCustomQuestionId }, context: MyContext): Promise<Answer> => {
+      const reference = 'answerByVersionedQuestionId resolver';
       try {
         if (isAuthorized(context.token)) {
           const plan = await Plan.findById(reference, context, planId);
@@ -63,8 +63,14 @@ export const resolvers: Resolvers = {
           }
           const project = await Project.findById(reference, context, plan.projectId);
           if (await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.COMMENT)) {
-            const temp = await Answer.findByPlanIdAndVersionedQuestionId(reference, context, planId, versionedQuestionId);
-            return temp;
+            if (versionedCustomQuestionId) {
+              return await Answer.findByPlanIdAndVersionedCustomQuestionId(
+                reference, context, planId, versionedCustomQuestionId
+              );
+            }
+            return await Answer.findByPlanIdAndVersionedQuestionId(
+              reference, context, planId, versionedQuestionId
+            );
           }
         }
         throw context?.token ? ForbiddenError() : AuthenticationError();
@@ -103,7 +109,7 @@ export const resolvers: Resolvers = {
 
   Mutation: {
     // Create a new answer
-    addAnswer: async (_, { planId, versionedSectionId, versionedQuestionId, json }, context: MyContext): Promise<Answer> => {
+    addAnswer: async (_, { planId, versionedSectionId, versionedQuestionId, versionedCustomSectionId, versionedCustomQuestionId, json }, context: MyContext): Promise<Answer> => {
       const reference = 'addAnswer resolver';
       try {
         if (isAuthorized(context.token)) {
@@ -114,7 +120,7 @@ export const resolvers: Resolvers = {
 
           const project = await Project.findById(reference, context, plan.projectId);
           if (await hasPermissionOnProject(context, project)) {
-            const answer = new Answer({ planId, versionedSectionId, versionedQuestionId, json });
+            const answer = new Answer({ planId, versionedSectionId, versionedQuestionId, versionedCustomSectionId, versionedCustomQuestionId, json });
             const newAnswer = await answer.create(context);
             if (newAnswer && !newAnswer.hasErrors()) {
               // Update the maDMP version of the Plan

--- a/src/resolvers/guidance.ts
+++ b/src/resolvers/guidance.ts
@@ -95,7 +95,7 @@ export const resolvers: Resolvers = {
     // ============================================================================
     guidanceSourcesForPlan: async (
       _,
-      { planId, versionedSectionId, versionedQuestionId, customSectionId },
+      { planId, versionedSectionId, versionedQuestionId, customSectionId, customQuestionId },
       context: MyContext
     ): Promise<GuidanceSource[]> => {
       const reference = 'guidanceSourcesForPlan resolver';
@@ -114,7 +114,8 @@ export const resolvers: Resolvers = {
               planId,
               versionedSectionId,
               versionedQuestionId,
-              customSectionId
+              customSectionId,
+              customQuestionId
             );
 
             return sources;

--- a/src/resolvers/versionedQuestion.ts
+++ b/src/resolvers/versionedQuestion.ts
@@ -11,6 +11,7 @@ import { GraphQLError } from "graphql";
 import { normaliseDateTime } from "../utils/helpers";
 import { VersionedTemplate } from "../models/VersionedTemplate";
 import { VersionedTemplateCustomization } from "../models/VersionedTemplateCustomization";
+import { VersionedQuestionCustomization } from "../models/VersionedQuestionCustomization";
 import { Affiliation } from "../models/Affiliation";
 
 
@@ -151,12 +152,28 @@ export const resolvers: Resolvers = {
       }
     },
 
-    publishedQuestion: async (_, { versionedQuestionId }, context: MyContext): Promise<VersionedQuestion> => {
+    // Return the VersionedQuestion for the specified versionedQuestionId which includes customization
+    // sample text, guidance text, and info on the org that customized it
+    publishedQuestion: async (_, { versionedQuestionId }, context: MyContext) => {
       const reference = 'publishedQuestion resolver';
       try {
         if (isAuthorized(context?.token)) {
-          // Grab the versionedSection so we can get the section, and then the templateId
-          return await VersionedQuestion.findById(reference, context, versionedQuestionId);
+          const [question, customization] = await Promise.all([
+            VersionedQuestion.findById(reference, context, versionedQuestionId),
+            VersionedQuestionCustomization.findActiveByTemplateAffiliationAndQuestion(
+              reference, context, context.token.affiliationId, versionedQuestionId
+            ),
+          ]);
+
+          if (!question) return null;
+
+          return {
+            ...question,
+            customizationId: customization?.id ?? null,
+            customizationGuidanceText: customization?.guidanceText ?? null,
+            customizationSampleText: customization?.sampleText ?? null,
+            customizationAffiliationId: customization ? context.token.affiliationId : null,
+          };
         }
         throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {
@@ -225,6 +242,14 @@ export const resolvers: Resolvers = {
         reference,
         context,
         versionedTemplate.ownerId
+      );
+    },
+    customizationOwnerAffiliation: async (parent: VersionedQuestion & { customizationAffiliationId?: string }, _, context: MyContext): Promise<Affiliation | null> => {
+      if (!parent.customizationAffiliationId) return null;
+      return await Affiliation.findByURI(
+        'VersionedQuestion.customizationOwnerAffiliation resolver',
+        context,
+        parent.customizationAffiliationId
       );
     },
     created: (parent: VersionedQuestion) => {

--- a/src/resolvers/versionedQuestion.ts
+++ b/src/resolvers/versionedQuestion.ts
@@ -10,6 +10,7 @@ import { isAuthorized } from "../services/authService";
 import { GraphQLError } from "graphql";
 import { normaliseDateTime } from "../utils/helpers";
 import { VersionedTemplate } from "../models/VersionedTemplate";
+import { VersionedTemplateCustomization } from "../models/VersionedTemplateCustomization";
 import { Affiliation } from "../models/Affiliation";
 
 
@@ -106,7 +107,7 @@ export const resolvers: Resolvers = {
         throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {
         if (err instanceof GraphQLError) throw err;
-        
+
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
         throw InternalServerError();
       }
@@ -164,6 +165,44 @@ export const resolvers: Resolvers = {
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
         throw InternalServerError();
       }
+    },
+
+    publishedCustomQuestion: async (_, { versionedCustomQuestionId }, context: MyContext): Promise<VersionedCustomQuestion> => {
+      const reference = 'publishedCustomQuestion resolver';
+      try {
+        if (isAuthorized(context?.token)) {
+          const temp = await VersionedCustomQuestion.findById(reference, context, versionedCustomQuestionId);
+          console.log("***Response from publishedCustomQuestion resolver: ", temp);
+          return temp;
+        }
+        throw context?.token ? ForbiddenError() : AuthenticationError();
+      } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+
+        context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
+        throw InternalServerError();
+      }
+    },
+  },
+
+  VersionedCustomQuestion: {
+    ownerAffiliation: async (parent: VersionedCustomQuestion, _, context: MyContext): Promise<Affiliation | null> => {
+      const reference = 'VersionedCustomQuestion.ownerAffiliation resolver';
+      const vtc = await VersionedTemplateCustomization.findById(
+        reference, context, parent.versionedTemplateCustomizationId
+      );
+      if (!vtc?.currentVersionedTemplateId) return null;
+      const versionedTemplate = await VersionedTemplate.findById(
+        reference, context, vtc.currentVersionedTemplateId
+      );
+      if (!versionedTemplate?.ownerId) return null;
+      return await Affiliation.findByURI(reference, context, versionedTemplate.ownerId);
+    },
+    created: (parent: VersionedCustomQuestion) => {
+      return normaliseDateTime(parent.created);
+    },
+    modified: (parent: VersionedCustomQuestion) => {
+      return normaliseDateTime(parent.modified);
     },
   },
 

--- a/src/resolvers/versionedQuestion.ts
+++ b/src/resolvers/versionedQuestion.ts
@@ -171,9 +171,7 @@ export const resolvers: Resolvers = {
       const reference = 'publishedCustomQuestion resolver';
       try {
         if (isAuthorized(context?.token)) {
-          const temp = await VersionedCustomQuestion.findById(reference, context, versionedCustomQuestionId);
-          console.log("***Response from publishedCustomQuestion resolver: ", temp);
-          return temp;
+          return await VersionedCustomQuestion.findById(reference, context, versionedCustomQuestionId);
         }
         throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {

--- a/src/schemas/answer.ts
+++ b/src/schemas/answer.ts
@@ -6,7 +6,7 @@ export const typeDefs = gql`
     answers(projectId: Int!, planId: Int!, versionedSectionId: Int!): [Answer]
 
     "Get an answer by versionedQuestionId"
-    answerByVersionedQuestionId(projectId: Int!, planId: Int!, versionedQuestionId: Int!): Answer
+    answerByVersionedQuestionId(projectId: Int!, planId: Int!, versionedQuestionId: Int, versionedCustomQuestionId: Int): Answer
 
     "Get the specific answer"
     answer(projectId: Int!, answerId: Int!): Answer

--- a/src/schemas/guidance.ts
+++ b/src/schemas/guidance.ts
@@ -7,7 +7,7 @@ export const typeDefs = gql`
     "Get a specific Guidance item by ID"
     guidance(guidanceId: Int!): Guidance
     "Get all guidance sources for a plan, optionally filtered by section"
-    guidanceSourcesForPlan(planId: Int!, versionedSectionId: Int, versionedQuestionId: Int, customSectionId: Int): [GuidanceSource!]!
+    guidanceSourcesForPlan(planId: Int!, versionedSectionId: Int, versionedQuestionId: Int, customSectionId: Int, customQuestionId: Int): [GuidanceSource!]!
   }
 
   extend type Mutation {

--- a/src/schemas/versionedQuestion.ts
+++ b/src/schemas/versionedQuestion.ts
@@ -8,6 +8,8 @@ export const typeDefs = gql`
     publishedCustomQuestions(versionedCustomSectionId: Int!, planId: Int!): [PublishedQuestion]
     "Get a specific VersionedQuestion based on versionedQuestionId"
     publishedQuestion(versionedQuestionId: Int!): VersionedQuestion
+    "Get a specific published custom question based on versionedCustomQuestionId"
+    publishedCustomQuestion(versionedCustomQuestionId: Int!): VersionedCustomQuestion
   }
 
   "A snapshot of a Question when it became published."
@@ -113,6 +115,9 @@ export const typeDefs = gql`
     useSampleTextAsDefault: Boolean
     "Whether this question is required"
     required: Boolean
+
+    "Owner affiliation for the question"
+    ownerAffiliation: Affiliation
 
     "Errors associated with the Object"
     errors: VersionedCustomQuestionErrors

--- a/src/schemas/versionedQuestion.ts
+++ b/src/schemas/versionedQuestion.ts
@@ -50,6 +50,12 @@ export const typeDefs = gql`
     "To indicate whether the question is required to be completed"
     required: Boolean
 
+    "For question customization info"
+    customizationId: Int
+    customizationGuidanceText: String
+    customizationSampleText: String
+    customizationOwnerAffiliation: Affiliation
+
     "The conditional logic associated with this VersionedQuestion"
     versionedQuestionConditions: [VersionedQuestionCondition!]
     "Owner affiliation for the question"

--- a/src/services/__tests__/guidanceService.spec.ts
+++ b/src/services/__tests__/guidanceService.spec.ts
@@ -24,6 +24,7 @@ import { VersionedQuestion } from "../../models/VersionedQuestion";
 import { VersionedSectionCustomization } from "../../models/VersionedSectionCustomization";
 import { VersionedQuestionCustomization } from "../../models/VersionedQuestionCustomization";
 import { VersionedCustomSection } from "../../models/VersionedCustomSection";
+import { VersionedCustomQuestion } from "../../models/VersionedCustomQuestion";
 import { Affiliation } from "../../models/Affiliation";
 import { isSuperAdmin } from "../authService";
 
@@ -150,6 +151,12 @@ jest.mock("../../models/VersionedCustomSection", () => ({
   },
 }));
 
+jest.mock("../../models/VersionedCustomQuestion", () => ({
+  VersionedCustomQuestion: {
+    findById: jest.fn(),
+  },
+}));
+
 jest.mock("../../models/Affiliation", () => ({
   Affiliation: {
     findByURI: jest.fn(),
@@ -203,7 +210,7 @@ describe("hasPermissionOnGuidanceGroup", () => {
     context = await buildMockContextWithToken(logger);
     jest.clearAllMocks();
   });
-  
+
   it("returns true if user is from the same org", async () => {
     (GuidanceGroup.findById as jest.Mock).mockResolvedValue({ affiliationId: "abc" });
     const localContext = { token: { affiliationId: "abc" } };
@@ -239,16 +246,16 @@ describe("publishGuidanceGroup", () => {
   beforeEach(async () => {
     context = await buildMockContextWithToken(logger);
     jest.clearAllMocks();
-    
-    group = { 
-      id: 1, 
-      bestPractice: true, 
-      optionalSubset: false, 
-      name: "g", 
-      description: "desc", 
-      update: jest.fn().mockResolvedValue({ hasErrors: () => false }) 
+
+    group = {
+      id: 1,
+      bestPractice: true,
+      optionalSubset: false,
+      name: "g",
+      description: "desc",
+      update: jest.fn().mockResolvedValue({ hasErrors: () => false })
     };
-    
+
     VersionedGuidanceGroupMock.mockImplementation((data: Record<string, unknown>) => ({
       ...data,
       create: jest.fn().mockResolvedValue({
@@ -260,11 +267,11 @@ describe("publishGuidanceGroup", () => {
       hasErrors: () => false,
       update: jest.fn().mockResolvedValue({ hasErrors: () => false }),
     }));
-    
+
     VersionedGuidanceGroupMock.findByGuidanceGroupId.mockResolvedValue([{ version: 1 }]);
     VersionedGuidanceGroupMock.deactivateAll.mockResolvedValue(true);
     GuidanceMock.findByGuidanceGroupId.mockResolvedValue([{ id: 1, tagId: 2, guidanceText: "txt" }]);
-    
+
     VersionedGuidanceMock.mockImplementation((data: Record<string, unknown>) => ({
       ...data,
       create: jest.fn().mockResolvedValue({ hasErrors: () => false }),
@@ -289,7 +296,7 @@ describe("publishGuidanceGroup", () => {
       modifiedById: 0,
       update: jest.fn(),
     };
-    
+
     await expect(guidanceService.publishGuidanceGroup(context, invalidGroup as GuidanceGroup)).rejects.toThrow();
   });
 
@@ -299,7 +306,7 @@ describe("publishGuidanceGroup", () => {
       create: jest.fn().mockResolvedValue({ hasErrors: () => true }),
       hasErrors: () => true,
     }));
-    
+
     await expect(guidanceService.publishGuidanceGroup(context, group as GuidanceGroup)).rejects.toThrow();
   });
 
@@ -309,7 +316,7 @@ describe("publishGuidanceGroup", () => {
       create: jest.fn().mockResolvedValue({ hasErrors: () => true }),
       hasErrors: () => true,
     }));
-    
+
     await expect(guidanceService.publishGuidanceGroup(context, group as GuidanceGroup)).rejects.toThrow();
   });
 });
@@ -320,7 +327,7 @@ describe("unpublishGuidanceGroup", () => {
     jest.clearAllMocks();
     group = { id: 1 };
   });
-  
+
   it("unpublishes a group and returns true", async () => {
     VersionedGuidanceGroupMock.deactivateAll.mockResolvedValue(true);
     const result = await guidanceService.unpublishGuidanceGroup(context, group as GuidanceGroup);
@@ -339,7 +346,7 @@ describe("unpublishGuidanceGroup", () => {
       modifiedById: 0,
       update: jest.fn(),
     };
-    
+
     await expect(guidanceService.unpublishGuidanceGroup(context, invalidGroup as GuidanceGroup)).rejects.toThrow();
   });
 
@@ -354,14 +361,14 @@ describe("markGuidanceGroupAsDirty", () => {
     context = await buildMockContextWithToken(logger);
     jest.clearAllMocks();
   });
-  
+
   it("marks group as dirty if active version exists", async () => {
     const group = { isDirty: false, update: jest.fn().mockResolvedValue({}) };
     (GuidanceGroup.findById as jest.Mock).mockResolvedValue(group);
     VersionedGuidanceGroupMock.findActiveByGuidanceGroupId.mockResolvedValue(true);
-    
+
     await guidanceService.markGuidanceGroupAsDirty(context, 1);
-    
+
     expect(group.isDirty).toBe(true);
     expect(group.update).toHaveBeenCalled();
   });
@@ -375,20 +382,20 @@ describe("markGuidanceGroupAsDirty", () => {
     const group = { isDirty: false, update: jest.fn().mockResolvedValue({}) };
     (GuidanceGroup.findById as jest.Mock).mockResolvedValue(group);
     VersionedGuidanceGroupMock.findActiveByGuidanceGroupId.mockResolvedValue(null);
-    
+
     await expect(guidanceService.markGuidanceGroupAsDirty(context, 1)).resolves.toBeUndefined();
   });
 
   it("logs and throws on error", async () => {
     (GuidanceGroup.findById as jest.Mock).mockRejectedValue(new Error("fail"));
-    
+
     await expect(guidanceService.markGuidanceGroupAsDirty(context, 1)).rejects.toThrow();
     expect(context.logger.error).toHaveBeenCalled();
   });
 });
 
 describe("getSectionTags", () => {
-  beforeEach(async() => {
+  beforeEach(async () => {
     context = await buildMockContextWithToken(logger);
   });
   it("returns tags map", async () => {
@@ -406,7 +413,7 @@ describe("getSectionTags", () => {
 });
 
 describe("getSectionTagsMap", () => {
-  beforeEach(async() => {
+  beforeEach(async () => {
     context = await buildMockContextWithToken(logger);
   });
   it("returns tags map", async () => {
@@ -438,39 +445,39 @@ describe("getAffiliationsWithGuidanceForTemplate", () => {
   it("returns all affiliations with associated section tag guidance", async () => {
     const mockTemplate = { id: 1, ownerId: "https://ror.org/021nxhr62" };
     (VersionedTemplate.findById as jest.Mock).mockResolvedValue(mockTemplate);
-    
+
     // Mock section guidance check - has guidance
     (Affiliation.query as jest.Mock).mockResolvedValueOnce([{ count: 1 }]); // sections with guidance
     (Affiliation.query as jest.Mock).mockResolvedValueOnce([{ count: 0 }]); // questions without guidance
-    
+
     // Mock getSectionTagsMap returning empty (no tags)
     (PlanGuidance.query as jest.Mock).mockResolvedValue([]);
-    
+
     const result = await guidanceService.getAffiliationsWithGuidanceForTemplate(context, 1);
-    
+
     expect(result).toEqual(["https://ror.org/021nxhr62"]);
   });
 
   it("returns template owner URI if template has question guidance", async () => {
     const mockTemplate = { id: 1, ownerId: "https://ror.org/021nxhr62" };
     (VersionedTemplate.findById as jest.Mock).mockResolvedValue(mockTemplate);
-    
+
     // Mock question guidance check - has guidance
     (Affiliation.query as jest.Mock).mockResolvedValueOnce([{ count: 0 }]); // sections without guidance
     (Affiliation.query as jest.Mock).mockResolvedValueOnce([{ count: 1 }]); // questions with guidance
-    
+
     // Mock getSectionTagsMap returning empty (no tags)
     (PlanGuidance.query as jest.Mock).mockResolvedValue([]);
-    
+
     const result = await guidanceService.getAffiliationsWithGuidanceForTemplate(context, 1);
-    
+
     expect(result).toEqual(["https://ror.org/021nxhr62"]);
   });
 
   it("returns ALL affiliations that have the correct tag-based guidance", async () => {
     const mockTemplate = { id: 1, ownerId: "https://ror.org/021nxhr62" };
     (VersionedTemplate.findById as jest.Mock).mockResolvedValue(mockTemplate);
-    
+
     // Mock Affiliation.query calls in sequence
     (Affiliation.query as jest.Mock)
       .mockResolvedValueOnce([{ count: 0 }]) // sections check
@@ -480,15 +487,15 @@ describe("getAffiliationsWithGuidanceForTemplate", () => {
         { affiliationId: "https://ror.org/01cwqze88" }, // NSF
         { affiliationId: "https://ror.org/03yrm5c26" }  // NIH
       ]);
-    
+
     // Mock getSectionTagIds returning tag IDs
     (PlanGuidance.query as jest.Mock).mockResolvedValue([
       { tagId: 1 },
       { tagId: 2 }
     ]);
-    
+
     const result = await guidanceService.getAffiliationsWithGuidanceForTemplate(context, 1);
-    
+
     expect(result).toEqual([
       "https://ror.org/021nxhr62",
       "https://ror.org/01cwqze88",
@@ -498,72 +505,72 @@ describe("getAffiliationsWithGuidanceForTemplate", () => {
 
   it("does not duplicate template owner URI if they match user affiliation", async () => {
     const mockTemplate = { id: 1, ownerId: "https://ror.org/021nxhr62" };
-    const userContext = { 
-      ...context, 
-      token: { ...context.token, affiliationId: "https://ror.org/021nxhr62" } 
+    const userContext = {
+      ...context,
+      token: { ...context.token, affiliationId: "https://ror.org/021nxhr62" }
     };
-    
+
     (VersionedTemplate.findById as jest.Mock).mockResolvedValue(mockTemplate);
-    
+
     // Mock Affiliation.query calls in sequence
     (Affiliation.query as jest.Mock)
       .mockResolvedValueOnce([{ count: 1 }]) // sections check - has guidance
       .mockResolvedValueOnce([{ count: 0 }]) // questions check
       .mockResolvedValueOnce([{ count: 1 }]); // template owner tag-based guidance check
     // Should not check user affiliation since it's the same as template owner
-    
+
     // Mock getSectionTagIds returning tag IDs
     (PlanGuidance.query as jest.Mock).mockResolvedValue([
       { tagId: 1 }
     ]);
-    
+
     const result = await guidanceService.getAffiliationsWithGuidanceForTemplate(userContext, 1);
-    
+
     expect(result).toEqual(["https://ror.org/021nxhr62"]);
   });
 
   it("returns [] if no section/question guidance and no tag-based guidance", async () => {
     const mockTemplate = { id: 1, ownerId: "https://ror.org/021nxhr62" };
     (VersionedTemplate.findById as jest.Mock).mockResolvedValue(mockTemplate);
-    
+
     // Mock Affiliation.query calls in sequence
     (Affiliation.query as jest.Mock)
       .mockResolvedValueOnce([{ count: 0 }]) // sections check
       .mockResolvedValueOnce([{ count: 0 }]) // questions check
       .mockResolvedValueOnce([{ count: 0 }]); // template owner tag-based guidance check
-    
+
     // Mock getSectionTagIds returning tag IDs
     (PlanGuidance.query as jest.Mock).mockResolvedValue([
       { tagId: 1 }
     ]);
-    
+
     const result = await guidanceService.getAffiliationsWithGuidanceForTemplate(context, 1);
-    
+
     expect(result).toEqual([]);
   });
 
   it("returns [] if template has no tags and no section/question guidance", async () => {
     const mockTemplate = { id: 1, ownerId: "https://ror.org/021nxhr62" };
     (VersionedTemplate.findById as jest.Mock).mockResolvedValue(mockTemplate);
-    
+
     // Mock Affiliation.query calls in sequence
     (Affiliation.query as jest.Mock)
       .mockResolvedValueOnce([{ count: 0 }]) // sections check - no guidance
       .mockResolvedValueOnce([{ count: 0 }]); // questions check - no guidance
-    
+
     // Mock getSectionTagIds returning no tags
     (PlanGuidance.query as jest.Mock).mockResolvedValue([]);
-    
+
     const result = await guidanceService.getAffiliationsWithGuidanceForTemplate(context, 1);
-    
+
     expect(result).toEqual([]);
   });
 
   it("logs error and returns [] on exception", async () => {
     (VersionedTemplate.findById as jest.Mock).mockRejectedValue(new Error("Database error"));
-    
+
     const result = await guidanceService.getAffiliationsWithGuidanceForTemplate(context, 1);
-    
+
     expect(result).toEqual([]);
     expect(context.logger.error).toHaveBeenCalled();
   });
@@ -774,6 +781,141 @@ describe("getGuidanceSourcesForPlan", () => {
     const templateOwnerSource = result.find(s => s.type === "TEMPLATE_OWNER");
     expect(templateOwnerSource).toBeDefined();
     // guidanceText must NOT be prepended for template owner when customSectionId is provided
+    expect(templateOwnerSource.items).toHaveLength(1);
+    expect(templateOwnerSource.items[0].guidanceText).toEqual("NSF tag guidance");
+  });
+
+  it("should return [] if customQuestionId is provided but custom question not found", async () => {
+    (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
+    (VersionedCustomQuestion.findById as jest.Mock).mockResolvedValue(null);
+
+    const result = await guidanceService.getGuidanceSourcesForPlan(
+      context, mockPlan.id, undefined, undefined, undefined, 99
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("should use section tags when customQuestionId refers to a BASE-section question", async () => {
+    (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
+    (VersionedCustomQuestion.findById as jest.Mock).mockResolvedValue({
+      id: 42,
+      versionedSectionType: 'BASE',
+      versionedSectionId: 7,
+      guidanceText: null,
+    });
+    // getSectionTags is called with sectionId 7 — PlanGuidance.query receives ["7"]
+    (PlanGuidance.query as jest.Mock).mockResolvedValue([{ id: 1, name: "Data Sharing" }]);
+    (VersionedTemplate.findById as jest.Mock).mockResolvedValue(mockVersionedTemplate);
+    (PlanGuidance.findByPlanAndUserId as jest.Mock).mockResolvedValue([]);
+    (VersionedGuidance.findBestPracticeByTagIds as jest.Mock).mockResolvedValue(
+      mockBestPracticeGuidance
+    );
+    (VersionedGuidance.findByAffiliationAndTagIds as jest.Mock).mockResolvedValue([]);
+
+    const result = await guidanceService.getGuidanceSourcesForPlan(
+      context, mockPlan.id, undefined, undefined, undefined, 42
+    );
+
+    expect(VersionedCustomQuestion.findById).toHaveBeenCalled();
+    // getSectionTags uses the versionedSectionId (7), not the versionedTemplateId (973)
+    expect((PlanGuidance.query as jest.Mock).mock.calls[0][2]).toEqual(["7"]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: "bestPractice", type: "BEST_PRACTICE" });
+  });
+
+  it("should use template-wide tags when customQuestionId refers to a CUSTOM-section question", async () => {
+    (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
+    (VersionedCustomQuestion.findById as jest.Mock).mockResolvedValue({
+      id: 42,
+      versionedSectionType: 'CUSTOM',
+      versionedSectionId: 7,
+      guidanceText: null,
+    });
+    // getSectionTagsMap is called with versionedTemplateId — PlanGuidance.query receives ["973"]
+    (PlanGuidance.query as jest.Mock).mockResolvedValue([{ id: 2, name: "Preservation" }]);
+    (VersionedTemplate.findById as jest.Mock).mockResolvedValue(mockVersionedTemplate);
+    (PlanGuidance.findByPlanAndUserId as jest.Mock).mockResolvedValue([]);
+    (VersionedGuidance.findBestPracticeByTagIds as jest.Mock).mockResolvedValue(
+      mockBestPracticeGuidance
+    );
+    (VersionedGuidance.findByAffiliationAndTagIds as jest.Mock).mockResolvedValue([]);
+
+    const result = await guidanceService.getGuidanceSourcesForPlan(
+      context, mockPlan.id, undefined, undefined, undefined, 42
+    );
+
+    expect(VersionedCustomQuestion.findById).toHaveBeenCalled();
+    // getSectionTagsMap uses the versionedTemplateId (973), not the versionedSectionId
+    expect((PlanGuidance.query as jest.Mock).mock.calls[0][2]).toEqual(["973"]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: "bestPractice", type: "BEST_PRACTICE" });
+  });
+
+  it("should attribute guidanceText to user affiliation when customQuestionId is provided and no tags", async () => {
+    const userAffiliationUri = "https://ror.org/03yrm5c26"; // CDL
+    const localContext = {
+      ...context,
+      token: { ...context.token, affiliationId: userAffiliationUri },
+    };
+
+    (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
+    (VersionedCustomQuestion.findById as jest.Mock).mockResolvedValue({
+      id: 42,
+      versionedSectionType: 'BASE',
+      versionedSectionId: 7,
+      guidanceText: "Custom question guidance text",
+    });
+    (PlanGuidance.query as jest.Mock).mockResolvedValue([]); // no tags
+    (VersionedTemplate.findById as jest.Mock).mockResolvedValue(mockVersionedTemplate);
+    (PlanGuidance.findByPlanAndUserId as jest.Mock).mockResolvedValue([
+      { affiliationId: userAffiliationUri },
+    ]);
+    (Affiliation.findByURI as jest.Mock).mockResolvedValue(mockAffiliationCDL);
+
+    const result = await guidanceService.getGuidanceSourcesForPlan(
+      localContext as MyContext, mockPlan.id, undefined, undefined, undefined, 42
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: "USER_AFFILIATION",
+      orgURI: userAffiliationUri,
+      hasGuidance: true,
+    });
+    expect(result[0].items[0].guidanceText).toEqual("Custom question guidance text");
+  });
+
+  it("should not prepend guidanceText to template owner items when customQuestionId is used", async () => {
+    const localContext = {
+      ...context,
+      token: { ...context.token, affiliationId: "https://unrelated.org" },
+    };
+
+    (Plan.findById as jest.Mock).mockResolvedValue(mockPlan);
+    (VersionedCustomQuestion.findById as jest.Mock).mockResolvedValue({
+      id: 42,
+      versionedSectionType: 'BASE',
+      versionedSectionId: 7,
+      guidanceText: "Custom question guidance",
+    });
+    (PlanGuidance.query as jest.Mock).mockResolvedValue([{ id: 1, name: "Data Sharing" }]);
+    (VersionedTemplate.findById as jest.Mock).mockResolvedValue(mockVersionedTemplate);
+    (PlanGuidance.findByPlanAndUserId as jest.Mock).mockResolvedValue([
+      { affiliationId: mockVersionedTemplate.ownerId },
+    ]);
+    (VersionedGuidance.findBestPracticeByTagIds as jest.Mock).mockResolvedValue([]);
+    (VersionedGuidance.findByAffiliationAndTagIds as jest.Mock).mockResolvedValue([
+      { tagId: 1, guidanceText: "NSF tag guidance" },
+    ]);
+    (Affiliation.findByURI as jest.Mock).mockResolvedValue(mockAffiliationNSF);
+
+    const result = await guidanceService.getGuidanceSourcesForPlan(
+      localContext as MyContext, mockPlan.id, undefined, undefined, undefined, 42
+    );
+
+    const templateOwnerSource = result.find(s => s.type === "TEMPLATE_OWNER");
+    expect(templateOwnerSource).toBeDefined();
+    // guidanceText must NOT be prepended to template owner when customQuestionId is provided
     expect(templateOwnerSource.items).toHaveLength(1);
     expect(templateOwnerSource.items[0].guidanceText).toEqual("NSF tag guidance");
   });

--- a/src/services/guidanceService.ts
+++ b/src/services/guidanceService.ts
@@ -10,6 +10,7 @@ import { VersionedQuestion } from "../models/VersionedQuestion";
 import { VersionedQuestionCustomization } from "../models/VersionedQuestionCustomization";
 import { VersionedSectionCustomization } from "../models/VersionedSectionCustomization";
 import { VersionedCustomSection } from "../models/VersionedCustomSection";
+import { VersionedCustomQuestion } from "../models/VersionedCustomQuestion";
 import { Plan } from "../models/Plan";
 import { VersionedTemplate } from "../models/VersionedTemplate";
 import { prepareObjectForLogs } from "../logger";
@@ -294,7 +295,8 @@ export async function getGuidanceSourcesForPlan(
   planId: number,
   versionedSectionId?: number,
   versionedQuestionId?: number,
-  customSectionId?: number
+  customSectionId?: number,
+  customQuestionId?: number
 ): Promise<GuidanceSource[]> {
   const reference = 'getGuidanceSourcesForPlan';
 
@@ -340,6 +342,20 @@ export async function getGuidanceSourcesForPlan(
       // Get tags for the question's section
       tagsMap = await getSectionTags(context, question.versionedSectionId);
       guidanceText = question.guidanceText || null; // Question-level guidance
+    } else if (customQuestionId) {
+      // Custom question: guidance is owned by the user's institution
+      const customQuestion = await VersionedCustomQuestion.findById(
+        reference, context, customQuestionId
+      );
+      if (!customQuestion) return [];
+      guidanceText = customQuestion.guidanceText || null;
+      // Get tags from the parent section (which may be BASE or CUSTOM)
+      if (customQuestion.versionedSectionType === 'BASE') {
+        tagsMap = await getSectionTags(context, customQuestion.versionedSectionId);
+      } else {
+        // CUSTOM parent section — fall back to template-wide tags
+        tagsMap = await getSectionTagsMap(context, versionedTemplateId);
+      }
     } else if (versionedSectionId) { // Otherwise, get tags and guidance for the section id provided
 
       tagsMap = await getSectionTags(context, versionedSectionId);
@@ -374,6 +390,8 @@ export async function getGuidanceSourcesForPlan(
 
         customizationGuidanceText = sectionCustomization?.guidance || null;
       }
+      // customQuestionId: guidanceText is already on the VersionedCustomQuestion itself —
+      // no separate customization record exists for custom questions
     }
 
     // Get template owner info
@@ -387,8 +405,8 @@ export async function getGuidanceSourcesForPlan(
 
       // Add primary guidance source (customization or template owner)
       if (guidanceText) {
-        // Custom section guidance belongs to the institution, not the template owner
-        if (customSectionId && userAffiliationUri) {
+        // Custom section/question guidance belongs to the institution, not the template owner
+        if ((customSectionId || customQuestionId) && userAffiliationUri) {
           const affiliation = await Affiliation.findByURI(reference, context, userAffiliationUri);
           if (affiliation) {
             result.push({
@@ -512,9 +530,9 @@ export async function getGuidanceSourcesForPlan(
 
           const items = groupGuidanceByTag(tagBasedGuidance, sectionTagIds, tagsMap);
 
-          // For custom sections, the section's guidanceText IS the user's content — prepend it
+          // For custom sections/questions, the guidanceText IS the user's content — prepend it
           // For versioned sections, customizationGuidanceText is the override — prepend it
-          const customGuidanceText = customSectionId ? guidanceText : customizationGuidanceText;
+          const customGuidanceText = (customSectionId || customQuestionId) ? guidanceText : customizationGuidanceText;
           if (customGuidanceText) {
             items.unshift({
               title: affiliation.displayName || affiliation.name,
@@ -564,10 +582,10 @@ export async function getGuidanceSourcesForPlan(
 
           const items = groupGuidanceByTag(tagBasedGuidance, sectionTagIds, tagsMap);
 
-          // Only prepend section-level guidanceText for versioned sections.
-          // For custom sections, the section was created by the user's institution —
-          // the template owner has no section-level guidance to contribute here.
-          if (guidanceText && !customSectionId) {
+          // Only prepend section-level guidanceText for versioned sections/questions.
+          // For custom sections/questions, the content was created by the user's institution —
+          // the template owner has no guidance to contribute here.
+          if (guidanceText && !customSectionId && !customQuestionId) {
             items.unshift({
               title: affiliation.displayName || affiliation.name,
               guidanceText
@@ -589,7 +607,7 @@ export async function getGuidanceSourcesForPlan(
           });
 
           processedOrgURIs.add(templateOwnerUri);
-          
+
         }
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5295,6 +5295,11 @@ export type VersionedQuestion = {
   created?: Maybe<Scalars['String']['output']>;
   /** The user who created the Object */
   createdById?: Maybe<Scalars['Int']['output']>;
+  customizationGuidanceText?: Maybe<Scalars['String']['output']>;
+  /** For question customization info */
+  customizationId?: Maybe<Scalars['Int']['output']>;
+  customizationOwnerAffiliation?: Maybe<Affiliation>;
+  customizationSampleText?: Maybe<Scalars['String']['output']>;
   /** The display order of the VersionedQuestion */
   displayOrder?: Maybe<Scalars['Int']['output']>;
   /** Errors associated with the Object */
@@ -8083,6 +8088,10 @@ export type VersionedGuidanceGroupErrorsResolvers<ContextType = MyContext, Paren
 export type VersionedQuestionResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['VersionedQuestion'] = ResolversParentTypes['VersionedQuestion']> = {
   created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  customizationGuidanceText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  customizationId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  customizationOwnerAffiliation?: Resolver<Maybe<ResolversTypes['Affiliation']>, ParentType, ContextType>;
+  customizationSampleText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   displayOrder?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   errors?: Resolver<Maybe<ResolversTypes['VersionedQuestionErrors']>, ParentType, ContextType>;
   guidanceText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3176,6 +3176,8 @@ export type Query = {
   projectMembers?: Maybe<Array<Maybe<ProjectMember>>>;
   /** Search for VersionedQuestions that belong to Section specified by sectionId */
   publishedConditionsForQuestion?: Maybe<Array<Maybe<VersionedQuestionCondition>>>;
+  /** Get a specific published custom question based on versionedCustomQuestionId */
+  publishedCustomQuestion?: Maybe<VersionedCustomQuestion>;
   /** Fetch all published custom questions for the specified versioned section */
   publishedCustomQuestions?: Maybe<Array<Maybe<PublishedQuestion>>>;
   /** Fetch a specific VersionedCustomSection for a plan - resolved via the caller's affiliation */
@@ -3368,6 +3370,7 @@ export type QueryGuidanceGroupsArgs = {
 
 
 export type QueryGuidanceSourcesForPlanArgs = {
+  customQuestionId?: InputMaybe<Scalars['Int']['input']>;
   customSectionId?: InputMaybe<Scalars['Int']['input']>;
   planId: Scalars['Int']['input'];
   versionedQuestionId?: InputMaybe<Scalars['Int']['input']>;
@@ -3495,6 +3498,11 @@ export type QueryProjectMembersArgs = {
 
 export type QueryPublishedConditionsForQuestionArgs = {
   versionedQuestionId: Scalars['Int']['input'];
+};
+
+
+export type QueryPublishedCustomQuestionArgs = {
+  versionedCustomQuestionId: Scalars['Int']['input'];
 };
 
 
@@ -5112,6 +5120,8 @@ export type VersionedCustomQuestion = {
   modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
   modifiedById?: Maybe<Scalars['Int']['output']>;
+  /** Owner affiliation for the question */
+  ownerAffiliation?: Maybe<Affiliation>;
   /** The id of the question this custom question is pinned after */
   pinnedVersionedQuestionId?: Maybe<Scalars['Int']['output']>;
   /** The type of question this custom question is pinned after (null = first question in section) */
@@ -7336,6 +7346,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   projectMember?: Resolver<Maybe<ResolversTypes['ProjectMember']>, ParentType, ContextType, RequireFields<QueryProjectMemberArgs, 'projectMemberId'>>;
   projectMembers?: Resolver<Maybe<Array<Maybe<ResolversTypes['ProjectMember']>>>, ParentType, ContextType, RequireFields<QueryProjectMembersArgs, 'projectId'>>;
   publishedConditionsForQuestion?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedQuestionCondition']>>>, ParentType, ContextType, RequireFields<QueryPublishedConditionsForQuestionArgs, 'versionedQuestionId'>>;
+  publishedCustomQuestion?: Resolver<Maybe<ResolversTypes['VersionedCustomQuestion']>, ParentType, ContextType, RequireFields<QueryPublishedCustomQuestionArgs, 'versionedCustomQuestionId'>>;
   publishedCustomQuestions?: Resolver<Maybe<Array<Maybe<ResolversTypes['PublishedQuestion']>>>, ParentType, ContextType, RequireFields<QueryPublishedCustomQuestionsArgs, 'planId' | 'versionedCustomSectionId'>>;
   publishedCustomSection?: Resolver<Maybe<ResolversTypes['VersionedCustomSection']>, ParentType, ContextType, RequireFields<QueryPublishedCustomSectionArgs, 'customSectionId' | 'planId'>>;
   publishedQuestion?: Resolver<Maybe<ResolversTypes['VersionedQuestion']>, ParentType, ContextType, RequireFields<QueryPublishedQuestionArgs, 'versionedQuestionId'>>;
@@ -7972,6 +7983,7 @@ export type VersionedCustomQuestionResolvers<ContextType = MyContext, ParentType
   json?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  ownerAffiliation?: Resolver<Maybe<ResolversTypes['Affiliation']>, ParentType, ContextType>;
   pinnedVersionedQuestionId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   pinnedVersionedQuestionType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   questionText?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3297,7 +3297,8 @@ export type QueryAnswerArgs = {
 export type QueryAnswerByVersionedQuestionIdArgs = {
   planId: Scalars['Int']['input'];
   projectId: Scalars['Int']['input'];
-  versionedQuestionId: Scalars['Int']['input'];
+  versionedCustomQuestionId?: InputMaybe<Scalars['Int']['input']>;
+  versionedQuestionId?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -7306,7 +7307,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   affiliations?: Resolver<Maybe<ResolversTypes['AffiliationSearchResults']>, ParentType, ContextType, RequireFields<QueryAffiliationsArgs, 'name'>>;
   allProjects?: Resolver<Maybe<ResolversTypes['ProjectSearchResults']>, ParentType, ContextType, Partial<QueryAllProjectsArgs>>;
   answer?: Resolver<Maybe<ResolversTypes['Answer']>, ParentType, ContextType, RequireFields<QueryAnswerArgs, 'answerId' | 'projectId'>>;
-  answerByVersionedQuestionId?: Resolver<Maybe<ResolversTypes['Answer']>, ParentType, ContextType, RequireFields<QueryAnswerByVersionedQuestionIdArgs, 'planId' | 'projectId' | 'versionedQuestionId'>>;
+  answerByVersionedQuestionId?: Resolver<Maybe<ResolversTypes['Answer']>, ParentType, ContextType, RequireFields<QueryAnswerByVersionedQuestionIdArgs, 'planId' | 'projectId'>>;
   answers?: Resolver<Maybe<Array<Maybe<ResolversTypes['Answer']>>>, ParentType, ContextType, RequireFields<QueryAnswersArgs, 'planId' | 'projectId' | 'versionedSectionId'>>;
   bestPracticeGuidance?: Resolver<Array<ResolversTypes['VersionedGuidance']>, ParentType, ContextType, RequireFields<QueryBestPracticeGuidanceArgs, 'tagIds'>>;
   bestPracticeSections?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedSection']>>>, ParentType, ContextType>;


### PR DESCRIPTION
## Description
- Added `publishedCustomQuestion` query resolver and added to schema
- Updated `guidanceSourcesForPlan` query to pass in `customQuestionId` and updated `getGuidanceSourcesForPlan` service to add `customQuestion` guidance
- Updated sql query in `findActiveByTemplateAffiliationAndQuestion` function in `VersionedQuestionCustomization` model to include `affiliationId` so that we can get the name of the org that made the customization
- Updated `publishedQuestion` resolver in `versionedQuestion.ts` to return customization info, including customized sample answer and name of org that made the customization
- Updated `VersionedQuestion` schema to include `customizationId`, `customizationGuidanceText`, `customizationSampleText` and `customizationOwnerAffiliation` fields
- Updated `answerByVersionedQuestionId` query and `addAnswer` mutation to pass in `versionedCustomSectionId` and `versionedCustomQuestionid` variables so that we can get and save the correct answers

Fixes # ([173](https://github.com/CDLUC3/dmptool-doc/issues/173))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested and used updated unit tests


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules