### PR TITLE
Updated version of @dmptool/utils so we can get the updates to include customizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated `@dmptool/utils` to `v2.0.0` to get `download` updates to capture customizations
 - Updated graphql codegen dependencies
 - Moved `re3data-os-populate.ts` to `data-migration/dataSync` directory.
 - Updated `re3data-os-populate.ts` to work with OpenSearch serverless collections

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@aws-sdk/signature-v4": "^3.370.0",
         "@aws-sdk/util-dynamodb": "^3.996.2",
         "@dmptool/types": "^3.1.3",
-        "@dmptool/utils": "^1.0.43",
+        "@dmptool/utils": "^2.0.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@graphql-tools/merge": "^9.1.7",
         "@graphql-tools/mock": "^9.1.5",
@@ -2555,9 +2555,9 @@
       }
     },
     "node_modules/@dmptool/utils": {
-      "version": "1.0.43",
-      "resolved": "https://registry.npmjs.org/@dmptool/utils/-/utils-1.0.43.tgz",
-      "integrity": "sha512-AL/5bhtFRMd3TcKoyLb16cm5xeMdSW9xB7alraCADmcEcyHwcfdF2HyyKfonqDIFnQa7/9CoE+oTLP5phQCZZw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dmptool/utils/-/utils-2.0.0.tgz",
+      "integrity": "sha512-qIfc+llYJytzFpHp8w9xC7VhHL83s0p/NA4c27Ha7+TKQoM3zC0CqoIyK0CKvvYLqlZPBbWISTfr91wy2DsBpQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@aws-sdk/signature-v4": "^3.370.0",
     "@aws-sdk/util-dynamodb": "^3.996.2",
     "@dmptool/types": "^3.1.3",
-    "@dmptool/utils": "^1.0.43",
+    "@dmptool/utils": "^2.0.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@graphql-tools/merge": "^9.1.7",
     "@graphql-tools/mock": "^9.1.5",


### PR DESCRIPTION
## Description

I was testing the downloads on `dev` and `stage`. Downloads were not working on `dev`, and on `stage` not all the customization info was coming through. I realized that we never updated the version of `@dmptool/utils` to capture the recent changes to include customizations.

- Updated version of `@dmptool/utils` to `v2.0.01`