### PR TITLE
Update plan requestFeedback to save message and send email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.1.0
 
 ### Added
+- Added `messageToOrg` field in `feedback` table [#189]
 - Added `fetchAnswerCustomQuestion` to `Plan` model in order to get answered counts for custom questions [#161]
 - Added `publishedCustomQuestion` query resolver and added to schema [#173]
 - Added `ON DELETE CASCADE` sql migration script for deletion of `versionedTemplateCustomization` and `templateCustomization` FKs [#171]
@@ -58,6 +59,7 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated `requestFeedback` resolver to save `messageToOrg` in `feedback` table, as well as to email the message to `feedbackEmails` from the `affiliations` table [#189]
 - Moved `re3data-os-populate.ts` to `data-migration/dataSync` directory.
 - Updated `re3data-os-populate.ts` to work with OpenSearch serverless collections
 - Fixed some typescipt issues with the re3data import script
@@ -134,6 +136,7 @@
 - Removed `ioredis` package
 
 ### Fixed
+- Fixed some new `type` errors in `feedback` resolver and `emailService` brought on by a recent update to `typescript-eslint` [#189]
 - Had issue running `nuke-db.sh` and `process.sh`, so I turned off SSL by using `--ssl=off` instead
 - Fixed `fetchTemplateData` query in `TemplateCustomization` model because `questionCustomizationHasSampleText` was incorrectly returning true [#130] 
 - In `preparePaginationOptions` function, wrapped each cursorField with `COALESCE` to handle `NULL` values in SQL `CONCAT`, otherwise if any cursorField is NULL, it would just return a null value due to the way `CONCAT` works [#107]
@@ -141,6 +144,7 @@
 - Fixed issue with templates not cloning with sections and questions by updating the `addTemplate` mutation to clone from non-versioned template, section and question [#1006]
 
 ### Chore
+- Added `@types/nodemailer` [#189]
 - Added override for `lodash` to `4.18.1` to address high vulnerability issue
 
 ## v1.0

--- a/data-migrations/2026-04-20-1007-add-messageToOrg-to-feedback.sql
+++ b/data-migrations/2026-04-20-1007-add-messageToOrg-to-feedback.sql
@@ -1,0 +1,3 @@
+-- Add messageToOrg column to feedback table, which can be NULL
+ALTER TABLE `feedback`
+ADD COLUMN `messageToOrg` text NULL AFTER `completed`;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,6 +78,7 @@ services:
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
       - DEBUG=${DEBUG:-0}
       - SERVICES=ses,sqs,lambda,ssm,logs,events,dynamodb
+      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN}
     volumes:
       - "./docker/localstack:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,7 +78,6 @@ services:
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
       - DEBUG=${DEBUG:-0}
       - SERVICES=ses,sqs,lambda,ssm,logs,events,dynamodb
-      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN}
     volumes:
       - "./docker/localstack:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@aws-sdk/signature-v4": "^3.370.0",
         "@aws-sdk/util-dynamodb": "^3.996.2",
         "@dmptool/types": "^3.1.3",
-        "@dmptool/utils": "^1.0.43",
+        "@dmptool/utils": "^2.0.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@graphql-tools/merge": "^9.1.7",
         "@graphql-tools/mock": "^9.1.5",
@@ -2555,9 +2555,9 @@
       }
     },
     "node_modules/@dmptool/utils": {
-      "version": "1.0.43",
-      "resolved": "https://registry.npmjs.org/@dmptool/utils/-/utils-1.0.43.tgz",
-      "integrity": "sha512-AL/5bhtFRMd3TcKoyLb16cm5xeMdSW9xB7alraCADmcEcyHwcfdF2HyyKfonqDIFnQa7/9CoE+oTLP5phQCZZw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dmptool/utils/-/utils-2.0.0.tgz",
+      "integrity": "sha512-qIfc+llYJytzFpHp8w9xC7VhHL83s0p/NA4c27Ha7+TKQoM3zC0CqoIyK0CKvvYLqlZPBbWISTfr91wy2DsBpQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "@types/express": "^5.0.6",
         "@types/express-oauth-server": "^2.0.10",
         "@types/jest": "^30.0.0",
+        "@types/nodemailer": "^8.0.0",
         "@types/oauth2-server": "^3.0.18",
         "@types/supertest": "^7.2.0",
         "assert": "^2.1.0",
@@ -6117,6 +6118,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
+      "integrity": "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/oauth2-server": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/signature-v4": "^3.370.0",
     "@aws-sdk/util-dynamodb": "^3.996.2",
     "@dmptool/types": "^3.1.3",
-    "@dmptool/utils": "^1.0.43",
+    "@dmptool/utils": "^2.0.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@graphql-tools/merge": "^9.1.7",
     "@graphql-tools/mock": "^9.1.5",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@types/express": "^5.0.6",
     "@types/express-oauth-server": "^2.0.10",
     "@types/jest": "^30.0.0",
+    "@types/nodemailer": "^8.0.0",
     "@types/oauth2-server": "^3.0.18",
     "@types/supertest": "^7.2.0",
     "assert": "^2.1.0",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -118,8 +118,8 @@ export function initLogger(baseLogger: Logger, contextFields: LoggerContext): Lo
 }
 
 // Filter out undefined fields for cleaner logs
-export function prepareObjectForLogs(obj: object): object {
-  if (isNullOrUndefined(obj)) return {};
+export function prepareObjectForLogs(obj: unknown): object {
+  if (isNullOrUndefined(obj) || typeof obj !== 'object') return {};
 
   const cleansed = redactSensitiveInfo(obj, new WeakSet());
   return Object.fromEntries(

--- a/src/models/MySqlModel.ts
+++ b/src/models/MySqlModel.ts
@@ -157,10 +157,9 @@ export class MySqlModel {
   // Get the default pagination options
   static getDefaultPaginationOptions(): PaginationOptionsForCursors {
     return {
-      type: PaginationType.CURSOR,
       limit: generalConfig.defaultSearchLimit,
-      cursor: undefined,
-    };
+      cursor: null,
+    } as PaginationOptionsForCursors;
   }
 
   // Determine the pagination limit base on the provided limit or the default
@@ -228,10 +227,10 @@ export class MySqlModel {
 
     } else {
       opts = paginationOptions as PaginationOptionsForCursors;
-      const {sortField} = opts;
+      const { sortField } = opts;
       // If a sort field was provided and its in the list of available sort fields
       const cursorFields = isNullOrUndefined(opts.cursorField) ? ['id'] : [opts.cursorField];
-      if(sortField && sortFields.includes(sortField)){
+      if (sortField && sortFields.includes(sortField)) {
         cursorFields.unshift(sortField);
       }
 
@@ -414,7 +413,7 @@ export class MySqlModel {
       apolloContext.logger.error(prepareObjectForLogs(err), msg);
       return {
         limit: generalConfig.defaultSearchLimit,
-        currentOffset: undefined,
+        currentOffset: null,
         totalCount: 0,
         hasNextPage: false,
         hasPreviousPage: false,
@@ -502,7 +501,7 @@ export class MySqlModel {
       apolloContext.logger.error(prepareObjectForLogs(err), msg);
       return {
         limit: generalConfig.defaultSearchLimit,
-        nextCursor: undefined,
+        nextCursor: null,
         totalCount: 0,
         hasNextPage: false,
         items: []
@@ -584,7 +583,7 @@ export class MySqlModel {
                  WHERE id = ?`;
 
     const vals = props.map((entry) => this.prepareValue(entry.value, typeof (entry.value)));
-    if(!obj.id){
+    if (!obj.id) {
       const msg = `${reference}, ERROR: Cannot update record in ${table} because id is not set.`;
       apolloContext.logger.error(msg);
       return null;

--- a/src/models/MySqlModel.ts
+++ b/src/models/MySqlModel.ts
@@ -57,7 +57,7 @@ export class MySqlModel {
   async isValid(): Promise<boolean> {
     if (!validateDate(this.created)) this.addError('created', 'Created date can\'t be blank');
 
-    if (!validateDate(this.modified)) this.addError('modified', 'Modified date can\'t be blank');
+    if (!validateDate(this.modified ?? '')) this.addError('modified', 'Modified date can\'t be blank');
 
     if (this.createdById === null) this.addError('createdById', 'Created by can\'t be blank');
 
@@ -148,7 +148,7 @@ export class MySqlModel {
       const results = await MySqlModel.query(apolloContext, sql, [id.toString()], reference);
       return results && results.length === 1;
     } catch (err) {
-      const msg = `${reference}, ERROR: ${err.message}`;
+      const msg = `${reference}, ERROR: ${err instanceof Error ? err.message : String(err)}`;
       apolloContext.logger.error(prepareObjectForLogs(err), msg);
       return false;
     }
@@ -157,9 +157,10 @@ export class MySqlModel {
   // Get the default pagination options
   static getDefaultPaginationOptions(): PaginationOptionsForCursors {
     return {
+      type: PaginationType.CURSOR,
       limit: generalConfig.defaultSearchLimit,
-      cursor: null,
-    } as PaginationOptionsForCursors;
+      cursor: undefined,
+    };
   }
 
   // Determine the pagination limit base on the provided limit or the default
@@ -203,7 +204,7 @@ export class MySqlModel {
         return Array.isArray(countResponse) && countResponse.length > 0 ? countResponse?.[0]?.total : 0;
       }
     } catch (err) {
-      const msg = `${reference}, ERROR: ${err.message}`;
+      const msg = `${reference}, ERROR: ${err instanceof Error ? err.message : String(err)}`;
       apolloContext.logger.error(prepareObjectForLogs(err), msg);
       return 0;
     }
@@ -227,11 +228,11 @@ export class MySqlModel {
 
     } else {
       opts = paginationOptions as PaginationOptionsForCursors;
-      const cursorFields = isNullOrUndefined(opts.cursorField) ? ['id'] : [opts.cursorField];
-
+      const {sortField} = opts;
       // If a sort field was provided and its in the list of available sort fields
-      if (!isNullOrUndefined(paginationOptions.sortField) && sortFields.includes(paginationOptions.sortField)) {
-        cursorFields.unshift(paginationOptions.sortField);
+      const cursorFields = isNullOrUndefined(opts.cursorField) ? ['id'] : [opts.cursorField];
+      if(sortField && sortFields.includes(sortField)){
+        cursorFields.unshift(sortField);
       }
 
       // Wrap each field with COALESCE to handle NULL values in SQL CONCAT
@@ -275,7 +276,7 @@ export class MySqlModel {
         const resp = await dataSources.sqlDataSource.query(apolloContext, sql, vals);
         return Array.isArray(resp) ? resp : [resp];
       } catch (err) {
-        const msg = `${reference}, ERROR: ${err.message}`;
+        const msg = `${reference}, ERROR: ${err instanceof Error ? err.message : String(err)}`;
         apolloContext.logger.error(prepareObjectForLogs(err), msg);
         return [];
       }
@@ -337,7 +338,8 @@ export class MySqlModel {
         );
       }
     } catch (err) {
-      const msg = `${reference}, ERROR: ${err.message}`;
+      const msg = `${reference}, ERROR: ${err instanceof Error ? err.message : String(err)}`;
+
       apolloContext.logger.error(prepareObjectForLogs(err), msg);
       return {
         limit: generalConfig.defaultSearchLimit,
@@ -408,11 +410,11 @@ export class MySqlModel {
         availableSortFields: options.availableSortFields ?? [],
       };
     } catch (err) {
-      const msg = `${reference}, ERROR: ${err.message}`;
+      const msg = `${reference}, ERROR: ${err instanceof Error ? err.message : String(err)}`;
       apolloContext.logger.error(prepareObjectForLogs(err), msg);
       return {
         limit: generalConfig.defaultSearchLimit,
-        currentOffset: null,
+        currentOffset: undefined,
         totalCount: 0,
         hasNextPage: false,
         hasPreviousPage: false,
@@ -495,11 +497,12 @@ export class MySqlModel {
         availableSortFields: options.availableSortFields ?? [],
       };
     } catch (err) {
-      const msg = `${reference}, ERROR: ${err.message}`;
+      const msg = `${reference}, ERROR: ${err instanceof Error ? err.message : String(err)}`;
+
       apolloContext.logger.error(prepareObjectForLogs(err), msg);
       return {
         limit: generalConfig.defaultSearchLimit,
-        nextCursor: null,
+        nextCursor: undefined,
         totalCount: 0,
         hasNextPage: false,
         items: []
@@ -519,7 +522,7 @@ export class MySqlModel {
     obj: MySqlModel & { userId?: number },
     reference = 'undefined caller',
     skipKeys?: string[]
-  ): Promise<number> {
+  ): Promise<number | null> {
     // If the createdById and modifiedById have not alredy been set, use the value in the token or the userId
     if (!obj.createdById) {
       obj.createdById = apolloContext?.token?.id ?? obj.userId;
@@ -558,7 +561,7 @@ export class MySqlModel {
     reference = 'undefined caller',
     skipKeys?: string[],
     noTouch?: boolean,
-  ): Promise<MySqlModel> {
+  ): Promise<MySqlModel | null> {
     // Update the modifier info
     if (noTouch !== true) {
       // Only update the modifiedById if we have a token otherwise leave it as is
@@ -581,6 +584,11 @@ export class MySqlModel {
                  WHERE id = ?`;
 
     const vals = props.map((entry) => this.prepareValue(entry.value, typeof (entry.value)));
+    if(!obj.id){
+      const msg = `${reference}, ERROR: Cannot update record in ${table} because id is not set.`;
+      apolloContext.logger.error(msg);
+      return null;
+    }
     // Make sure the record id is the last value
     vals.push(obj.id.toString());
 

--- a/src/models/PlanFeedback.ts
+++ b/src/models/PlanFeedback.ts
@@ -2,6 +2,22 @@ import { MyContext } from "../context";
 import { MySqlModel } from "./MySqlModel";
 import { PlanFeedbackStatusEnum } from "../types";
 
+interface PlanFeedbackOptions {
+  id?: number;
+  created?: string;
+  createdById?: number;
+  modified?: string;
+  modifiedById?: number;
+  errors?: Record<string, string>;
+  planId: number;
+  requested: string;
+  requestedById: number;
+  completed?: string;
+  completedById?: number;
+  summaryText?: string;
+  messageToOrg?: string;
+}
+
 export class PlanFeedback extends MySqlModel {
   public planId: number;
   public requested: string;
@@ -9,10 +25,11 @@ export class PlanFeedback extends MySqlModel {
   public completed?: string; //Optional - won't exist initially when request is made
   public completedById?: number; //Optional - won't exist initially when request is made
   public summaryText?: string; //Optional - won't exist initially when request is made
+  public messageToOrg?: string; //Optional - won't exist initially when request is made
 
   private static tableName = 'feedback';
 
-  constructor(options) {
+  constructor(options: PlanFeedbackOptions) {
     super(options.id, options.created, options.createdById, options.modified, options.modifiedById, options.errors);
 
     this.planId = options.planId;
@@ -21,6 +38,7 @@ export class PlanFeedback extends MySqlModel {
     this.completed = options.completed;
     this.completedById = options.completedById;
     this.summaryText = options.summaryText;
+    this.messageToOrg = options.messageToOrg;
   }
 
   // Validation to be used prior to saving the record
@@ -41,25 +59,32 @@ export class PlanFeedback extends MySqlModel {
   }
 
   //Create new PlanFeedback
-  async create(context: MyContext): Promise<PlanFeedback> {
+  async create(context: MyContext): Promise<PlanFeedback | null> {
     const reference = 'PlanFeedback.create';
 
     // First make sure the record is valid
     if (await this.isValid()) {
-
       // My assumption is that you can have multiple rounds of requests for the same planId, so we don't need to check if it already exists
       // Save the record and then fetch it
       const newId = await PlanFeedback.insert(context, PlanFeedback.tableName, this, reference);
-      const response = await PlanFeedback.findById(reference, context, newId);
-      return response;
-
+      // If no id was returned then something went wrong with the insert and we should log an error and return the object with an error message
+      if(!newId){
+        const msg = `${reference}, ERROR: Failed to create PlanFeedback.`;
+        context.logger.error(msg);
+        // Something went wrong with the insert and we don't have an id for the new record so we should log an error and return the object with an error message
+        this.addError('general', 'PlanFeedback was not created successfully');
+        return new PlanFeedback(this);
+      } else {
+        const response = await PlanFeedback.findById(reference, context, newId);
+        return response;
+      }
     }
     // Otherwise return as-is with all the errors
     return new PlanFeedback(this);
   }
 
   //Update an existing PlanFeedback
-  async update(context: MyContext, noTouch = false): Promise<PlanFeedback> {
+  async update(context: MyContext, noTouch = false): Promise<PlanFeedback | null> {
     if (await this.isValid()) {
       if (this.id) {
         this.prepForSave();
@@ -73,7 +98,7 @@ export class PlanFeedback extends MySqlModel {
   }
 
   //Delete the PlanFeedback
-  async delete(context: MyContext): Promise<PlanFeedback> {
+  async delete(context: MyContext): Promise<PlanFeedback | null> {
     if (this.id) {
       const deleted = await PlanFeedback.findById('PlanFeedback.delete', context, this.id);
 
@@ -93,7 +118,7 @@ export class PlanFeedback extends MySqlModel {
   }
 
   // Fetch a PlanFeedback by it's id
-  static async findById(reference: string, context: MyContext, feedbackId: number): Promise<PlanFeedback> {
+  static async findById(reference: string, context: MyContext, feedbackId: number): Promise<PlanFeedback | null> {
     const sql = `SELECT * FROM ${PlanFeedback.tableName} WHERE id = ?`;
     const results = await PlanFeedback.query(context, sql, [feedbackId?.toString()], reference);
     return Array.isArray(results) && results.length > 0 ? new PlanFeedback(results[0]) : null;

--- a/src/models/__tests__/PlanFeedback.spec.ts
+++ b/src/models/__tests__/PlanFeedback.spec.ts
@@ -219,6 +219,7 @@ describe('create', () => {
 
   beforeEach(() => {
     insertQuery = jest.fn();
+    insertQuery.mockResolvedValueOnce({ insertId: 123 });
     (PlanFeedback.insert as jest.Mock) = insertQuery;
 
     planFeedback = new PlanFeedback({
@@ -256,7 +257,6 @@ describe('create', () => {
     const mockFindById = jest.fn();
     (PlanFeedback.findById as jest.Mock) = mockFindById;
     mockFindById.mockResolvedValueOnce(planFeedback);
-
     const result = await planFeedback.create(context);
     expect(mockFindById).toHaveBeenCalledTimes(1);
     expect(insertQuery).toHaveBeenCalledTimes(1);

--- a/src/resolvers/affiliation.ts
+++ b/src/resolvers/affiliation.ts
@@ -15,6 +15,7 @@ import { PaginationOptionsForCursors, PaginationOptionsForOffsets, PaginationTyp
 import { isNullOrUndefined, normaliseDateTime } from "../utils/helpers";
 import { GuidanceGroup } from "../models/GuidanceGroup";
 import { getAffiliationsWithGuidanceForTemplate } from "../services/guidanceService";
+import { ResolversParentTypes } from "../types";
 
 export const resolvers: Resolvers = {
   Query: {
@@ -27,11 +28,11 @@ export const resolvers: Resolvers = {
     affiliations: async (_, { name, funderOnly, paginationOptions }, context: MyContext): Promise<AffiliationSearchResults> => {
       const reference = 'affiliations resolver';
       try {
-        const opts = !isNullOrUndefined(paginationOptions) && paginationOptions.type === PaginationType.OFFSET
+        const opts = !isNullOrUndefined(paginationOptions) && paginationOptions?.type === PaginationType.OFFSET
           ? paginationOptions as PaginationOptionsForOffsets
           : { ...paginationOptions, type: PaginationType.CURSOR } as PaginationOptionsForCursors;
 
-        return await AffiliationSearch.search(reference, context, name, funderOnly, opts);
+        return await AffiliationSearch.search(reference, context, name, funderOnly ?? false, opts);
       } catch (err) {
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
         throw InternalServerError();
@@ -61,7 +62,7 @@ export const resolvers: Resolvers = {
           };
         }
 
-        const opts = !isNullOrUndefined(paginationOptions) && paginationOptions.type === PaginationType.OFFSET
+        const opts = !isNullOrUndefined(paginationOptions) && paginationOptions?.type === PaginationType.OFFSET
           ? paginationOptions as PaginationOptionsForOffsets
           : { ...paginationOptions, type: PaginationType.CURSOR } as PaginationOptionsForCursors;
 
@@ -69,7 +70,7 @@ export const resolvers: Resolvers = {
         return await AffiliationSearch.searchManagedWithPublishedGuidance(
           reference, 
           context, 
-          name, 
+          name ?? undefined,
           affiliationUris,
           opts
         );
@@ -141,8 +142,8 @@ export const resolvers: Resolvers = {
     updateAffiliation: async (_, { input }, context: MyContext): Promise<Affiliation> => {
       const reference = 'updateAffiliation resolver';
       try {
-        let existing = await Affiliation.findById(reference, context, input.id);
-        existing = existing || await Affiliation.findByURI(reference, context, input.uri);
+        let existing = input.id ? await Affiliation.findById(reference, context, input.id) : null;
+        existing = existing || (input.uri ? await Affiliation.findByURI(reference, context, input.uri) : null);
 
         // If the record doesn't exist
         if (!existing) {
@@ -198,7 +199,7 @@ export const resolvers: Resolvers = {
   },
 
   Affiliation: {
-    guidanceGroups: async (parent: Affiliation, _, context: MyContext): Promise<GuidanceGroup[]> => {
+    guidanceGroups: async (parent: ResolversParentTypes['Affiliation'], _, context: MyContext): Promise<GuidanceGroup[]> => {
       const reference = 'Affiliation.guidanceGroups resolver';
       try {
         // Require authentication
@@ -239,11 +240,11 @@ export const resolvers: Resolvers = {
         throw InternalServerError();
       }
     },
-    created: (parent: Affiliation) => {
-      return normaliseDateTime(parent.created);
+    created: (parent: ResolversParentTypes['Affiliation']) => {
+      return normaliseDateTime(parent.created ?? null);
     },
-    modified: (parent: Affiliation) => {
-      return normaliseDateTime(parent.modified);
+    modified: (parent: ResolversParentTypes['Affiliation']) => {
+      return normaliseDateTime(parent.modified ?? null);
     }
   }
 }

--- a/src/resolvers/feedback.ts
+++ b/src/resolvers/feedback.ts
@@ -10,7 +10,7 @@ import {
 
 import { isAuthorized } from "../services/authService";
 import { hasPermissionOnProject } from "../services/projectService";
-import { sendProjectCollaboratorsCommentsAddedEmail } from '../services/emailService';
+import { sendProjectCollaboratorsCommentsAddedEmail, sendFeedbackRequestEmail } from '../services/emailService';
 import { isAdmin, isSuperAdmin } from "../services/authService";
 import { canDeleteComment } from "../services/commentPermissions";
 import { Project } from "../models/Project";
@@ -20,6 +20,7 @@ import { User } from "../models/User";
 import { ProjectCollaborator } from "../models/Collaborator";
 import { PlanFeedbackComment } from "../models/PlanFeedbackComment";
 import { VersionedTemplate } from "../models/VersionedTemplate";
+import { Affiliation } from "../models/Affiliation";
 import { ResolversParentTypes } from "../types";
 import { Resolvers, PlanFeedbackStatusEnum } from "../types";
 import { getCurrentDate } from "../utils/helpers";
@@ -148,9 +149,10 @@ export const resolvers: Resolvers = {
 
   Mutation: {
     //Request a round of admin feedback
-    requestFeedback: async (_, { planId, messageToOrg }, context: MyContext): Promise<PlanFeedback> => {
+    requestFeedback: async (_, { planId, messageToOrg }, context: MyContext): Promise<PlanFeedback | null> => {
       const reference = 'requestFeedback resolver';
 
+      console.log("***Context in requestFeedback resolver: ", context); //context.token?.affiliationId
       try {
         if (isAuthorized(context.token)) {
           const plan = await Plan.findById(reference, context, planId);
@@ -181,10 +183,20 @@ export const resolvers: Resolvers = {
           if (await hasPermissionOnProject(context, project)) {
             const feedbackComment = new PlanFeedback({
               planId,
-              messageToOrg,
+              messageToOrg: messageToOrg ?? '',
               requestedById: context.token.id,
               requested: getCurrentDate()
             });
+
+            const affiliationId = context.token.affiliationId;
+            if (!affiliationId) {
+              throw NotFoundError(`Affiliation for user not found`);
+            }
+
+            const affiliation = await Affiliation.findByURI(reference, context, affiliationId);
+            // Send emails to
+            await sendFeedbackRequestEmail(context, affiliation.feedbackEmails, messageToOrg ?? '');
+
 
             return await feedbackComment.create(context);
           }
@@ -213,6 +225,10 @@ export const resolvers: Resolvers = {
 
           if (await hasPermissionOnProject(context, project)) {
             const feedback = await PlanFeedback.findById(reference, context, planFeedbackId);
+            if (!feedback) {
+              throw NotFoundError(`PlanFeedback with ID ${planFeedbackId} not found`);
+            }
+
 
             const newFeedback = new PlanFeedback({
               id: feedback.id,
@@ -221,10 +237,15 @@ export const resolvers: Resolvers = {
               requestedById: feedback.requestedById,
               completedById: context.token.id,
               completed: getCurrentDate(),
-              summaryText: summaryText
+              summaryText: summaryText ?? ''
             });
 
-            return await newFeedback.update(context);
+            const updatedFeedback = await newFeedback.update(context);
+            if (!updatedFeedback) {
+              throw NotFoundError(`PlanFeedback with ID ${planFeedbackId} not found`);
+            }
+            return updatedFeedback;
+
           }
         }
         throw context?.token ? ForbiddenError() : AuthenticationError();

--- a/src/resolvers/feedback.ts
+++ b/src/resolvers/feedback.ts
@@ -40,7 +40,7 @@ export const resolvers: Resolvers = {
         if (isAdmin(context.token)) {
           // Check to see if planId exists in our records
           const plan = await Plan.findById(reference, context, planId);
-          if (!planId) {
+          if (!plan) {
             throw NotFoundError(`Plan with ID ${planId} not found`);
           }
 
@@ -77,7 +77,7 @@ export const resolvers: Resolvers = {
         if (isAuthorized(context.token)) {
           // Check to see if planId exists in our records
           const plan = await Plan.findById(reference, context, planId);
-          if (!planId) {
+          if (!plan) {
             throw NotFoundError(`Plan with ID ${planId} not found`);
           }
 
@@ -112,6 +112,10 @@ export const resolvers: Resolvers = {
             throw NotFoundError(`Plan with ID ${planId} not found`);
           }
 
+          if (!plan.createdById) {
+            throw NotFoundError(`Plan with ID ${planId} has no creator`);
+          }
+
           // Fetch the plan creator to compare affiliations
           const planCreator = await User.findById(reference, context, plan.createdById);
           if (!planCreator) {
@@ -144,7 +148,7 @@ export const resolvers: Resolvers = {
 
   Mutation: {
     //Request a round of admin feedback
-    requestFeedback: async (_, { planId }, context: MyContext): Promise<PlanFeedback> => {
+    requestFeedback: async (_, { planId, messageToOrg }, context: MyContext): Promise<PlanFeedback> => {
       const reference = 'requestFeedback resolver';
 
       try {
@@ -177,6 +181,7 @@ export const resolvers: Resolvers = {
           if (await hasPermissionOnProject(context, project)) {
             const feedbackComment = new PlanFeedback({
               planId,
+              messageToOrg,
               requestedById: context.token.id,
               requested: getCurrentDate()
             });
@@ -251,6 +256,10 @@ export const resolvers: Resolvers = {
             if (!project) {
               throw NotFoundError(`Project with ID ${plan.projectId} not found`);
             }
+            if (!project.id) {
+              throw NotFoundError(`Project with ID ${plan.projectId} has no ID`);
+            }
+
 
             const feedback = await PlanFeedback.findById(reference, context, planFeedbackId);
             if (!feedback) {
@@ -380,33 +389,34 @@ export const resolvers: Resolvers = {
 
   PlanFeedback: {
     // The plan the feedback is associated with
-    plan: async (parent, _, context: MyContext): Promise<Plan> => {
+    plan: async (parent, _, context: MyContext): Promise<Plan | null> => {
       if (parent?.plan?.id) {
         return await Plan.findById('Feedback plan resolver', context, parent.plan?.id);
       }
       return null;
     },
     // The user id that the feedback belongs to
-    requestedBy: async (parent: PlanFeedbackParent, _, context: MyContext): Promise<User> => {
+    requestedBy: async (parent: PlanFeedbackParent, _, context: MyContext): Promise<User | null> => {
       if (parent?.requestedById) {
         return await User.findById('User resolver', context, parent?.requestedById);
       }
       return null;
     },
     // The completed by user id that the feedback belongs to
-    completedBy: async (parent: PlanFeedbackParent, _, context: MyContext): Promise<User> => {
+    completedBy: async (parent: PlanFeedbackParent, _, context: MyContext): Promise<User | null> => {
       if (parent?.completedById) {
         return await User.findById('User resolver', context, parent?.completedById);
       }
       return null;
     },
     feedbackComments: async (parent, _, context: MyContext): Promise<PlanFeedbackComment[]> => {
+      if (!parent.id) return [];
       return await PlanFeedbackComment.findByFeedbackId('Chained PlanFeedback.feedbackComments', context, parent.id)
     }
   },
   PlanFeedbackComment: {
     // Resolver to get the user who created the comment
-    user: async (parent: PlanFeedbackComment, _, context: MyContext): Promise<User> => {
+    user: async (parent: ResolversParentTypes['PlanFeedbackComment'], _, context: MyContext): Promise<User | null> => {
       if (parent?.createdById) {
         return await User.findById('PlanFeedbackComment user resolver', context, parent.createdById);
       }

--- a/src/resolvers/feedback.ts
+++ b/src/resolvers/feedback.ts
@@ -152,7 +152,6 @@ export const resolvers: Resolvers = {
     requestFeedback: async (_, { planId, messageToOrg }, context: MyContext): Promise<PlanFeedback | null> => {
       const reference = 'requestFeedback resolver';
 
-      console.log("***Context in requestFeedback resolver: ", context); //context.token?.affiliationId
       try {
         if (isAuthorized(context.token)) {
           const plan = await Plan.findById(reference, context, planId);
@@ -194,7 +193,7 @@ export const resolvers: Resolvers = {
             }
 
             const affiliation = await Affiliation.findByURI(reference, context, affiliationId);
-            // Send emails to
+            // Send emails to the feedback recipients
             await sendFeedbackRequestEmail(context, affiliation.feedbackEmails, messageToOrg ?? '');
 
 

--- a/src/schemas/feedback.ts
+++ b/src/schemas/feedback.ts
@@ -20,7 +20,7 @@ export const typeDefs = gql`
 
   extend type Mutation {
     "Request a round of admin feedback"
-    requestFeedback(planId: Int!): PlanFeedback
+    requestFeedback(planId: Int!, messageToOrg: String): PlanFeedback
     "Mark the feedback round as complete"
     completeFeedback(planId: Int!, planFeedbackId: Int!, summaryText: String): PlanFeedback
     "Add feedback comment for an answer within a round of feedback"
@@ -58,6 +58,8 @@ export const typeDefs = gql`
     completedBy: User
     "An overall summary that can be sent to the user upon completion"
     summaryText: String
+    "Message user sent to org when requesting feedback, which can be NULL"
+    messageToOrg: String
 
     "The specific contextual commentary"
     feedbackComments: [PlanFeedbackComment!]

--- a/src/services/__tests__/emailService.spec.ts
+++ b/src/services/__tests__/emailService.spec.ts
@@ -1,3 +1,4 @@
+import { MyContext } from "../../context";
 const mockSendEmail = jest.fn().mockResolvedValue(true);
 
 jest.mock('nodemailer', () => ({
@@ -23,7 +24,7 @@ import { generalConfig } from "../../config/generalConfig";
 import { emailConfig } from "../../config/emailConfig";
 import { User } from "../../models/User";
 
-let context;
+let context: MyContext;
 
 const subjectPrefix = `${generalConfig.applicationName}`;
 process.env.NODE_ENV = 'test';
@@ -213,6 +214,40 @@ describe('sendEmail', () => {
   it('should return false and does not send email when no collaborator emails provided', async () => {
     const sent = await sendProjectCollaboratorsCommentsAddedEmail(context, []);
 
+    expect(sent).toBe(false);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it('should send feedback request emails to all collaborators', async () => {
+    jest.spyOn(logger, 'info');
+    const emails = Array.from({ length: 3 }, () => casual.email);
+    const feedbackMessage = casual.sentence;
+    // Import here to avoid hoisting issues
+    const { sendFeedbackRequestEmail } = await import('../emailService');
+    const sent = await sendFeedbackRequestEmail(context, emails, feedbackMessage);
+
+    const expectedSubject = `${subjectPrefix} - ${emailSubjects.feedbackRequest}`;
+
+    expect(sent).toBe(true);
+    expect(logger.info).toHaveBeenCalledTimes(emails.length);
+    expect(mockSendEmail).toHaveBeenCalledTimes(emails.length);
+    for (const email of emails) {
+      expect(mockSendEmail).toHaveBeenCalledWith({
+        "bcc": "",
+        "cc": "",
+        "from": `"${generalConfig.applicationName}" <${emailConfig.doNotReplyAddress}>`,
+        "html": feedbackMessage,
+        "replyTo": emailConfig.helpDeskAddress,
+        "sender": emailConfig.doNotReplyAddress,
+        "subject": expectedSubject,
+        "to": email,
+      });
+    }
+  });
+
+  it('should return false and not send feedback request email when no collaborator emails provided', async () => {
+    const { sendFeedbackRequestEmail } = await import('../emailService');
+    const sent = await sendFeedbackRequestEmail(context, [], 'Some feedback message');
     expect(sent).toBe(false);
     expect(mockSendEmail).not.toHaveBeenCalled();
   });

--- a/src/services/commentPermissions.ts
+++ b/src/services/commentPermissions.ts
@@ -7,8 +7,8 @@ export function canDeleteComment({
   userId,
   collaborators
 }: {
-  commentCreatedById: number,
-  planCreatedById: number,
+  commentCreatedById?: number,
+  planCreatedById?: number,
   userId: number,
   collaborators: ProjectCollaborator[]
 }): boolean {

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -1,7 +1,7 @@
 // TODO: Store the automated email in a table so we can eventually have a UI page for
 //       SuperAdmins to update them.
 //       Load the appropriate message and send it out
-import nodemailer from 'nodemailer';
+import nodemailer, { TransportOptions } from 'nodemailer';
 import { MyContext } from "../context";
 import { User } from "../models/User";
 import { awsConfig } from "../config/awsConfig";
@@ -13,7 +13,8 @@ export const emailSubjects = {
   emailConfirmation: 'Please confirm your email address',
   projectCollaboration: 'You were invited to collaborate on a data management plan',
   templateCollaboration: 'You were invited to collaborate on a template',
-  projectCollaboratorCommentsAdded: 'New comments added to the plan'
+  projectCollaboratorCommentsAdded: 'New comments added to the plan',
+  feedbackRequest: 'You have been requested to provide feedback on a data management plan',
 }
 
 export const emailMessages = {
@@ -41,7 +42,7 @@ const transporter = nodemailer.createTransport({
     user: awsConfig.sesAccessKey,
     pass: awsConfig.sesAccessSecret,
   },
-});
+} as TransportOptions);
 
 // Function to either send or log an email notification based on the environment
 const sendEmail = async (
@@ -58,7 +59,7 @@ const sendEmail = async (
   // Add the App name to the start of the subject line. We include the env when not in production
   const subjectLine = `${generalConfig.applicationName} - ${subject}`;
 
-  if (['development'].includes(process.env.NODE_ENV)) {
+  if (['development'].includes(process.env.NODE_ENV || '')) {
     // When running in development mode, we do not have access to AWS SES and we probably don't want to
     // actually send emails to people by accident, so just log the message
     context.logger.info(
@@ -127,11 +128,17 @@ export const sendTemplateCollaborationEmail = async (
   if (userId) {
     const user = await User.findById('sendTemplateCollaborationEmail', context, userId);
     // Bail out if the user has asked us not to send these notifications
-    if (!user.notify_on_template_shared) {
+    if (!user?.notify_on_template_shared) {
+      return false;
+    }
+
+    const emailAddress = await user.getEmail(context);
+    if (!emailAddress) {
+      context.logger.error(prepareObjectForLogs({ userId }), `User with ID ${userId} does not have an email address and cannot be sent a template collaboration email`);
       return false;
     }
     // Use the user's primary email address, regardless of what was provided
-    toAddress = await user.getEmail(context);
+    toAddress = emailAddress;
   }
 
   return await sendEmail(
@@ -158,11 +165,16 @@ export const sendProjectCollaborationEmail = async (
   if (userId) {
     const user = await User.findById('sendProjectCollaborationEmail', context, userId);
     // Bail out if the user has asked us not to send these notifications
-    if (!user.notify_on_template_shared) {
+    if (!user?.notify_on_template_shared) {
+      return false;
+    }
+    const emailAddress = await user.getEmail(context);
+    if (!emailAddress) {
+      context.logger.error(prepareObjectForLogs({ userId }), `User with ID ${userId} does not have an email address and cannot be sent a project collaboration email`);
       return false;
     }
     // Use the user's primary email address, regardless of what was provided
-    toAddress = await user.getEmail(context);
+    toAddress = emailAddress;
   }
 
   return await sendEmail(
@@ -196,6 +208,30 @@ export const sendProjectCollaboratorsCommentsAddedEmail = async (
       [],
       emailSubjects.projectCollaboratorCommentsAdded,
       message,
+    );
+  }
+  return true;
+}
+
+export const sendFeedbackRequestEmail = async (
+  context: MyContext,
+  collaboratorEmails: string[],
+  feedbackRequestMessage: string,
+): Promise<boolean> => {
+  if (collaboratorEmails.length === 0) {
+    return false;
+  };
+
+  // Send each feedback email recipient their own email
+  for (const email of collaboratorEmails) {
+    await sendEmail(
+      context,
+      'FeedbackRequest',
+      [email],
+      [],
+      [],
+      emailSubjects.feedbackRequest,
+      feedbackRequestMessage
     );
   }
   return true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2024,6 +2024,7 @@ export type MutationRemoveUserEmailArgs = {
 
 
 export type MutationRequestFeedbackArgs = {
+  messageToOrg?: InputMaybe<Scalars['String']['input']>;
   planId: Scalars['Int']['input'];
 };
 
@@ -2447,6 +2448,8 @@ export type PlanFeedback = {
   feedbackComments?: Maybe<Array<PlanFeedbackComment>>;
   /** The unique identifer for the Object */
   id?: Maybe<Scalars['Int']['output']>;
+  /** Message user sent to org when requesting feedback, which can be NULL */
+  messageToOrg?: Maybe<Scalars['String']['output']>;
   /** The timestamp when the Object was last modifed */
   modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
@@ -6973,6 +6976,7 @@ export type PlanFeedbackResolvers<ContextType = MyContext, ParentType extends Re
   errors?: Resolver<Maybe<ResolversTypes['PlanFeedbackErrors']>, ParentType, ContextType>;
   feedbackComments?: Resolver<Maybe<Array<ResolversTypes['PlanFeedbackComment']>>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  messageToOrg?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   plan?: Resolver<Maybe<ResolversTypes['Plan']>, ParentType, ContextType>;


### PR DESCRIPTION
## Description

- Added `messageToOrg` field in `feedback` table
- Updated `requestFeedback` resolver to save `messageToOrg` in `feedback` table, as well as to email the message to `feedbackEmails` from the `affiliations` table
- Fixed some new `type` errors in `feedback` resolver and `emailService` brought on by a recent update to `typescript-eslint`

Fixes # ([189](https://github.com/CDLUC3/dmptool-doc/issues/189))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested manually and with updated tests


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules