### PR TITLE
Removed a sort in repositories query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Made further updates to `repositories` query resolver and related functions to address an issue with the paginated data being returned. Also realized that previous sorting only applied on a page-by-page level, so fixed that as well.[#118]
 - Updated `repositories` query resolver to have the response alphabetically sorted on name [#118]
 - Updated graphql codegen dependencies
 - Moved `re3data-os-populate.ts` to `data-migration/dataSync` directory.

--- a/src/resolvers/repository.ts
+++ b/src/resolvers/repository.ts
@@ -58,9 +58,7 @@ export const resolvers: Resolvers = {
           return {
             ...results,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            items: (results.items as any[]).sort((a, b) =>
-              (a.name ?? '').localeCompare(b.name ?? '')
-            ),
+            items: results.items as any[],
 
           } as RepositorySearchResults;
         }

--- a/src/services/__tests__/openSearchService.spec.ts
+++ b/src/services/__tests__/openSearchService.spec.ts
@@ -229,6 +229,7 @@ describe('OpenSearchService', () => {
               ],
             },
           },
+          sort: [{ "name.keyword": { order: 'asc' } }],
         },
       });
 
@@ -282,6 +283,7 @@ describe('OpenSearchService', () => {
               filter: [],
             },
           },
+          sort: [{ "name.keyword": { order: 'asc' } }],
         },
       });
 
@@ -312,6 +314,66 @@ describe('OpenSearchService', () => {
       expect(mockContext.logger.error).toHaveBeenCalledWith(
         expect.any(Object),
         expect.stringContaining('Error converting OpenSearch response'),
+      );
+    });
+
+    test('Normalizes subject casing to title case before filtering', async () => {
+      mockSearch.mockResolvedValue({
+        body: { hits: { total: { value: 0 }, hits: [] } },
+      });
+
+      await service.findRe3Data(null, mockContext, ['economics', 'life sciences'], null, 10, 0);
+
+      expect(mockSearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            query: expect.objectContaining({
+              bool: expect.objectContaining({
+                filter: [{ terms: { subjects: ['Economics', 'Life Sciences'] } }],
+              }),
+            }),
+          }),
+        })
+      );
+    });
+
+    test('Filters out empty or whitespace-only subjects', async () => {
+      mockSearch.mockResolvedValue({
+        body: { hits: { total: { value: 0 }, hits: [] } },
+      });
+
+      await service.findRe3Data(null, mockContext, ['', '   ', null], null, 10, 0);
+
+      expect(mockSearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            query: expect.objectContaining({
+              bool: expect.objectContaining({
+                filter: [], // all subjects were invalid, so no filter pushed
+              }),
+            }),
+          }),
+        })
+      );
+    });
+
+    test('Trims whitespace from subjects before title-casing', async () => {
+      mockSearch.mockResolvedValue({
+        body: { hits: { total: { value: 0 }, hits: [] } },
+      });
+
+      await service.findRe3Data(null, mockContext, ['  economics  '], null, 10, 0);
+
+      expect(mockSearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            query: expect.objectContaining({
+              bool: expect.objectContaining({
+                filter: [{ terms: { subjects: ['Economics'] } }],
+              }),
+            }),
+          }),
+        })
       );
     });
   });

--- a/src/services/__tests__/repositoryService.spec.ts
+++ b/src/services/__tests__/repositoryService.spec.ts
@@ -105,11 +105,11 @@ describe('RepositoryService', () => {
 
       // Results should have re3data first, then custom
       expect(result.items).toHaveLength(2);
-      expect(result.items[0]).toEqual(mockRe3DataResults.repositories[0]);
-      expect(result.items[1]).toEqual(mockCustomResults.items[0]);
-      expect(result.limit).toBe(mockPaginationOptions.limit);
-      // totalCount should be from re3data (primary source)
-      expect(result.totalCount).toBe(mockRe3DataResults.total);
+      expect(result.items[0]).toEqual(mockCustomResults.items[0]); //custom repo first
+      expect(result.items[1]).toEqual(mockRe3DataResults.repositories[0]); //re3data repo second
+      // totalCount is re3data.total + customTotal = 100 + 1 = 101
+      expect(result.totalCount).toBe(101);//combined total count from both sources
+
     });
 
     it('should return only custom results when re3data search fails', async () => {
@@ -334,13 +334,13 @@ describe('RepositoryService', () => {
       expect(result.hasNextPage).toBe(true);
       expect(result.hasPreviousPage).toBe(false);
       expect(result.limit).toBe(10);
-      // totalCount should be from re3data (primary pagination source): 250
-      expect(result.totalCount).toBe(250);
-      // items should include re3data first, then custom results
+      // // items should include custom results, then re3data results
       expect(result.items).toHaveLength(3);
-      expect(result.items[0]).toEqual(mockRe3DataResults.repositories[0]);
-      expect(result.items[1]).toEqual(mockRe3DataResults.repositories[1]);
-      expect(result.items[2]).toEqual(mockCustomResults.items[0]);
+      expect(result.items[0]).toEqual(mockCustomResults.items[0]); //custom first
+      expect(result.items[1]).toEqual(mockRe3DataResults.repositories[0]);
+      expect(result.items[2]).toEqual(mockRe3DataResults.repositories[1]);
+      // totalCount = 250 + 100 = 350
+      expect(result.totalCount).toBe(350); // totalCount should be combined from both sources
     });
 
     it('should log and rethrow if Repository.search fails', async () => {
@@ -487,6 +487,204 @@ describe('RepositoryService', () => {
         const call = (openSearchService.openSearchFindRe3Data as jest.Mock).mock.calls[0];
         expect(call[3]).toBe(expectedFormat);
       }
+    });
+
+    it('should only show custom repos on the first page when re3data has results', async () => {
+      const reference = 'test-reference';
+
+      const mockCustomResults: PaginatedQueryResults<Repository> = {
+        items: [{ id: 1, name: 'Custom Repo' } as Repository],
+        limit: 10,
+        totalCount: 1,
+        currentOffset: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        availableSortFields: ['name', 'created'],
+      };
+
+      const mockRe3DataResults = {
+        repositories: [{ id: 'r3d1', name: 'Re3Data Repo' }],
+        total: 50,
+      };
+
+      (Repository.search as jest.Mock).mockResolvedValue(mockCustomResults);
+      (openSearchService.openSearchFindRe3Data as jest.Mock).mockResolvedValue(mockRe3DataResults);
+
+      // Page 2 (from=10): custom repos should NOT appear
+      const offsetOptions = {
+        type: PaginationType.OFFSET,
+        offset: 10,
+        limit: 10,
+        sortField: 'name',
+        sortDir: 'ASC',
+      };
+
+      const result = await RepositoryService.searchCombined(
+        reference, mockContext, null, null, null, null, offsetOptions,
+      );
+
+      // Custom repo should not be in results on page 2, and re3data repo should be present
+      expect(result.items).not.toContainEqual(mockCustomResults.items[0]);
+      expect(result.items).toEqual(mockRe3DataResults.repositories);
+    });
+
+    it('should sort custom repos alphabetically before merging', async () => {
+      const reference = 'test-reference';
+
+      const mockCustomResults: PaginatedQueryResults<Repository> = {
+        items: [
+          { id: 3, name: 'Zebra Repo' } as Repository,
+          { id: 1, name: 'Alpha Repo' } as Repository,
+          { id: 2, name: 'Middle Repo' } as Repository,
+        ],
+        limit: 10,
+        totalCount: 3,
+        currentOffset: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        availableSortFields: ['name', 'created'],
+      };
+
+      const mockRe3DataResults = {
+        repositories: [{ id: 'r3d1', name: 'Re3Data Repo' }],
+        total: 50,
+      };
+
+      (Repository.search as jest.Mock).mockResolvedValueOnce(mockCustomResults);
+      (openSearchService.openSearchFindRe3Data as jest.Mock).mockResolvedValueOnce(mockRe3DataResults);
+
+      const result = await RepositoryService.searchCombined(
+        reference, mockContext, null, null, null, null, mockPaginationOptions,
+      );
+
+      // Custom repos should appear sorted alphabetically at the start
+      expect(result.items[0]).toMatchObject({ name: 'Alpha Repo' });
+      expect(result.items[1]).toMatchObject({ name: 'Middle Repo' });
+      expect(result.items[2]).toMatchObject({ name: 'Zebra Repo' });
+    });
+
+    it('should always fetch custom repos from offset 0 regardless of pagination', async () => {
+      const reference = 'test-reference';
+      const offsetOptions = {
+        type: PaginationType.OFFSET,
+        offset: 20,
+        limit: 10,
+        sortField: 'name',
+        sortDir: 'ASC',
+      };
+
+      const mockCustomResults: PaginatedQueryResults<Repository> = {
+        items: [],
+        limit: 10,
+        totalCount: 0,
+        currentOffset: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        availableSortFields: ['name', 'created'],
+      };
+
+      (Repository.search as jest.Mock).mockResolvedValueOnce(mockCustomResults);
+      (openSearchService.openSearchFindRe3Data as jest.Mock).mockResolvedValueOnce({
+        repositories: [],
+        total: 0,
+      });
+
+      await RepositoryService.searchCombined(
+        reference, mockContext, null, null, null, null, offsetOptions,
+      );
+
+      expect(Repository.search).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.anything(),
+        null,
+        [],
+        null,
+        null,
+        expect.objectContaining({ offset: 0 }), // always 0
+      );
+    });
+
+    it('should paginate custom repos directly when re3data returns nothing', async () => {
+      const reference = 'test-reference';
+      const offsetOptions = {
+        type: PaginationType.OFFSET,
+        offset: 5,
+        limit: 3,
+        sortField: 'name',
+        sortDir: 'ASC',
+      };
+
+      const customItems = Array.from({ length: 10 }, (_, i) => ({
+        id: i + 1,
+        name: `Custom Repo ${String(i + 1).padStart(2, '0')}`,
+      } as Repository));
+
+      const mockCustomResults: PaginatedQueryResults<Repository> = {
+        items: customItems,
+        limit: 1000,
+        totalCount: 10,
+        currentOffset: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        availableSortFields: ['name', 'created'],
+      };
+
+      (Repository.search as jest.Mock).mockResolvedValueOnce(mockCustomResults);
+      (openSearchService.openSearchFindRe3Data as jest.Mock).mockResolvedValueOnce({
+        repositories: [],
+        total: 0,
+      });
+
+      const result = await RepositoryService.searchCombined(
+        reference, mockContext, null, null, null, null, offsetOptions,
+      );
+
+      // Should slice custom items from offset 5, limit 3 → gives indices 5,6,7 (Custom Repo 06, 07, 08)
+      expect(result.items).toHaveLength(3);
+      expect(result.items[0]).toMatchObject({ name: 'Custom Repo 06' });
+      expect(result.totalCount).toBe(10);
+      expect(result.hasNextPage).toBe(true); // 5 + 3 < 10
+      expect(result.hasPreviousPage).toBe(true); // from > 0
+    });
+
+    it('should set hasNextPage false when on last page of custom-only results', async () => {
+      const reference = 'test-reference';
+      const offsetOptions = {
+        type: PaginationType.OFFSET,
+        offset: 8,
+        limit: 5,
+        sortField: 'name',
+        sortDir: 'ASC',
+      };
+
+      const customItems = Array.from({ length: 10 }, (_, i) => ({
+        id: i + 1,
+        name: `Custom Repo ${i + 1}`,
+      } as Repository));
+
+      const mockCustomResults: PaginatedQueryResults<Repository> = {
+        items: customItems,
+        limit: 1000,
+        totalCount: 10,
+        currentOffset: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        availableSortFields: ['name', 'created'],
+      };
+
+      (Repository.search as jest.Mock).mockResolvedValueOnce(mockCustomResults);
+      (openSearchService.openSearchFindRe3Data as jest.Mock).mockResolvedValueOnce({
+        repositories: [],
+        total: 0,
+      });
+
+      const result = await RepositoryService.searchCombined(
+        reference, mockContext, null, null, null, null, offsetOptions,
+      );
+
+      // from=8, limit=5: only 2 items remain (indices 8,9), 8+5=13 >= 10
+      expect(result.items).toHaveLength(2);
+      expect(result.hasNextPage).toBe(false); // No next page since only 2 items remain on the page
     });
   });
 
@@ -781,11 +979,11 @@ describe('RepositoryService', () => {
 
       // Results should have re3data first (3), then custom (5) = 8 total items
       expect(result.items).toHaveLength(8);
-      expect(result.items.slice(0, 3)).toEqual(mockRe3DataResults.repositories);
-      expect(result.items.slice(3, 8)).toEqual(mockCustomResults.items);
-      // totalCount should be from re3data (primary source): 250
-      expect(result.totalCount).toBe(250);
-      expect(result.hasNextPage).toBe(true); // re3data has more results
+      expect(result.items.slice(0, 5)).toEqual(mockCustomResults.items); // custom first
+      expect(result.items.slice(5, 8)).toEqual(mockRe3DataResults.repositories);
+      // totalCount = 250 + 100 = 350
+      expect(result.totalCount).toBe(350);
+
     });
   });
 });

--- a/src/services/openSearchService.ts
+++ b/src/services/openSearchService.ts
@@ -112,7 +112,7 @@ export class OpenSearchService {
     // Fetch data from OpenSearch
     let response: unknown;
     try {
-      response = await this.searchClient.search({
+      response = await this.client.search({
         index: 'works-index',
         body: {
           size: maxResults,

--- a/src/services/openSearchService.ts
+++ b/src/services/openSearchService.ts
@@ -177,8 +177,12 @@ export class OpenSearchService {
     }
 
     // Handle multiple subjects: match repositories that have ANY of the provided subjects
+    // handle case insensitivity and trim whitespace
     if (subjects && subjects.length > 0) {
-      const validSubjects = subjects.filter(s => s?.trim());
+      const validSubjects = subjects
+        .filter(s => s?.trim())
+        .map(s => s.trim().replace(/\b\w/g, c => c.toUpperCase())); // "economics" → "Economics"
+
       if (validSubjects.length > 0) {
         filter.push({
           terms: { subjects: validSubjects },
@@ -206,6 +210,7 @@ export class OpenSearchService {
               filter,
             },
           },
+          sort: [{ "name.keyword": { order: 'asc' } }],
         },
       });
     } catch (err) {

--- a/src/services/openSearchService.ts
+++ b/src/services/openSearchService.ts
@@ -97,6 +97,12 @@ export class OpenSearchService {
     this.serverlessClient = createOpenSearchServerlessClient(awsConfig.opensearchServerless as OpenSearchServerlessConfig);
   }
 
+  // Selects the correct OpenSearch client based on environment
+  private get searchClient(): Client {
+    const useServerless = process.env.OPENSEARCH_AUTH_TYPE === 'aws';
+    return useServerless ? this.serverlessClient : this.client;
+  }
+
   public async findWorkByIdentifier(reference: string, context: MyContext, doi: string | null | undefined, maxResults: number): Promise<OpenSearchWork[]> {
     // If doi is empty, whitespace, null or undefined return no results
     if (!doi?.trim()) {
@@ -106,7 +112,7 @@ export class OpenSearchService {
     // Fetch data from OpenSearch
     let response: unknown;
     try {
-      response = await this.client.search({
+      response = await this.searchClient.search({
         index: 'works-index',
         body: {
           size: maxResults,
@@ -275,7 +281,7 @@ export class OpenSearchService {
 
     context.logger.debug({ uris }, 'Fetching URIs from OpenSearch re3data index');
     try {
-      response = await this.serverlessClient.search({
+      response = await this.searchClient.search({
         index: 're3data',
         body: {
           size: uris.length,
@@ -349,7 +355,7 @@ export class OpenSearchService {
           },
         };
 
-      response = await this.serverlessClient.search({
+      response = await this.searchClient.search({
         index: 're3data',
         body,
       });
@@ -405,7 +411,7 @@ export class OpenSearchService {
         },
       };
 
-      response = await this.serverlessClient.search({
+      response = await this.searchClient.search({
         index: 're3data',
         body,
       });

--- a/src/services/repositoryService.ts
+++ b/src/services/repositoryService.ts
@@ -78,29 +78,57 @@ export const RepositoryService = {
         repositoryType,
         {
           ...options,
+          offset: 0, // Always fetch from beginning for custom results
           limit: 1000, // Get all custom results to supplement re3data
         },
       );
 
-      // Combine results - re3data first (primary source), then custom
-      const combinedItems: object[] = [
-        ...re3dataResponse.repositories,
-        ...(customResults.items || []),
-      ];
-
-      // Calculate pagination based on re3data (primary source)
       const limit = options.limit || 10;
-      const hasNextPage = from + re3dataResponse.repositories.length < re3dataResponse.total;
+      const customItems = (customResults.items || [])
+        .sort((a: { name?: string | null }, b: { name?: string | null }) =>
+          (a.name ?? '').localeCompare(b.name ?? '')
+        );
+
+      const customTotal = customResults.totalCount ?? 0;
+
+      // If re3data has results, show custom repos on first page only
+      // If re3data has NO results, paginate custom repos directly
+      let items: object[];
+      let totalCount: number;
+      let hasNextPage: boolean;
+
+      if (re3dataResponse.total > 0 && re3dataResponse.repositories.length > 0) {
+        const isFirstPage = from === 0;
+        items = [
+          ...(isFirstPage ? customItems : []),
+          ...re3dataResponse.repositories,
+        ];
+        totalCount = re3dataResponse.total + customTotal;
+        hasNextPage = from + re3dataResponse.repositories.length < re3dataResponse.total;
+      } else if (re3dataResponse.total > 0 && re3dataResponse.repositories.length === 0) {
+        // Offset is beyond re3data results — paginate remaining custom repos
+        // Adjust offset relative to re3data's total (custom repos start after re3data)
+        const customFrom = from - re3dataResponse.total;
+        items = customItems.slice(customFrom, customFrom + limit);
+        totalCount = re3dataResponse.total + customTotal;
+        hasNextPage = customFrom + limit < customTotal;
+      } else {
+        // re3data found nothing — paginate custom repos instead
+        items = customItems.slice(from, from + limit);
+        totalCount = customTotal;
+        hasNextPage = from + limit < customTotal;
+      }
 
       return {
-        items: combinedItems,
+        items,
         limit,
-        totalCount: re3dataResponse.total,
+        totalCount,
         currentOffset: from,
         hasNextPage,
         hasPreviousPage: from > 0,
         availableSortFields: ['name', 'created'],
       };
+
     } catch (err) {
       context.logger.error(
         prepareObjectForLogs(err),


### PR DESCRIPTION
 Removed a sort in repositories query that only applied at the page level, and updated the searchCombined function to fix issues with incorrect totalCount and customRepos pagination data

Also fixed some weird issues with pagination data and total count data that was returned. Ideally, I guess we'd want to index the customRepos into opensearch, but I added a work around.

@briri could you take a look and let me know what you think?

I'm putting this into DRAFT mode just to get your feedback on it.

## Description

Please include a summary of the changes and the related issue. Are there any dependencies related to this change?

Fixes # ([118](https://github.com/CDLUC3/dmptool-doc/issues/118))

## Type of change
Please delete options that are not relevant

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Include any relevant details for your test configuration.


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules