### PR TITLE
Updated the planFeedbackStatus to return the feedback id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.1.0
 
 ### Added
+- Added a `PlanFeedbackStatus` type that can be returned by `planFeedbackStatus`, which now includes the feedback `id` [#191]
 - Added `messageToOrg` field in `feedback` table [#189]
 - Added override for `@node-oauth/oauth2-server`
 - Added `fetchAnswerCustomQuestion` to `Plan` model in order to get answered counts for custom questions [#161]
@@ -60,6 +61,11 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+<<<<<<< Updated upstream
+=======
+- Updated `planFeedbackStatus` query resolver to return a feedback `id` as well, so frontend can use it to delete the feedback [#191]
+- Made further updates to `repositories` query resolver and related functions to address an issue with the paginated data being returned. Also realized that previous sorting only applied on a page-by-page level, so fixed that as well.[#118]
+>>>>>>> Stashed changes
 - Updated `repositories` query resolver to have the response alphabetically sorted on name [#118]
 - Updated graphql codegen dependencies
 - Moved `re3data-os-populate.ts` to `data-migration/dataSync` directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,11 +61,7 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
-<<<<<<< Updated upstream
-=======
 - Updated `planFeedbackStatus` query resolver to return a feedback `id` as well, so frontend can use it to delete the feedback [#191]
-- Made further updates to `repositories` query resolver and related functions to address an issue with the paginated data being returned. Also realized that previous sorting only applied on a page-by-page level, so fixed that as well.[#118]
->>>>>>> Stashed changes
 - Updated `repositories` query resolver to have the response alphabetically sorted on name [#118]
 - Updated graphql codegen dependencies
 - Moved `re3data-os-populate.ts` to `data-migration/dataSync` directory.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@keyv/redis": "^5.1.6",
         "@node-oauth/express-oauth-server": "^4.1.5",
         "@opensearch-project/opensearch": "^3.5.1",
-        "@xmldom/xmldom": "^0.9.9",
+        "@xmldom/xmldom": "^0.9.10",
         "bcryptjs": "^3.0.3",
         "body-parser": "^2.2.2",
         "cookie-parser": "^1.4.7",
@@ -6832,9 +6832,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.9.tgz",
-      "integrity": "sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@keyv/redis": "^5.1.6",
     "@node-oauth/express-oauth-server": "^4.1.5",
     "@opensearch-project/opensearch": "^3.5.1",
-    "@xmldom/xmldom": "^0.9.9",
+    "@xmldom/xmldom": "^0.9.10",
     "bcryptjs": "^3.0.3",
     "body-parser": "^2.2.2",
     "cookie-parser": "^1.4.7",

--- a/src/models/PlanFeedback.ts
+++ b/src/models/PlanFeedback.ts
@@ -1,6 +1,6 @@
 import { MyContext } from "../context";
 import { MySqlModel } from "./MySqlModel";
-import { PlanFeedbackStatusEnum } from "../types";
+import { PlanFeedbackStatus } from "../types";
 
 interface PlanFeedbackOptions {
   id?: number;
@@ -68,7 +68,7 @@ export class PlanFeedback extends MySqlModel {
       // Save the record and then fetch it
       const newId = await PlanFeedback.insert(context, PlanFeedback.tableName, this, reference);
       // If no id was returned then something went wrong with the insert and we should log an error and return the object with an error message
-      if(!newId){
+      if (!newId) {
         const msg = `${reference}, ERROR: Failed to create PlanFeedback.`;
         context.logger.error(msg);
         // Something went wrong with the insert and we don't have an id for the new record so we should log an error and return the object with an error message
@@ -148,17 +148,25 @@ export class PlanFeedback extends MySqlModel {
     reference: string,
     context: MyContext,
     planId: number
-  ): Promise<PlanFeedbackStatusEnum> {
+  ): Promise<PlanFeedbackStatus> {
     // Aggregate: total rows and how many are open (completed IS NULL)
-    const sql = `SELECT COUNT(*) as total, SUM(completed IS NULL) as open FROM ${PlanFeedback.tableName} WHERE planId = ?`;
+    const sql = `
+      SELECT id, completed
+      FROM ${PlanFeedback.tableName}
+      WHERE planId = ?
+      ORDER BY id DESC
+      LIMIT 1
+    `;
     const results = await PlanFeedback.query(context, sql, [planId?.toString()], reference);
-    const row = Array.isArray(results) && results.length > 0 ? results[0] : { total: 0, open: 0 };
+    const row = Array.isArray(results) && results.length > 0 ? results[0] : null;
 
-    const total = Number(row.total) || 0;
-    const open = Number(row.open) || 0;
+    if (!row) {
+      return { status: 'NONE', id: null };
+    }
 
-    if (total === 0) return 'NONE';
-    if (open > 0) return 'REQUESTED';
-    return 'COMPLETED';
+    return {
+      status: row.completed ? 'COMPLETED' : 'REQUESTED',
+      id: row.id,
+    }
   }
 };

--- a/src/models/__tests__/PlanFeedback.spec.ts
+++ b/src/models/__tests__/PlanFeedback.spec.ts
@@ -329,25 +329,24 @@ describe('statusForPlan', () => {
     localQuery.mockResolvedValueOnce([]);
     const planId = casual.integer(1, 9999);
     const result = await PlanFeedback.statusForPlan('testing', context, planId);
-    const expectedSql = 'SELECT COUNT(*) as total, SUM(completed IS NULL) as open FROM feedback WHERE planId = ?';
+    const expectedSql = `\n      SELECT id, completed\n      FROM feedback\n      WHERE planId = ?\n      ORDER BY id DESC\n      LIMIT 1\n    `;
 
     expect(localQuery).toHaveBeenCalledTimes(1);
     expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [planId.toString()], 'testing');
-    expect(result).toEqual('NONE');
+    expect(result).toEqual({ status: 'NONE', id: null });
   });
 
-  it('returns REQUESTED when there is at least one open feedback (completed IS NULL)', async () => {
-    // simulate SQL returning counts as strings (like DB drivers often do)
-    localQuery.mockResolvedValueOnce([{ total: '2', open: '1' }]);
+  it('returns REQUESTED when the latest feedback is open (completed IS NULL)', async () => {
     const planId = casual.integer(1, 9999);
+    localQuery.mockResolvedValueOnce([{ id: 42, completed: null }]);
     const result = await PlanFeedback.statusForPlan('testing', context, planId);
-    expect(result).toEqual('REQUESTED');
+    expect(result).toEqual({ status: 'REQUESTED', id: 42 });
   });
 
-  it('returns COMPLETED when all feedback rows are completed', async () => {
-    localQuery.mockResolvedValueOnce([{ total: '3', open: '0' }]);
+  it('returns COMPLETED when the latest feedback is completed', async () => {
     const planId = casual.integer(1, 9999);
+    localQuery.mockResolvedValueOnce([{ id: 99, completed: '2024-04-24' }]);
     const result = await PlanFeedback.statusForPlan('testing', context, planId);
-    expect(result).toEqual('COMPLETED');
+    expect(result).toEqual({ status: 'COMPLETED', id: 99 });
   });
 });

--- a/src/resolvers/feedback.ts
+++ b/src/resolvers/feedback.ts
@@ -22,7 +22,7 @@ import { PlanFeedbackComment } from "../models/PlanFeedbackComment";
 import { VersionedTemplate } from "../models/VersionedTemplate";
 import { Affiliation } from "../models/Affiliation";
 import { ResolversParentTypes } from "../types";
-import { Resolvers, PlanFeedbackStatusEnum } from "../types";
+import { Resolvers, PlanFeedbackStatus } from "../types";
 import { getCurrentDate } from "../utils/helpers";
 
 type PlanFeedbackParent = ResolversParentTypes['PlanFeedback'] & {
@@ -102,7 +102,7 @@ export const resolvers: Resolvers = {
     },
 
     // Get the current feedback status for a plan
-    planFeedbackStatus: async (_, { planId }, context: MyContext): Promise<PlanFeedbackStatusEnum> => {
+    planFeedbackStatus: async (_, { planId }, context: MyContext): Promise<PlanFeedbackStatus> => {
       const reference = 'planFeedbackStatus resolver';
       try {
         // if the user is an admin

--- a/src/schemas/feedback.ts
+++ b/src/schemas/feedback.ts
@@ -15,7 +15,7 @@ export const typeDefs = gql`
     planFeedbackComments(planId: Int!, planFeedbackId: Int!): [PlanFeedbackComment]
 
     "Get the feedback status for a plan (NONE, REQUESTED, COMPLETED)"
-    planFeedbackStatus(planId: Int!): PlanFeedbackStatusEnum
+    planFeedbackStatus(planId: Int!): PlanFeedbackStatus
   }
 
   extend type Mutation {
@@ -109,5 +109,13 @@ export const typeDefs = gql`
     answer: String
     planFeedback: String
     comment: String
+  }
+
+  "Info on the Plan Feedback Status"
+  type PlanFeedbackStatus {
+  "The status of the plan feedback (NONE, REQUESTED, COMPLETED)"
+  status: PlanFeedbackStatusEnum  
+  "The id of the feedback request if it exists"
+  id: Int
   }
 `;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2510,6 +2510,15 @@ export type PlanFeedbackErrors = {
   summaryText?: Maybe<Scalars['String']['output']>;
 };
 
+/** Info on the Plan Feedback Status */
+export type PlanFeedbackStatus = {
+  __typename?: 'PlanFeedbackStatus';
+  /** The id of the feedback request if it exists */
+  id?: Maybe<Scalars['Int']['output']>;
+  /** The status of the plan feedback (NONE, REQUESTED, COMPLETED) */
+  status?: Maybe<PlanFeedbackStatusEnum>;
+};
+
 export type PlanFeedbackStatusEnum =
   | 'COMPLETED'
   | 'NONE'
@@ -3156,7 +3165,7 @@ export type Query = {
   /** Get all of the comments associated with the round of admin feedback */
   planFeedbackComments?: Maybe<Array<Maybe<PlanFeedbackComment>>>;
   /** Get the feedback status for a plan (NONE, REQUESTED, COMPLETED) */
-  planFeedbackStatus?: Maybe<PlanFeedbackStatusEnum>;
+  planFeedbackStatus?: Maybe<PlanFeedbackStatus>;
   /** Get all of the Funding information for the specific Plan */
   planFundings?: Maybe<Array<Maybe<PlanFunding>>>;
   /** Get all of the Users that are Members for the specific Plan */
@@ -5892,6 +5901,7 @@ export type ResolversTypes = {
   PlanFeedbackComment: ResolverTypeWrapper<PlanFeedbackComment>;
   PlanFeedbackCommentErrors: ResolverTypeWrapper<PlanFeedbackCommentErrors>;
   PlanFeedbackErrors: ResolverTypeWrapper<PlanFeedbackErrors>;
+  PlanFeedbackStatus: ResolverTypeWrapper<PlanFeedbackStatus>;
   PlanFeedbackStatusEnum: PlanFeedbackStatusEnum;
   PlanFunding: ResolverTypeWrapper<PlanFunding>;
   PlanFundingErrors: ResolverTypeWrapper<PlanFundingErrors>;
@@ -6130,6 +6140,7 @@ export type ResolversParentTypes = {
   PlanFeedbackComment: PlanFeedbackComment;
   PlanFeedbackCommentErrors: PlanFeedbackCommentErrors;
   PlanFeedbackErrors: PlanFeedbackErrors;
+  PlanFeedbackStatus: PlanFeedbackStatus;
   PlanFunding: PlanFunding;
   PlanFundingErrors: PlanFundingErrors;
   PlanGuidance: PlanGuidance;
@@ -7014,6 +7025,11 @@ export type PlanFeedbackErrorsResolvers<ContextType = MyContext, ParentType exte
   summaryText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 };
 
+export type PlanFeedbackStatusResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanFeedbackStatus'] = ResolversParentTypes['PlanFeedbackStatus']> = {
+  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  status?: Resolver<Maybe<ResolversTypes['PlanFeedbackStatusEnum']>, ParentType, ContextType>;
+};
+
 export type PlanFundingResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanFunding'] = ResolversParentTypes['PlanFunding']> = {
   created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -7344,7 +7360,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   plan?: Resolver<Maybe<ResolversTypes['Plan']>, ParentType, ContextType, RequireFields<QueryPlanArgs, 'planId'>>;
   planFeedback?: Resolver<Maybe<Array<Maybe<ResolversTypes['PlanFeedback']>>>, ParentType, ContextType, RequireFields<QueryPlanFeedbackArgs, 'planId'>>;
   planFeedbackComments?: Resolver<Maybe<Array<Maybe<ResolversTypes['PlanFeedbackComment']>>>, ParentType, ContextType, RequireFields<QueryPlanFeedbackCommentsArgs, 'planFeedbackId' | 'planId'>>;
-  planFeedbackStatus?: Resolver<Maybe<ResolversTypes['PlanFeedbackStatusEnum']>, ParentType, ContextType, RequireFields<QueryPlanFeedbackStatusArgs, 'planId'>>;
+  planFeedbackStatus?: Resolver<Maybe<ResolversTypes['PlanFeedbackStatus']>, ParentType, ContextType, RequireFields<QueryPlanFeedbackStatusArgs, 'planId'>>;
   planFundings?: Resolver<Maybe<Array<Maybe<ResolversTypes['PlanFunding']>>>, ParentType, ContextType, RequireFields<QueryPlanFundingsArgs, 'planId'>>;
   planMembers?: Resolver<Maybe<Array<Maybe<ResolversTypes['PlanMember']>>>, ParentType, ContextType, RequireFields<QueryPlanMembersArgs, 'planId'>>;
   plans?: Resolver<Maybe<Array<ResolversTypes['PlanSearchResult']>>, ParentType, ContextType, RequireFields<QueryPlansArgs, 'projectId'>>;
@@ -8353,6 +8369,7 @@ export type Resolvers<ContextType = MyContext> = {
   PlanFeedbackComment?: PlanFeedbackCommentResolvers<ContextType>;
   PlanFeedbackCommentErrors?: PlanFeedbackCommentErrorsResolvers<ContextType>;
   PlanFeedbackErrors?: PlanFeedbackErrorsResolvers<ContextType>;
+  PlanFeedbackStatus?: PlanFeedbackStatusResolvers<ContextType>;
   PlanFunding?: PlanFundingResolvers<ContextType>;
   PlanFundingErrors?: PlanFundingErrorsResolvers<ContextType>;
   PlanGuidance?: PlanGuidanceResolvers<ContextType>;


### PR DESCRIPTION
## Description

- Added a `PlanFeedbackStatus` type that can be returned by `planFeedbackStatus`, which now includes the feedback `id`
- Updated `planFeedbackStatus` query resolver to return a feedback `id` as well, so frontend can use it to delete the feedback

Fixes # ([191](https://github.com/CDLUC3/dmptool-doc/issues/191))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested and tested with existing and updated unit tests


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules