### PR TITLE
Added feedback status to plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.1.0
 
 ### Added
+- Added `feedbackStatus` to the plan query, so the client can know whether to display feedback notification at top of question page [#196]
 - Added new `OPENSEARCH_SERVERLESS_NODE` environment variable
 - Added a `PlanFeedbackStatus` type that can be returned by `planFeedbackStatus`, which now includes the feedback `id` [#191]
 - Added `messageToOrg` field in `feedback` table [#189]
@@ -147,6 +148,7 @@
 - Removed `ioredis` package
 
 ### Fixed
+- Fixed bug in `openSearchService` that was throwing an error and not returning repositories [#196]
 - Fixed some new `type` errors in `feedback` resolver and `emailService` brought on by a recent update to `typescript-eslint` [#189]
 - Had issue running `nuke-db.sh` and `process.sh`, so I turned off SSL by using `--ssl=off` instead
 - Fixed `fetchTemplateData` query in `TemplateCustomization` model because `questionCustomizationHasSampleText` was incorrectly returning true [#130] 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated `planFeedbackStatus` query resolver so that it doesn't require a user to be admin in order to access that data, since the client uses it to display data in the right sidebar for any user [#196]
 - Made further updates to `repositories` query resolver and related functions to address an issue with the paginated data being returned. Also realized that previous sorting only applied on a page-by-page level, so fixed that as well.[#118]
 - Updated re3data-os-populate.ts to write to an AWS Serverless OpenSearch (AOSS) instance
 - Updated OpenSearch datasource to include a new serverlessClient property and createOpenSearchServerlessClient function.

--- a/src/resolvers/feedback.ts
+++ b/src/resolvers/feedback.ts
@@ -105,38 +105,32 @@ export const resolvers: Resolvers = {
     planFeedbackStatus: async (_, { planId }, context: MyContext): Promise<PlanFeedbackStatus> => {
       const reference = 'planFeedbackStatus resolver';
       try {
-        // if the user is an admin
-        if (isAdmin(context.token)) {
-          // Check to see if planId exists in our records
-          const plan = await Plan.findById(reference, context, planId);
-          if (!plan) {
-            throw NotFoundError(`Plan with ID ${planId} not found`);
-          }
-
-          if (!plan.createdById) {
-            throw NotFoundError(`Plan with ID ${planId} has no creator`);
-          }
-
-          // Fetch the plan creator to compare affiliations
-          const planCreator = await User.findById(reference, context, plan.createdById);
-          if (!planCreator) {
-            throw NotFoundError(`User who created plan ${planId} not found`);
-          }
-
-          // If the user is a superAdmin or an admin for the same affiliation
-          if (isSuperAdmin(context.token) || (isAdmin(context.token) && context.token.affiliationId === planCreator.affiliationId)) {
-
-            // Check that user has permissions to access feedback
-            const projectId = plan.projectId;
-            const project = await Project.findById(reference, context, projectId);
-            if (!project) {
-              throw NotFoundError(`Project with ID ${projectId} not found`);
-            }
-            if (await hasPermissionOnProject(context, project)) {
-              return await PlanFeedback.statusForPlan(reference, context, planId);
-            }
-          }
+        // Check to see if planId exists in our records
+        const plan = await Plan.findById(reference, context, planId);
+        if (!plan) {
+          throw NotFoundError(`Plan with ID ${planId} not found`);
         }
+
+        if (!plan.createdById) {
+          throw NotFoundError(`Plan with ID ${planId} has no creator`);
+        }
+
+        // Fetch the plan creator to compare affiliations
+        const planCreator = await User.findById(reference, context, plan.createdById);
+        if (!planCreator) {
+          throw NotFoundError(`User who created plan ${planId} not found`);
+        }
+
+        const projectId = plan.projectId;
+        const project = await Project.findById(reference, context, projectId);
+        if (!project) {
+          throw NotFoundError(`Project with ID ${projectId} not found`);
+        }
+        if (await hasPermissionOnProject(context, project)) {
+          return await PlanFeedback.statusForPlan(reference, context, planId);
+        }
+
+
         throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {
         if (err instanceof GraphQLError) throw err;

--- a/src/resolvers/plan.ts
+++ b/src/resolvers/plan.ts
@@ -9,7 +9,7 @@ import { hasPermissionOnProject } from "../services/projectService";
 import { PlanMember } from "../models/Member";
 import { PlanFunding } from "../models/Funding";
 import { PlanFeedback } from "../models/PlanFeedback";
-import { Resolvers } from "../types";
+import { PlanFeedbackStatus, Resolvers } from "../types";
 import { VersionedTemplate } from "../models/VersionedTemplate";
 import { Answer } from "../models/Answer";
 import { ProjectCollaboratorAccessLevel } from "../models/Collaborator";
@@ -318,6 +318,13 @@ export const resolvers: Resolvers = {
         return await PlanFeedback.findByPlanId('plan feedback resolver', context, parent.id);
       }
       return [];
+    },
+    feedbackStatus: async (parent: Plan, _, context: MyContext): Promise<PlanFeedbackStatus> => {
+      if (parent?.id) {
+        // Use the same logic as in planFeedbackStatus query
+        return await PlanFeedback.statusForPlan('plan.feedbackStatus resolver', context, parent.id);
+      }
+      return null;
     },
     answers: async (parent: Plan, _, context: MyContext): Promise<Answer[]> => {
       if (parent?.id) {

--- a/src/schemas/plan.ts
+++ b/src/schemas/plan.ts
@@ -171,6 +171,9 @@ export const typeDefs = gql`
 
     "Feedback associated with the plan"
     feedback: [PlanFeedback!]
+
+    "Feedback status"
+    feedbackStatus: PlanFeedbackStatus
   }
 
   "The error messages for the plan"

--- a/src/services/openSearchService.ts
+++ b/src/services/openSearchService.ts
@@ -291,7 +291,7 @@ export class OpenSearchService {
             },
           },
           sort: {
-            name: {
+            "name.keyword": {
               order: 'asc',
             },
           }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2373,6 +2373,8 @@ export type Plan = {
   featured?: Maybe<Scalars['Boolean']['output']>;
   /** Feedback associated with the plan */
   feedback?: Maybe<Array<PlanFeedback>>;
+  /** Feedback status */
+  feedbackStatus?: Maybe<PlanFeedbackStatus>;
   /** The funding for the plan */
   fundings?: Maybe<Array<PlanFunding>>;
   /** The unique identifer for the Object */
@@ -6947,6 +6949,7 @@ export type PlanResolvers<ContextType = MyContext, ParentType extends ResolversP
   errors?: Resolver<Maybe<ResolversTypes['PlanErrors']>, ParentType, ContextType>;
   featured?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   feedback?: Resolver<Maybe<Array<ResolversTypes['PlanFeedback']>>, ParentType, ContextType>;
+  feedbackStatus?: Resolver<Maybe<ResolversTypes['PlanFeedbackStatus']>, ParentType, ContextType>;
   fundings?: Resolver<Maybe<Array<ResolversTypes['PlanFunding']>>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   languageId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;


### PR DESCRIPTION
## Description

- Added feedbackStatus to the plan query, so the client can know whether to display feedback notification at top of question page
- Fixed bug in `openSearchService` that was throwing an error and not returning repositories

Fixes # ([196](https://github.com/CDLUC3/dmptool-doc/issues/196))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested manually and with frontend changes here: https://github.com/CDLUC3/dmptool-ui/tree/feature/196/JS-update-textArea-question-with-feedback-mode


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules