### PR TITLE
Updates for custom question answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.1.0
 
 ### Added
+- Added `fetchAnswerCustomQuestion` to `Plan` model in order to get answered counts for custom questions [#161]
 - Added `publishedCustomQuestion` query resolver and added to schema [#173]
 - Added `ON DELETE CASCADE` sql migration script for deletion of `versionedTemplateCustomization` and `templateCustomization` FKs [#171]
 - Added `findByPosition` function to `CustomQuestion` to assist with reordering of custom questions [#171]
@@ -57,6 +58,8 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated `PlanProgress.findByPlanId` to use `fetchAnswerCustomQuestions` and return answered question counts that include the custom questions [#161]
+- Updated `PlanProgress.findByPlanId` to reuse the `PlanSectionProgress.findByPlanId` function to return `totalQuestions` and `answeredQuestions` [#161]
 - Updated `answerByVersionedQuestionId` query and `addAnswer` mutation to pass in `versionedCustomSectionId` and `versionedCustomQuestionid` variables so that we can get and save the correct answers [#173]
 - Updated sql query in `findActiveByTemplateAffiliationAndQuestion` function in `VersionedQuestionCustomization` model to include `affiliationId` so that we can get the name of the org that made the customization [#173]
 - Updated `publishedQuestion` resolver in `versionedQuestion.ts` to return customization info, including customized sample answer and name of org that made the customization [#173]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,6 +78,7 @@ services:
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
       - DEBUG=${DEBUG:-0}
       - SERVICES=ses,sqs,lambda,ssm,logs,events,dynamodb
+      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN}
     volumes:
       - "./docker/localstack:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,7 +78,6 @@ services:
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
       - DEBUG=${DEBUG:-0}
       - SERVICES=ses,sqs,lambda,ssm,logs,events,dynamodb
-      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN}
     volumes:
       - "./docker/localstack:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -224,6 +224,44 @@ export class PlanSectionProgress {
   }
 
   /**
+   * Fetch the count of custom questions that have been answered by section type for a given plan and template customization. 
+   * This allows us to credit answered custom questions in the progress calculation for both base and custom sections.
+   * @param reference
+   * @param context 
+   * @param planId 
+   * @param templateCustomizationId 
+   * @returns 
+   */
+  private static async fetchAnsweredCustomQuestions(
+    reference: string,
+    context: MyContext,
+    planId: number,
+    templateCustomizationId: number,
+  ): Promise<{ sectionId: number; sectionType: string; answeredCount: number }[]> {
+    const sql = `
+    SELECT
+      vcq.versionedSectionId  AS sectionId,
+      vcq.versionedSectionType AS sectionType,
+      COUNT(DISTINCT a.versionedCustomQuestionId) AS answeredCount
+    FROM answers a
+    JOIN versionedCustomQuestions vcq
+      ON vcq.id = a.versionedCustomQuestionId
+    JOIN versionedTemplateCustomizations vtc
+      ON vtc.id = vcq.versionedTemplateCustomizationId
+    WHERE a.planId = ?
+      AND vtc.templateCustomizationId = ?
+      AND NULLIF(TRIM(a.json), '') IS NOT NULL
+    GROUP BY vcq.versionedSectionId, vcq.versionedSectionType
+  `;
+    const rows = await Plan.query(
+      context, sql,
+      [planId.toString(), templateCustomizationId.toString()],
+      reference
+    );
+    return Array.isArray(rows) ? rows : [];
+  }
+
+  /**
    * Return the progress information for the plan by section, including any
    * custom sections or custom questions added via a template customization
    *
@@ -233,6 +271,8 @@ export class PlanSectionProgress {
    * @returns The progress information for the section or an empty array if the section does not exist
    */
   static async findByPlanId(reference: string, context: MyContext, planId: number, versionedTemplateId?: number): Promise<PlanSectionProgress[]> {
+    // First fetch base sections and their question counts, which we will use as the foundation to build out the full section list with custom sections 
+    // and adjusted question counts
     const sql = `SELECT
       vs.id AS versionedSectionId,
       vs.displayOrder,
@@ -294,35 +334,53 @@ export class PlanSectionProgress {
     );
 
     // No customization exists for this template — return base sections as-is
+    // totalQuestions and answeredQuestions will reflect only the base questions in this case
     if (!templateCustomizationId) return baseSections;
 
     // Fetch custom sections and extra question counts in parallel
-    const [customSectionRows, extraQuestionRows] = await Promise.all([
+    const [customSectionTotals, baseCustomQuestionTotals, answeredCustomTotals] = await Promise.all([
       this.fetchCustomSections(reference, context, templateCustomizationId),
       this.fetchExtraQuestionsForBaseSections(reference, context, templateCustomizationId),
+      this.fetchAnsweredCustomQuestions(reference, context, planId, templateCustomizationId),
     ]);
 
+    // Build answered-count maps keyed by sectionId, split by section type ("Base" vs "Custom") since they have different sectionId spaces
+    const answeredCustomByBaseSection = new Map<number, number>();
+    const answeredCustomByCustomSection = new Map<number, number>();
+
+    for (const row of answeredCustomTotals) {
+      if (row.sectionType === 'BASE') {
+        answeredCustomByBaseSection.set(row.sectionId, Number(row.answeredCount));
+      } else if (row.sectionType === 'CUSTOM') {
+        answeredCustomByCustomSection.set(row.sectionId, Number(row.answeredCount));
+      }
+    }
+
     // Bump totalQuestions on base sections that have extra custom questions
-    if (extraQuestionRows.length) {
+    if (baseCustomQuestionTotals.length) {
       const extraBySection = new Map<number, number>(
-        extraQuestionRows.map((r) => [r.versionedSectionId, Number(r.extraCount)])
+        baseCustomQuestionTotals.map((r) => [r.versionedSectionId, Number(r.extraCount)])
       );
       for (const section of baseSections) {
         const extra = extraBySection.get(section.versionedSectionId) ?? 0;
         if (extra > 0) section.totalQuestions += extra;
+
+        // Also credit answered custom questions on this base section
+        const answeredExtra = answeredCustomByBaseSection.get(section.versionedSectionId) ?? 0;
+        if (answeredExtra > 0) section.answeredQuestions += answeredExtra;
       }
     }
 
     // Build a map: pinnedId → custom sections pinned to it
-    const pinnedToMap = new Map<number, typeof customSectionRows>();
-    for (const cs of customSectionRows) {
+    const pinnedToMap = new Map<number, typeof customSectionTotals>();
+    for (const cs of customSectionTotals) {
       const existing = pinnedToMap.get(cs.pinnedSectionId) ?? [];
       existing.push(cs);
       pinnedToMap.set(cs.pinnedSectionId, existing);
     }
 
     // Recursively collect custom sections inserted after a given target id
-    function collectAfter(targetId: number, result: typeof customSectionRows, visited = new Set<number>()) {
+    function collectAfter(targetId: number, result: typeof customSectionTotals, visited = new Set<number>()) {
       if (visited.has(targetId)) return;
       visited.add(targetId);
       const pinned = (pinnedToMap.get(targetId) ?? []).sort((a, b) => a.id - b.id);
@@ -339,7 +397,7 @@ export class PlanSectionProgress {
     for (const base of baseSections) {
       orderedSections.push(new PlanSectionProgress({ ...base, displayOrder: displayOrder++ }));
 
-      const chain: typeof customSectionRows = [];
+      const chain: typeof customSectionTotals = [];
       collectAfter(base.versionedSectionId, chain);
 
       for (const cs of chain) {
@@ -350,7 +408,7 @@ export class PlanSectionProgress {
           title: cs.name,
           displayOrder: displayOrder++,
           totalQuestions: Number(cs.totalQuestions),
-          answeredQuestions: 0,
+          answeredQuestions: answeredCustomByCustomSection.get(cs.id) ?? 0,
           tags: [],
         }));
       }
@@ -386,24 +444,26 @@ export class PlanProgress {
    * @param planId The ID of the plan to return progress information for
    * @returns The overall progress information for the plan or null if the plan does not exist
    */
-  static async findByPlanId(reference: string, context: MyContext, planId: number): Promise<PlanProgress> {
-    const sql = `SELECT COUNT(DISTINCT vq.id) AS totalQuestions,
-        COUNT(DISTINCT CASE
-            WHEN a.id IS NOT NULL AND NULLIF(TRIM(a.json), '') IS NOT NULL
-            THEN vq.id
-        END) AS answeredQuestions
-        FROM plans p
-            JOIN versionedTemplates vt ON vt.id = p.versionedTemplateId
-            JOIN versionedSections  vs ON vs.versionedTemplateId = vt.id
-            JOIN versionedQuestions vq ON vq.versionedSectionId = vs.id
-            LEFT JOIN answers a
-                ON a.planId = p.id
-                AND a.versionedQuestionId = vq.id
-        WHERE p.id = ?;
-`
+  static async findByPlanId(
+    reference: string,
+    context: MyContext,
+    planId: number,
+    versionedTemplateId?: number  // add this param
+  ): Promise<PlanProgress> {
+    // Reuse PlanSectionProgress which already handles custom questions correctly
+    const sections = await PlanSectionProgress.findByPlanId(
+      reference,
+      context,
+      planId,
+      versionedTemplateId
+    );
 
-    const results = await Plan.query(context, sql, [planId?.toString()], reference);
-    return Array.isArray(results) && results.length > 0 ? new PlanProgress(results[0]) : null;
+    if (!sections.length) return null;
+
+    const totalQuestions = sections.reduce((sum, s) => sum + s.totalQuestions, 0);
+    const answeredQuestions = sections.reduce((sum, s) => sum + s.answeredQuestions, 0);
+
+    return new PlanProgress({ totalQuestions, answeredQuestions });
   }
 }
 

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -448,7 +448,7 @@ export class PlanProgress {
     reference: string,
     context: MyContext,
     planId: number,
-    versionedTemplateId?: number  // add this param
+    versionedTemplateId?: number
   ): Promise<PlanProgress> {
     // Reuse PlanSectionProgress which already handles custom questions correctly
     const sections = await PlanSectionProgress.findByPlanId(

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -250,7 +250,7 @@ export class PlanSectionProgress {
       ON vtc.id = vcq.versionedTemplateCustomizationId
     WHERE a.planId = ?
       AND vtc.templateCustomizationId = ?
-      AND NULLIF(TRIM(a.json), '') IS NOT NULL
+      AND JSON_TYPE(a.json) = 'OBJECT'
     GROUP BY vcq.versionedSectionId, vcq.versionedSectionType
   `;
     const rows = await Plan.query(
@@ -279,7 +279,7 @@ export class PlanSectionProgress {
       vs.name AS title,
       COUNT(DISTINCT vq.id) AS totalQuestions,
       COUNT(DISTINCT CASE
-          WHEN a.id IS NOT NULL AND NULLIF(TRIM(a.json), '') IS NOT NULL
+          WHEN a.id IS NOT NULL AND JSON_TYPE(a.json) = 'OBJECT'
           THEN vq.id
         END) AS answeredQuestions,
       COALESCE(tagAgg.tags, JSON_ARRAY()) AS tags

--- a/src/models/__tests__/Plan.spec.ts
+++ b/src/models/__tests__/Plan.spec.ts
@@ -200,7 +200,7 @@ describe('PlanSectionProgress.findByPlanId', () => {
       vs.name AS title,
       COUNT(DISTINCT vq.id) AS totalQuestions,
       COUNT(DISTINCT CASE
-          WHEN a.id IS NOT NULL AND NULLIF(TRIM(a.json), '') IS NOT NULL
+          WHEN a.id IS NOT NULL AND JSON_TYPE(a.json) = 'OBJECT'
           THEN vq.id
         END) AS answeredQuestions,
       COALESCE(tagAgg.tags, JSON_ARRAY()) AS tags

--- a/src/models/__tests__/Plan.spec.ts
+++ b/src/models/__tests__/Plan.spec.ts
@@ -188,12 +188,13 @@ describe('PlanSectionProgress.findByPlanId', () => {
 
   afterEach(() => {
     Plan.query = originalQuery;
+    jest.restoreAllMocks(); // moved here so all spyOn tests are cleaned up consistently
   });
 
   it('should call the correct SQL query', async () => {
-  const planId = casual.integer(1, 99);
-  const versionedTemplateId = casual.integer(1, 99);
-  const sql = `SELECT
+    const planId = casual.integer(1, 99);
+    const versionedTemplateId = casual.integer(1, 99);
+    const sql = `SELECT
       vs.id AS versionedSectionId,
       vs.displayOrder,
       vs.name AS title,
@@ -230,23 +231,17 @@ describe('PlanSectionProgress.findByPlanId', () => {
     ORDER BY vs.displayOrder;
 `
 
-  localQuery
-    .mockResolvedValueOnce([progress])  // first call: base sections query
-    .mockResolvedValueOnce([]);         // second call: findTemplateCustomizationId returns no customization
+    localQuery
+      .mockResolvedValueOnce([progress])  // first call: base sections query
+      .mockResolvedValueOnce([]);         // second call: findTemplateCustomizationId returns no customization
 
-  const result = await PlanSectionProgress.findByPlanId('testing', context, planId, versionedTemplateId);
+    const result = await PlanSectionProgress.findByPlanId('testing', context, planId, versionedTemplateId);
 
-  expect(localQuery).toHaveBeenCalledTimes(2);
-
-  // Check the FIRST call (base sections), not the last
-  expect(localQuery).toHaveBeenNthCalledWith(1, context, sql, [planId.toString()], 'testing');
-
-  // Check the SECOND call (customization lookup)
-  expect(localQuery).toHaveBeenNthCalledWith(2, context, expect.stringContaining('SELECT templateCustomizationId'), [versionedTemplateId.toString(), context.token.affiliationId], 'testing');
-
-  expect(result).toHaveLength(1);
-});
-
+    expect(localQuery).toHaveBeenCalledTimes(2);
+    expect(localQuery).toHaveBeenNthCalledWith(1, context, sql, [planId.toString()], 'testing');
+    expect(localQuery).toHaveBeenNthCalledWith(2, context, expect.stringContaining('SELECT templateCustomizationId'), [versionedTemplateId.toString(), context.token.affiliationId], 'testing');
+    expect(result).toHaveLength(1);
+  });
 
   it('should return an empty array if no results are found', async () => {
     localQuery.mockResolvedValueOnce([]);
@@ -274,6 +269,7 @@ describe('PlanSectionProgress.findByPlanId', () => {
     jest.spyOn(PlanSectionProgress as any, 'findTemplateCustomizationId').mockResolvedValue(99);
     jest.spyOn(PlanSectionProgress as any, 'fetchCustomSections').mockResolvedValue([]);
     jest.spyOn(PlanSectionProgress as any, 'fetchExtraQuestionsForBaseSections').mockResolvedValue([{ versionedSectionId: 1, extraCount: 3 }]);
+    jest.spyOn(PlanSectionProgress as any, 'fetchAnsweredCustomQuestions').mockResolvedValue([]);
 
     const result = await PlanSectionProgress.findByPlanId('ref', context, 123, 456);
     expect(result[0].totalQuestions).toBe(5);
@@ -284,11 +280,14 @@ describe('PlanSectionProgress.findByPlanId', () => {
 
   it('should not bump totalQuestions if no extra questions exist', async () => {
     const baseSection = { versionedSectionId: 1, displayOrder: 0, title: 'Base', totalQuestions: 2, answeredQuestions: 1, tags: [] };
-    localQuery
-      .mockResolvedValueOnce([baseSection]) // base sections
-      .mockResolvedValueOnce(99)            // findTemplateCustomizationId returns 99
-      .mockResolvedValueOnce([], [])        // fetchCustomSections returns []
-      .mockResolvedValueOnce([]);           // fetchExtraQuestionsForBaseSections
+    localQuery.mockResolvedValueOnce([baseSection]);
+
+    /*eslint-disable @typescript-eslint/no-explicit-any */
+    jest.spyOn(PlanSectionProgress as any, 'findTemplateCustomizationId').mockResolvedValue(99);
+    jest.spyOn(PlanSectionProgress as any, 'fetchCustomSections').mockResolvedValue([]);
+    jest.spyOn(PlanSectionProgress as any, 'fetchExtraQuestionsForBaseSections').mockResolvedValue([]);
+    jest.spyOn(PlanSectionProgress as any, 'fetchAnsweredCustomQuestions').mockResolvedValue([]);
+
     const result = await PlanSectionProgress.findByPlanId('ref', context, 123, 456);
     expect(result[0].totalQuestions).toBe(2);
   });
@@ -296,21 +295,19 @@ describe('PlanSectionProgress.findByPlanId', () => {
   it('should insert custom sections after the correct base section', async () => {
     const baseSection = { versionedSectionId: 1, displayOrder: 0, title: 'Base', totalQuestions: 2, answeredQuestions: 1, tags: [] };
     const customSection = { id: 10, name: 'Custom', pinnedSectionType: 'BASE', pinnedSectionId: 1, totalQuestions: 3 };
-
-    localQuery.mockResolvedValueOnce([baseSection]); // base sections
+    localQuery.mockResolvedValueOnce([baseSection]);
 
     /*eslint-disable @typescript-eslint/no-explicit-any */
     jest.spyOn(PlanSectionProgress as any, 'findTemplateCustomizationId').mockResolvedValue(99);
     jest.spyOn(PlanSectionProgress as any, 'fetchCustomSections').mockResolvedValue([customSection]);
     jest.spyOn(PlanSectionProgress as any, 'fetchExtraQuestionsForBaseSections').mockResolvedValue([]);
+    jest.spyOn(PlanSectionProgress as any, 'fetchAnsweredCustomQuestions').mockResolvedValue([]);
 
     const result = await PlanSectionProgress.findByPlanId('ref', context, 123, 456);
     expect(result).toHaveLength(2);
     expect(result[1].sectionType).toBeDefined();
     expect(result[1].customSectionId).toBe(10);
     expect(result[1].title).toBe('Custom');
-
-    jest.restoreAllMocks();
   });
 
   it('should insert chains of custom sections (custom sections pinned to other custom sections)', async () => {
@@ -323,6 +320,7 @@ describe('PlanSectionProgress.findByPlanId', () => {
     jest.spyOn(PlanSectionProgress as any, 'findTemplateCustomizationId').mockResolvedValue(99);
     jest.spyOn(PlanSectionProgress as any, 'fetchCustomSections').mockResolvedValue([customSection1, customSection2]);
     jest.spyOn(PlanSectionProgress as any, 'fetchExtraQuestionsForBaseSections').mockResolvedValue([]);
+    jest.spyOn(PlanSectionProgress as any, 'fetchAnsweredCustomQuestions').mockResolvedValue([]);
 
     const result = await PlanSectionProgress.findByPlanId('ref', context, 123, 456);
     expect(result).toHaveLength(3);
@@ -331,10 +329,76 @@ describe('PlanSectionProgress.findByPlanId', () => {
     expect(result[2].title).toBe('Custom2');
   });
 
+  it('should credit answered custom questions to the correct base section', async () => {
+    const baseSection = { versionedSectionId: 1, displayOrder: 0, title: 'Base', totalQuestions: 2, answeredQuestions: 1, tags: [] };
+    localQuery.mockResolvedValueOnce([baseSection]);
+
+    /*eslint-disable @typescript-eslint/no-explicit-any */
+    jest.spyOn(PlanSectionProgress as any, 'findTemplateCustomizationId').mockResolvedValue(99);
+    jest.spyOn(PlanSectionProgress as any, 'fetchCustomSections').mockResolvedValue([]);
+    jest.spyOn(PlanSectionProgress as any, 'fetchExtraQuestionsForBaseSections').mockResolvedValue([{ versionedSectionId: 1, extraCount: 2 }]);
+    jest.spyOn(PlanSectionProgress as any, 'fetchAnsweredCustomQuestions').mockResolvedValue([
+      { sectionId: 1, sectionType: 'BASE', answeredCount: 2 },
+    ]);
+
+    const result = await PlanSectionProgress.findByPlanId('ref', context, 123, 456);
+    expect(result[0].answeredQuestions).toBe(3); // 1 base + 2 custom answered
+  });
+
+  it('should credit answered custom questions to the correct custom section', async () => {
+    const baseSection = { versionedSectionId: 1, displayOrder: 0, title: 'Base', totalQuestions: 2, answeredQuestions: 1, tags: [] };
+    const customSection = { id: 10, name: 'Custom', pinnedSectionType: 'BASE', pinnedSectionId: 1, totalQuestions: 3 };
+    localQuery.mockResolvedValueOnce([baseSection]);
+
+    /*eslint-disable @typescript-eslint/no-explicit-any */
+    jest.spyOn(PlanSectionProgress as any, 'findTemplateCustomizationId').mockResolvedValue(99);
+    jest.spyOn(PlanSectionProgress as any, 'fetchCustomSections').mockResolvedValue([customSection]);
+    jest.spyOn(PlanSectionProgress as any, 'fetchExtraQuestionsForBaseSections').mockResolvedValue([]);
+    jest.spyOn(PlanSectionProgress as any, 'fetchAnsweredCustomQuestions').mockResolvedValue([
+      { sectionId: 10, sectionType: 'CUSTOM', answeredCount: 2 },
+    ]);
+
+    const result = await PlanSectionProgress.findByPlanId('ref', context, 123, 456);
+    const customResult = result.find(s => s.customSectionId === 10);
+    expect(customResult.answeredQuestions).toBe(2);
+  });
+
+  it('should not credit answered custom questions to the wrong section', async () => {
+    const baseSection = { versionedSectionId: 1, displayOrder: 0, title: 'Base', totalQuestions: 2, answeredQuestions: 1, tags: [] };
+    const customSection = { id: 10, name: 'Custom', pinnedSectionType: 'BASE', pinnedSectionId: 1, totalQuestions: 3 };
+    localQuery.mockResolvedValueOnce([baseSection]);
+
+    /*eslint-disable @typescript-eslint/no-explicit-any */
+    jest.spyOn(PlanSectionProgress as any, 'findTemplateCustomizationId').mockResolvedValue(99);
+    jest.spyOn(PlanSectionProgress as any, 'fetchCustomSections').mockResolvedValue([customSection]);
+    jest.spyOn(PlanSectionProgress as any, 'fetchExtraQuestionsForBaseSections').mockResolvedValue([]);
+    jest.spyOn(PlanSectionProgress as any, 'fetchAnsweredCustomQuestions').mockResolvedValue([
+      { sectionId: 10, sectionType: 'CUSTOM', answeredCount: 2 },
+    ]);
+
+    const result = await PlanSectionProgress.findByPlanId('ref', context, 123, 456);
+    const baseResult = result.find(s => s.versionedSectionId === 1);
+    expect(baseResult.answeredQuestions).toBe(1); // unchanged — credits belong to the custom section
+  });
+
+  it('should handle no answered custom questions gracefully', async () => {
+    const baseSection = { versionedSectionId: 1, displayOrder: 0, title: 'Base', totalQuestions: 2, answeredQuestions: 1, tags: [] };
+    localQuery.mockResolvedValueOnce([baseSection]);
+
+    /*eslint-disable @typescript-eslint/no-explicit-any */
+    jest.spyOn(PlanSectionProgress as any, 'findTemplateCustomizationId').mockResolvedValue(99);
+    jest.spyOn(PlanSectionProgress as any, 'fetchCustomSections').mockResolvedValue([]);
+    jest.spyOn(PlanSectionProgress as any, 'fetchExtraQuestionsForBaseSections').mockResolvedValue([]);
+    jest.spyOn(PlanSectionProgress as any, 'fetchAnsweredCustomQuestions').mockResolvedValue([]);
+
+    const result = await PlanSectionProgress.findByPlanId('ref', context, 123, 456);
+    expect(result[0].answeredQuestions).toBe(1); // unchanged
+  });
+
   it('should parse tags correctly if tags are a string', async () => {
     const baseSection = { versionedSectionId: 1, displayOrder: 0, title: 'Base', totalQuestions: 2, answeredQuestions: 1, tags: '[{"id":1,"slug":"foo","name":"Foo","description":"desc"}]' };
     localQuery.mockResolvedValueOnce([baseSection]);
-    const result = await PlanSectionProgress.findByPlanId('ref', context, 123);
+    const result = await PlanSectionProgress.findByPlanId('ref', context, 123, 456);
     expect(Array.isArray(result[0].tags)).toBe(true);
     expect(result[0].tags[0].slug).toBe('foo');
   });
@@ -342,7 +406,7 @@ describe('PlanSectionProgress.findByPlanId', () => {
   it('should handle empty or malformed tags gracefully', async () => {
     const baseSection = { versionedSectionId: 1, displayOrder: 0, title: 'Base', totalQuestions: 2, answeredQuestions: 1, tags: 'not-json' };
     localQuery.mockResolvedValueOnce([baseSection]);
-    const result = await PlanSectionProgress.findByPlanId('ref', context, 123);
+    const result = await PlanSectionProgress.findByPlanId('ref', context, 123, 456);
     expect(Array.isArray(result[0].tags)).toBe(true);
     expect(result[0].tags.length).toBe(0);
   });
@@ -356,13 +420,13 @@ describe('PlanSectionProgress.findByPlanId', () => {
   it('should set correct sectionType and IDs for custom and base sections', async () => {
     const baseSection = { versionedSectionId: 1, displayOrder: 0, title: 'Base', totalQuestions: 2, answeredQuestions: 1, tags: [] };
     const customSection = { id: 10, name: 'Custom', pinnedSectionType: 'BASE', pinnedSectionId: 1, totalQuestions: 3 };
-
     localQuery.mockResolvedValueOnce([baseSection]); // base sections
 
     /*eslint-disable @typescript-eslint/no-explicit-any */
     jest.spyOn(PlanSectionProgress as any, 'findTemplateCustomizationId').mockResolvedValue(99);
     jest.spyOn(PlanSectionProgress as any, 'fetchCustomSections').mockResolvedValue([customSection]);
     jest.spyOn(PlanSectionProgress as any, 'fetchExtraQuestionsForBaseSections').mockResolvedValue([]);
+    jest.spyOn(PlanSectionProgress as any, 'fetchAnsweredCustomQuestions').mockResolvedValue([]);
 
     const result = await PlanSectionProgress.findByPlanId('ref', context, 123, 456);
     expect(result[0].sectionType).toBeDefined();
@@ -376,13 +440,16 @@ describe('PlanSectionProgress.findByPlanId', () => {
     const customSection1 = { id: 10, name: 'Custom1', pinnedSectionType: 'BASE', pinnedSectionId: 1, totalQuestions: 3 };
     // Circular: customSection2 pinned to customSection1, customSection1 pinned to customSection2
     const customSection2 = { id: 11, name: 'Custom2', pinnedSectionType: 'CUSTOM', pinnedSectionId: 10, totalQuestions: 2 };
-    // Now, customSection1 is also pinned to customSection2 (circular)
+        // Now, customSection1 is also pinned to customSection2 (circular)
     customSection1.pinnedSectionId = 11;
-    localQuery
-      .mockResolvedValueOnce([baseSection]) // base sections
-      .mockResolvedValueOnce(99)            // findTemplateCustomizationId returns 99
-      .mockResolvedValueOnce([customSection1, customSection2], []) // fetchCustomSections returns both
-      .mockResolvedValueOnce([]);           // fetchExtraQuestionsForBaseSections
+    localQuery.mockResolvedValueOnce([baseSection]); // base sections
+
+    /*eslint-disable @typescript-eslint/no-explicit-any */
+    jest.spyOn(PlanSectionProgress as any, 'findTemplateCustomizationId').mockResolvedValue(99);
+    jest.spyOn(PlanSectionProgress as any, 'fetchCustomSections').mockResolvedValue([customSection1, customSection2]);
+    jest.spyOn(PlanSectionProgress as any, 'fetchExtraQuestionsForBaseSections').mockResolvedValue([]);
+    jest.spyOn(PlanSectionProgress as any, 'fetchAnsweredCustomQuestions').mockResolvedValue([]);
+
     const result = await PlanSectionProgress.findByPlanId('ref', context, 123, 456);
     // Should not hang, should return base + both customs at most
     expect(result.length).toBeGreaterThanOrEqual(1);
@@ -413,55 +480,69 @@ describe('PlanProgress', () => {
 });
 
 describe('PlanProgress.findByPlanId', () => {
-  const originalQuery = Plan.query;
-
-  let localQuery;
-  let progress;
+  let mockFindSectionProgress: jest.SpyInstance;
 
   beforeEach(() => {
-    localQuery = jest.fn();
-    (Plan.query as jest.Mock) = localQuery;
-
-    progress = new PlanProgress({
-      totalQuestions: casual.integer(50, 100),
-      answeredQuestions: casual.integer(0, 50)
-    });
+    mockFindSectionProgress = jest.spyOn(PlanSectionProgress, 'findByPlanId');
   });
 
   afterEach(() => {
-    Plan.query = originalQuery;
+    jest.restoreAllMocks();
   });
 
-  it('should call the correct SQL query', async () => {
-    localQuery.mockResolvedValueOnce([progress]);
+  it('should delegate to PlanSectionProgress.findByPlanId with the correct arguments', async () => {
+    mockFindSectionProgress.mockResolvedValueOnce([]);
     const planId = casual.integer(1, 99);
-    const sql = `SELECT COUNT(DISTINCT vq.id) AS totalQuestions,
-        COUNT(DISTINCT CASE
-            WHEN a.id IS NOT NULL AND NULLIF(TRIM(a.json), '') IS NOT NULL
-            THEN vq.id
-        END) AS answeredQuestions
-        FROM plans p
-            JOIN versionedTemplates vt ON vt.id = p.versionedTemplateId
-            JOIN versionedSections  vs ON vs.versionedTemplateId = vt.id
-            JOIN versionedQuestions vq ON vq.versionedSectionId = vs.id
-            LEFT JOIN answers a
-                ON a.planId = p.id
-                AND a.versionedQuestionId = vq.id
-        WHERE p.id = ?;
-`
-    const result = await PlanProgress.findByPlanId('testing', context, planId);
-    expect(localQuery).toHaveBeenCalledTimes(1);
-    expect(localQuery).toHaveBeenLastCalledWith(context, sql, [planId.toString()], 'testing')
-    expect(result).toEqual(progress);
+    const versionedTemplateId = casual.integer(1, 99);
+
+    await PlanProgress.findByPlanId('testing', context, planId, versionedTemplateId);
+
+    expect(mockFindSectionProgress).toHaveBeenCalledTimes(1);
+    expect(mockFindSectionProgress).toHaveBeenCalledWith('testing', context, planId, versionedTemplateId);
   });
 
-  it('should return 0 if no questions are found', async () => {
-    progress = new PlanProgress({
-      totalQuestions: 0,
-      answeredQuestions: 0
-    });
-    localQuery.mockResolvedValueOnce([]);
-    expect(progress.percentComplete).toEqual(0);
+  it('should return null if no sections are found', async () => {
+    mockFindSectionProgress.mockResolvedValueOnce([]);
+    const result = await PlanProgress.findByPlanId('testing', context, casual.integer(1, 99));
+    expect(result).toBeNull();
+  });
+
+  it('should aggregate totalQuestions and answeredQuestions across all sections', async () => {
+    const sections = [
+      new PlanSectionProgress({ versionedSectionId: 1, title: 'S1', displayOrder: 0, totalQuestions: 5, answeredQuestions: 3 }),
+      new PlanSectionProgress({ versionedSectionId: 2, title: 'S2', displayOrder: 1, totalQuestions: 10, answeredQuestions: 7 }),
+    ];
+    mockFindSectionProgress.mockResolvedValueOnce(sections);
+
+    const result = await PlanProgress.findByPlanId('testing', context, casual.integer(1, 99));
+
+    expect(result).toBeInstanceOf(PlanProgress);
+    expect(result.totalQuestions).toBe(15);
+    expect(result.answeredQuestions).toBe(10);
+  });
+
+  it('should calculate percentComplete correctly', async () => {
+    const sections = [
+      new PlanSectionProgress({ versionedSectionId: 1, title: 'S1', displayOrder: 0, totalQuestions: 4, answeredQuestions: 1 }),
+      new PlanSectionProgress({ versionedSectionId: 2, title: 'S2', displayOrder: 1, totalQuestions: 6, answeredQuestions: 4 }),
+    ];
+    mockFindSectionProgress.mockResolvedValueOnce(sections);
+
+    const result = await PlanProgress.findByPlanId('testing', context, casual.integer(1, 99));
+
+    expect(result.percentComplete).toBe(50.0); // 5/10 * 100
+  });
+
+  it('should return 0 percentComplete when totalQuestions is 0', async () => {
+    const sections = [
+      new PlanSectionProgress({ versionedSectionId: 1, title: 'S1', displayOrder: 0, totalQuestions: 0, answeredQuestions: 0 }),
+    ];
+    mockFindSectionProgress.mockResolvedValueOnce(sections);
+
+    const result = await PlanProgress.findByPlanId('testing', context, casual.integer(1, 99));
+
+    expect(result).toBeInstanceOf(PlanProgress);
+    expect(result.percentComplete).toBe(0);
   });
 });
 

--- a/src/resolvers/plan.ts
+++ b/src/resolvers/plan.ts
@@ -333,7 +333,7 @@ export const resolvers: Resolvers = {
     },
     progress: async (parent: Plan, _, context: MyContext): Promise<PlanProgress> => {
       if (parent?.id) {
-        return await PlanProgress.findByPlanId('plan progress resolver', context, parent.id);
+        return await PlanProgress.findByPlanId('plan progress resolver', context, parent.id, parent?.versionedTemplateId);
       }
       return null;
     },


### PR DESCRIPTION
## Description

- Added `fetchAnswerCustomQuestion` to `Plan` model in order to get answered counts for custom questions
- Updated `PlanProgress.findByPlanId` to use `fetchAnswerCustomQuestions` and return answered question counts that include the custom questions
- Updated `PlanProgress.findByPlanId` to reuse the `PlanSectionProgress.findByPlanId` function to return `totalQuestions` and `answeredQuestions`

Fixes # ([161](https://github.com/CDLUC3/dmptool-doc/issues/161))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested and tested with updated unit tests


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules