### PR TITLE
Updated completeFeedback 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## v1.1.0
 
 ### Added
-- Added `planOwner` field to the `plan` query response so that client can get plan owner affiliation.uri for feedback pages [#198]
+- Added `planCreator` field to the `plan` query response so that client can get plan owner affiliation.uri for feedback pages [#198]
+- Added `sendFeedbackCompleteEmail` to `emailService` [#198]
 - Added `feedback.spec.ts` unit tests for the feedback resolver [#198]
 - Added `feedbackStatus` to the plan query, so the client can know whether to display feedback notification at top of question page [#196]
 - Added new `OPENSEARCH_SERVERLESS_NODE` environment variable
@@ -65,7 +66,7 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
-- Updated `completedFeedback` resolver to send an email to the plan owner when feedback is marked as complete, and added a `sendEmail` boolean flag to input variables to stop an email from being sent [#198]
+- Updated `completedFeedback` resolver to send an email to the feedback requestor when feedback is marked as complete, and added a `sendEmail` boolean flag to input variables to stop an email from being sent [#198]
 - Updated the `findTemplateCustomizationId` method sql query to guarantee that correct templateCustomizationId is retrieved [#200]
 - Updated `updateQuestionDisplayOrder` method in `question.ts` to mark the template as dirty whenever there is reordering. Did the same thing for `updateSectionDisplayOrder` in `section.ts` [#200]
 - Updated `handleFunderTemplateRepublication` to set correct `customization.currentVersionedTemplateId` after marking the old one as stale [#200]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Added `planOwner` field to the `plan` query response so that client can get plan owner affiliation.uri for feedback pages [#198]
+- Added `feedback.spec.ts` unit tests for the feedback resolver [#198]
 - Added `feedbackStatus` to the plan query, so the client can know whether to display feedback notification at top of question page [#196]
 - Added new `OPENSEARCH_SERVERLESS_NODE` environment variable
 - Added a `PlanFeedbackStatus` type that can be returned by `planFeedbackStatus`, which now includes the feedback `id` [#191]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.1.0
 
 ### Added
+- Added `planOwner` field to the `plan` query response so that client can get plan owner affiliation.uri for feedback pages [#198]
 - Added `feedbackStatus` to the plan query, so the client can know whether to display feedback notification at top of question page [#196]
 - Added new `OPENSEARCH_SERVERLESS_NODE` environment variable
 - Added a `PlanFeedbackStatus` type that can be returned by `planFeedbackStatus`, which now includes the feedback `id` [#191]
@@ -63,6 +64,7 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated `completedFeedback` resolver to send an email to the plan owner when feedback is marked as complete, and added a `sendEmail` boolean flag to input variables to stop an email from being sent [#198]
 - Updated the `findTemplateCustomizationId` method sql query to guarantee that correct templateCustomizationId is retrieved [#200]
 - Updated `updateQuestionDisplayOrder` method in `question.ts` to mark the template as dirty whenever there is reordering. Did the same thing for `updateSectionDisplayOrder` in `section.ts` [#200]
 - Updated `handleFunderTemplateRepublication` to set correct `customization.currentVersionedTemplateId` after marking the old one as stale [#200]

--- a/src/resolvers/__tests__/feedback.spec.ts
+++ b/src/resolvers/__tests__/feedback.spec.ts
@@ -1,0 +1,828 @@
+import { ApolloServer } from "@apollo/server";
+import { typeDefs } from "../../schema";
+import { resolvers } from "../../resolver";
+import casual from "casual";
+import assert from "assert";
+import { buildContext, mockToken } from "../../__mocks__/context";
+import { logger } from "../../logger";
+import { JWTAccessToken } from "../../services/tokenService";
+import { User, UserRole } from "../../models/User";
+import { Plan } from "../../models/Plan";
+import { Project } from "../../models/Project";
+import { PlanFeedback } from "../../models/PlanFeedback";
+import { PlanFeedbackComment } from "../../models/PlanFeedbackComment";
+import { VersionedTemplate } from "../../models/VersionedTemplate";
+import { Affiliation } from "../../models/Affiliation";
+import { ProjectCollaborator } from "../../models/Collaborator";
+import { getCurrentDate } from "../../utils/helpers";
+import { sendFeedbackCompleteEmail } from "../../services/emailService";
+
+jest.mock('../../context.ts');
+jest.mock('../../datasources/cache');
+jest.mock('../../services/emailService');
+jest.mock('../../services/openSearchService');
+
+let testServer: ApolloServer;
+let affiliationId: string;
+let planId: number;
+let planFeedbackId: number;
+let plan: Plan;
+let project: Project;
+let feedback: PlanFeedback;
+let feedbackComment: PlanFeedbackComment;
+let researcherToken: JWTAccessToken;
+let adminToken: JWTAccessToken;
+let superAdminToken: JWTAccessToken;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function executeQuery(query: string, variables: any, token: JWTAccessToken): Promise<any> {
+  const context = buildContext(logger, token, null);
+  return await testServer.executeOperation({ query, variables }, { contextValue: context });
+}
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+
+  testServer = new ApolloServer({ typeDefs, resolvers });
+
+  affiliationId = casual.url;
+  planId = casual.integer(1, 9999);
+  planFeedbackId = casual.integer(1, 9999);
+
+  researcherToken = await mockToken();
+  researcherToken.role = UserRole.RESEARCHER;
+
+  adminToken = await mockToken();
+  adminToken.role = UserRole.ADMIN;
+  adminToken.affiliationId = affiliationId;
+
+  superAdminToken = await mockToken();
+  superAdminToken.role = UserRole.SUPERADMIN;
+  superAdminToken.affiliationId = affiliationId;
+
+  plan = new Plan({
+    id: planId,
+    projectId: casual.integer(1, 9999),
+    versionedTemplateId: casual.integer(1, 9999),
+    title: casual.sentence,
+    createdById: casual.integer(1, 9999),
+  });
+
+  project = new Project({
+    id: plan.projectId,
+    createdById: casual.integer(1, 9999),
+    title: casual.sentence,
+  });
+
+  feedback = new PlanFeedback({
+    id: planFeedbackId,
+    planId,
+    requested: getCurrentDate(),
+    requestedById: casual.integer(1, 9999),
+    completed: null,
+  });
+
+  feedbackComment = new PlanFeedbackComment({
+    id: casual.integer(1, 9999),
+    answerId: casual.integer(1, 9999),
+    feedbackId: planFeedbackId,
+    commentText: casual.sentence,
+    createdById: casual.integer(1, 9999),
+  });
+
+  jest.spyOn(Plan, 'findById').mockResolvedValue(plan);
+  jest.spyOn(Project, 'findById').mockResolvedValue(project);
+  jest.spyOn(PlanFeedback, 'findById').mockResolvedValue(feedback);
+  jest.spyOn(PlanFeedback, 'findByPlanId').mockResolvedValue([]);
+  jest.spyOn(PlanFeedback, 'statusForPlan').mockResolvedValue({ status: 'NONE', id: null });
+  jest.spyOn(PlanFeedbackComment, 'findById').mockResolvedValue(feedbackComment);
+  jest.spyOn(PlanFeedbackComment, 'findByFeedbackId').mockResolvedValue([feedbackComment]);
+  jest.spyOn(VersionedTemplate, 'findById').mockResolvedValue(
+    new VersionedTemplate({ id: plan.versionedTemplateId, ownerId: affiliationId })
+  );
+  jest.spyOn(User, 'findById').mockResolvedValue(new User({ id: casual.integer(1, 9999) }));
+  jest.spyOn(ProjectCollaborator, 'findByProjectId').mockResolvedValue([]);
+  jest.spyOn(Affiliation, 'findByURI').mockResolvedValue(
+    new Affiliation({ uri: affiliationId, feedbackEmails: [casual.email] })
+  );
+  jest.spyOn(PlanFeedback.prototype, 'create').mockResolvedValue(feedback);
+  jest.spyOn(PlanFeedback.prototype, 'update').mockResolvedValue(feedback);
+  jest.spyOn(PlanFeedbackComment.prototype, 'create').mockResolvedValue(feedbackComment);
+  jest.spyOn(PlanFeedbackComment.prototype, 'update').mockResolvedValue(feedbackComment);
+  jest.spyOn(PlanFeedbackComment.prototype, 'delete').mockResolvedValue(feedbackComment);
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// planFeedback query
+// ---------------------------------------------------------------------------
+describe('planFeedback query', () => {
+  let query: string;
+
+  beforeEach(() => {
+    query = `
+      query PlanFeedback($planId: Int!) {
+        planFeedback(planId: $planId) {
+          id
+          requested
+          summaryText
+        }
+      }
+    `;
+  });
+
+  it('returns a 401 when the user is not authenticated', async () => {
+    const resp = await executeQuery(query, { planId }, null);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+
+  it('returns a 403 when the user is not an admin', async () => {
+    const resp = await executeQuery(query, { planId }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('returns a 404 when the plan is not found', async () => {
+    jest.spyOn(Plan, 'findById').mockResolvedValue(null);
+    const resp = await executeQuery(query, { planId }, superAdminToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
+  });
+
+  it('returns a 403 when the admin belongs to a different affiliation', async () => {
+    const differentAffiliationAdmin = await mockToken();
+    differentAffiliationAdmin.role = UserRole.ADMIN;
+    differentAffiliationAdmin.affiliationId = casual.url; // different from versionedTemplate.ownerId
+
+    const resp = await executeQuery(query, { planId }, differentAffiliationAdmin);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('returns the planFeedback list when successful', async () => {
+    jest.spyOn(PlanFeedback, 'findByPlanId').mockResolvedValue([feedback]);
+
+    const resp = await executeQuery(query, { planId }, superAdminToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeUndefined();
+    expect(resp.body.singleResult.data.planFeedback).toHaveLength(1);
+    expect(resp.body.singleResult.data.planFeedback[0].id).toEqual(feedback.id);
+  });
+
+  it('returns a 500 on a fatal error', async () => {
+    jest.spyOn(Plan, 'findById').mockRejectedValue(new Error('DB error'));
+    const resp = await executeQuery(query, { planId }, superAdminToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('INTERNAL_SERVER');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// planFeedbackComments query
+// ---------------------------------------------------------------------------
+describe('planFeedbackComments query', () => {
+  let query: string;
+
+  beforeEach(() => {
+    query = `
+      query PlanFeedbackComments($planId: Int!, $planFeedbackId: Int!) {
+        planFeedbackComments(planId: $planId, planFeedbackId: $planFeedbackId) {
+          id
+          commentText
+        }
+      }
+    `;
+  });
+
+  it('returns a 401 when the user is not authenticated', async () => {
+    const resp = await executeQuery(query, { planId, planFeedbackId }, null);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+
+  it('returns a 404 when the plan is not found', async () => {
+    jest.spyOn(Plan, 'findById').mockResolvedValue(null);
+    const resp = await executeQuery(query, { planId, planFeedbackId }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
+  });
+
+  it('returns a 403 when the user has no permission on the project', async () => {
+    // project.createdById does not match token.id and user is not collaborator/admin
+    const resp = await executeQuery(query, { planId, planFeedbackId }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('returns the feedback comments when successful', async () => {
+    // Grant permission by setting project creator to the token user
+    project.createdById = researcherToken.id;
+
+    const resp = await executeQuery(query, { planId, planFeedbackId }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeUndefined();
+    expect(resp.body.singleResult.data.planFeedbackComments).toHaveLength(1);
+    expect(resp.body.singleResult.data.planFeedbackComments[0].id)
+      .toEqual(feedbackComment.id);
+  });
+
+  it('returns a 500 on a fatal error', async () => {
+    project.createdById = researcherToken.id;
+    jest.spyOn(PlanFeedbackComment, 'findByFeedbackId').mockRejectedValue(new Error('DB error'));
+
+    const resp = await executeQuery(query, { planId, planFeedbackId }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('INTERNAL_SERVER');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// planFeedbackStatus query
+// ---------------------------------------------------------------------------
+describe('planFeedbackStatus query', () => {
+  let query: string;
+
+  beforeEach(() => {
+    query = `
+      query PlanFeedbackStatus($planId: Int!) {
+        planFeedbackStatus(planId: $planId) {
+          status
+          id
+        }
+      }
+    `;
+  });
+
+  it('returns a 401 when the user is not authenticated', async () => {
+    const resp = await executeQuery(query, { planId }, null);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+
+  it('returns a 404 when the plan is not found', async () => {
+    jest.spyOn(Plan, 'findById').mockResolvedValue(null);
+    const resp = await executeQuery(query, { planId }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
+  });
+
+  it('returns a 404 when the plan creator is not found', async () => {
+    jest.spyOn(User, 'findById').mockResolvedValue(null);
+    const resp = await executeQuery(query, { planId }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
+  });
+
+  it('returns a 403 when the user has no permission on the project', async () => {
+    const resp = await executeQuery(query, { planId }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('returns the feedback status when successful', async () => {
+    project.createdById = researcherToken.id;
+    jest.spyOn(PlanFeedback, 'statusForPlan').mockResolvedValue({ status: 'REQUESTED', id: planFeedbackId });
+
+    const resp = await executeQuery(query, { planId }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeUndefined();
+    expect(resp.body.singleResult.data.planFeedbackStatus.status).toEqual('REQUESTED');
+    expect(resp.body.singleResult.data.planFeedbackStatus.id).toEqual(planFeedbackId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requestFeedback mutation
+// ---------------------------------------------------------------------------
+describe('requestFeedback mutation', () => {
+  let query: string;
+
+  beforeEach(() => {
+    query = `
+      mutation RequestFeedback($planId: Int!, $messageToOrg: String) {
+        requestFeedback(planId: $planId, messageToOrg: $messageToOrg) {
+          id
+          requested
+        }
+      }
+    `;
+    // By default no existing open feedback
+    jest.spyOn(PlanFeedback, 'findByPlanId').mockResolvedValue([]);
+  });
+
+  it('returns a 401 when the user is not authenticated', async () => {
+    const resp = await executeQuery(query, { planId }, null);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+
+  it('returns a 404 when the plan is not found', async () => {
+    jest.spyOn(Plan, 'findById').mockResolvedValue(null);
+    const resp = await executeQuery(query, { planId }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
+  });
+
+  it('returns a 403 when the user has no permission on the project', async () => {
+    const resp = await executeQuery(query, { planId }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('returns a 403 when there is already an open feedback round', async () => {
+    project.createdById = researcherToken.id;
+    // Return existing feedback with completed = null (open)
+    jest.spyOn(PlanFeedback, 'findByPlanId').mockResolvedValue([feedback]);
+
+    const resp = await executeQuery(query, { planId }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('creates the feedback and returns it when successful', async () => {
+    project.createdById = researcherToken.id;
+    researcherToken.affiliationId = affiliationId;
+
+    const resp = await executeQuery(
+      query,
+      { planId, messageToOrg: casual.sentence },
+      researcherToken,
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeUndefined();
+    expect(resp.body.singleResult.data.requestFeedback.id).toEqual(feedback.id);
+    expect(PlanFeedback.prototype.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a 500 on a fatal error', async () => {
+    project.createdById = researcherToken.id;
+    researcherToken.affiliationId = affiliationId;
+    jest.spyOn(PlanFeedback.prototype, 'create').mockRejectedValue(new Error('DB error'));
+
+    const resp = await executeQuery(query, { planId }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('INTERNAL_SERVER');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// completeFeedback mutation
+// ---------------------------------------------------------------------------
+describe('completeFeedback mutation', () => {
+  let query: string;
+
+  beforeEach(() => {
+    query = `
+      mutation CompleteFeedback($planId: Int!, $planFeedbackId: Int!, $summaryText: String, $sendEmail: Boolean) {
+        completeFeedback(planId: $planId, planFeedbackId: $planFeedbackId, summaryText: $summaryText, sendEmail: $sendEmail) {
+          id
+          requested
+          completed
+        }
+      }
+    `;
+  });
+
+  it('returns a 401 when the user is not authenticated', async () => {
+    const resp = await executeQuery(query, { planId, planFeedbackId }, null);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+
+  it('returns a 404 when the plan is not found', async () => {
+    jest.spyOn(Plan, 'findById').mockResolvedValue(null);
+    const resp = await executeQuery(query, { planId, planFeedbackId }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
+  });
+
+  it('returns a 403 when the user has no permission on the project', async () => {
+    const resp = await executeQuery(query, { planId, planFeedbackId }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('returns a 404 when the feedback record is not found', async () => {
+    project.createdById = researcherToken.id;
+    jest.spyOn(PlanFeedback, 'findById').mockResolvedValue(null);
+
+    const resp = await executeQuery(query, { planId, planFeedbackId }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
+  });
+
+  it('marks the feedback as complete and returns it when successful', async () => {
+    project.createdById = researcherToken.id;
+    const completedFeedback = new PlanFeedback({
+      ...feedback,
+      completed: getCurrentDate(),
+      completedById: researcherToken.id,
+      summaryText: casual.sentence,
+    });
+    jest.spyOn(PlanFeedback.prototype, 'update').mockResolvedValue(completedFeedback);
+
+    const resp = await executeQuery(
+      query,
+      { planId, planFeedbackId, summaryText: casual.sentence, sendEmail: true },
+      researcherToken,
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeUndefined();
+    expect(resp.body.singleResult.data.completeFeedback.id).toEqual(completedFeedback.id);
+    expect(resp.body.singleResult.data.completeFeedback.completed).toBeDefined();
+    expect(PlanFeedback.prototype.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a 500 on a fatal error', async () => {
+    project.createdById = researcherToken.id;
+    jest.spyOn(PlanFeedback.prototype, 'update').mockRejectedValue(new Error('DB error'));
+
+    const resp = await executeQuery(query, { planId, planFeedbackId, summaryText: casual.sentence, sendEmail: true }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('INTERNAL_SERVER');
+  });
+
+  it('should not call sendFeedbackCompleteEmail when sendEmail is false', async () => {
+    project.createdById = researcherToken.id;
+    const resp = await executeQuery(
+      query,
+      { planId, planFeedbackId, summaryText: casual.sentence, sendEmail: false },
+      researcherToken,
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeUndefined();
+    expect(resp.body.singleResult.data.completeFeedback.id).toEqual(feedback.id);
+    expect(PlanFeedback.prototype.update).toHaveBeenCalledTimes(1);
+    expect(sendFeedbackCompleteEmail).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addFeedbackComment mutation
+// ---------------------------------------------------------------------------
+describe('addFeedbackComment mutation', () => {
+  let query: string;
+  let answerId: number;
+
+  beforeEach(() => {
+    answerId = casual.integer(1, 9999);
+    query = `
+      mutation AddFeedbackComment(
+        $planId: Int!, $planFeedbackId: Int!, $answerId: Int!, $commentText: String!
+      ) {
+        addFeedbackComment(
+          planId: $planId, planFeedbackId: $planFeedbackId,
+          answerId: $answerId, commentText: $commentText
+        ) {
+          id
+          commentText
+        }
+      }
+    `;
+  });
+
+  it('returns a 401 when the user is not authenticated', async () => {
+    const resp = await executeQuery(
+      query, { planId, planFeedbackId, answerId, commentText: casual.sentence }, null
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+
+  it('returns a 403 when the user is not an admin', async () => {
+    const resp = await executeQuery(
+      query, { planId, planFeedbackId, answerId, commentText: casual.sentence }, researcherToken
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('returns a 404 when the plan is not found', async () => {
+    jest.spyOn(Plan, 'findById').mockResolvedValue(null);
+    const resp = await executeQuery(
+      query, { planId, planFeedbackId, answerId, commentText: casual.sentence }, superAdminToken
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
+  });
+
+  it('returns a 404 when the feedback record is not found', async () => {
+    jest.spyOn(PlanFeedback, 'findById').mockResolvedValue(null);
+    const resp = await executeQuery(
+      query, { planId, planFeedbackId, answerId, commentText: casual.sentence }, superAdminToken
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
+  });
+
+  it('returns a 403 when the feedback round is already completed', async () => {
+    const completedFeedback = new PlanFeedback({
+      ...feedback,
+      completed: getCurrentDate(),
+    });
+    jest.spyOn(PlanFeedback, 'findById').mockResolvedValue(completedFeedback);
+
+    const resp = await executeQuery(
+      query, { planId, planFeedbackId, answerId, commentText: casual.sentence }, superAdminToken
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('adds the comment and returns it when successful', async () => {
+    // feedback.completed is null by default (open)
+    const resp = await executeQuery(
+      query,
+      { planId, planFeedbackId, answerId, commentText: casual.sentence },
+      superAdminToken,
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeUndefined();
+    expect(resp.body.singleResult.data.addFeedbackComment.id).toEqual(feedbackComment.id);
+    expect(PlanFeedbackComment.prototype.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a 500 on a fatal error', async () => {
+    jest.spyOn(PlanFeedbackComment.prototype, 'create').mockRejectedValue(new Error('DB error'));
+    const resp = await executeQuery(
+      query,
+      { planId, planFeedbackId, answerId, commentText: casual.sentence },
+      superAdminToken,
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('INTERNAL_SERVER');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateFeedbackComment mutation
+// ---------------------------------------------------------------------------
+describe('updateFeedbackComment mutation', () => {
+  let query: string;
+
+  beforeEach(() => {
+    query = `
+      mutation UpdateFeedbackComment(
+        $planId: Int!, $planFeedbackCommentId: Int!, $commentText: String!
+      ) {
+        updateFeedbackComment(
+          planId: $planId, planFeedbackCommentId: $planFeedbackCommentId, commentText: $commentText
+        ) {
+          id
+          commentText
+        }
+      }
+    `;
+  });
+
+  it('returns a 401 when the user is not authenticated', async () => {
+    const resp = await executeQuery(
+      query, { planId, planFeedbackCommentId: feedbackComment.id, commentText: casual.sentence }, null
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+
+  it('returns a 403 when the user is not an admin', async () => {
+    const resp = await executeQuery(
+      query,
+      { planId, planFeedbackCommentId: feedbackComment.id, commentText: casual.sentence },
+      researcherToken,
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('returns a 404 when the plan is not found', async () => {
+    jest.spyOn(Plan, 'findById').mockResolvedValue(null);
+    const resp = await executeQuery(
+      query,
+      { planId, planFeedbackCommentId: feedbackComment.id, commentText: casual.sentence },
+      superAdminToken,
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
+  });
+
+  it('returns a 404 when the comment is not found', async () => {
+    jest.spyOn(PlanFeedbackComment, 'findById').mockResolvedValue(null);
+    const resp = await executeQuery(
+      query,
+      { planId, planFeedbackCommentId: feedbackComment.id, commentText: casual.sentence },
+      superAdminToken,
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
+  });
+
+  it('returns a 403 when the user is not the comment creator', async () => {
+    // feedbackComment.createdById is a random int that won't match the token id
+    const resp = await executeQuery(
+      query,
+      { planId, planFeedbackCommentId: feedbackComment.id, commentText: casual.sentence },
+      superAdminToken,
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('updates the comment and returns it when successful', async () => {
+    feedbackComment.createdById = superAdminToken.id;
+    const newText = casual.sentence;
+    const updatedComment = new PlanFeedbackComment({ ...feedbackComment, commentText: newText });
+    jest.spyOn(PlanFeedbackComment.prototype, 'update').mockResolvedValue(updatedComment);
+
+    const resp = await executeQuery(
+      query,
+      { planId, planFeedbackCommentId: feedbackComment.id, commentText: newText },
+      superAdminToken,
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeUndefined();
+    expect(resp.body.singleResult.data.updateFeedbackComment.id).toEqual(updatedComment.id);
+    expect(PlanFeedbackComment.prototype.update).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeFeedbackComment mutation
+// ---------------------------------------------------------------------------
+describe('removeFeedbackComment mutation', () => {
+  let query: string;
+
+  beforeEach(() => {
+    query = `
+      mutation RemoveFeedbackComment($planId: Int!, $planFeedbackCommentId: Int!) {
+        removeFeedbackComment(planId: $planId, planFeedbackCommentId: $planFeedbackCommentId) {
+          id
+          commentText
+        }
+      }
+    `;
+  });
+
+  it('returns a 401 when the user is not authenticated', async () => {
+    const resp = await executeQuery(
+      query, { planId, planFeedbackCommentId: feedbackComment.id }, null
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+
+  it('returns a 404 when the plan is not found', async () => {
+    project.createdById = researcherToken.id;
+    jest.spyOn(Plan, 'findById').mockResolvedValue(null);
+    const resp = await executeQuery(
+      query, { planId, planFeedbackCommentId: feedbackComment.id }, researcherToken
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
+  });
+
+  it('returns a 403 when the user has no permission on the project', async () => {
+    const resp = await executeQuery(
+      query, { planId, planFeedbackCommentId: feedbackComment.id }, researcherToken
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('returns a 404 when the comment is not found', async () => {
+    project.createdById = researcherToken.id;
+    jest.spyOn(PlanFeedbackComment, 'findById').mockResolvedValue(null);
+    const resp = await executeQuery(
+      query, { planId, planFeedbackCommentId: feedbackComment.id }, researcherToken
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
+  });
+
+  it('returns a 403 when the user has no permission to delete the comment', async () => {
+    project.createdById = researcherToken.id;
+    // feedbackComment.createdById and plan.createdById don't match researcherToken.id
+    // and no OWN-level collaborators
+    const resp = await executeQuery(
+      query, { planId, planFeedbackCommentId: feedbackComment.id }, researcherToken
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('deletes the comment and returns it when the user is the comment creator', async () => {
+    project.createdById = researcherToken.id;
+    feedbackComment.createdById = researcherToken.id;
+
+    const resp = await executeQuery(
+      query, { planId, planFeedbackCommentId: feedbackComment.id }, researcherToken
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeUndefined();
+    expect(resp.body.singleResult.data.removeFeedbackComment.id).toEqual(feedbackComment.id);
+    expect(PlanFeedbackComment.prototype.delete).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a 500 on a fatal error', async () => {
+    project.createdById = researcherToken.id;
+    feedbackComment.createdById = researcherToken.id;
+    jest.spyOn(PlanFeedbackComment.prototype, 'delete').mockRejectedValue(new Error('DB error'));
+
+    const resp = await executeQuery(
+      query, { planId, planFeedbackCommentId: feedbackComment.id }, researcherToken
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('INTERNAL_SERVER');
+  });
+});

--- a/src/resolvers/feedback.ts
+++ b/src/resolvers/feedback.ts
@@ -226,7 +226,6 @@ export const resolvers: Resolvers = {
               throw NotFoundError(`PlanFeedback with ID ${planFeedbackId} not found`);
             }
 
-
             const newFeedback = new PlanFeedback({
               id: feedback.id,
               planId: feedback.planId,
@@ -243,13 +242,13 @@ export const resolvers: Resolvers = {
             }
 
             if (sendEmail) {
-              const planURL = `/projects/${project.id}/plans/${planId}`;
+              const planURL = `/projects/${project.id}/dmp/${planId}`;
               const adminName = [context.token.givenName, context.token.surName]
                 .filter(Boolean).join(' ');
 
               await sendFeedbackCompleteEmail(
                 context,
-                plan.createdById,
+                feedback.requestedById,
                 adminName,
                 plan.title,
                 planURL,

--- a/src/resolvers/feedback.ts
+++ b/src/resolvers/feedback.ts
@@ -10,7 +10,11 @@ import {
 
 import { isAuthorized } from "../services/authService";
 import { hasPermissionOnProject } from "../services/projectService";
-import { sendProjectCollaboratorsCommentsAddedEmail, sendFeedbackRequestEmail } from '../services/emailService';
+import {
+  sendProjectCollaboratorsCommentsAddedEmail,
+  sendFeedbackRequestEmail,
+  sendFeedbackCompleteEmail
+} from '../services/emailService';
 import { isAdmin, isSuperAdmin } from "../services/authService";
 import { canDeleteComment } from "../services/commentPermissions";
 import { Project } from "../models/Project";
@@ -203,7 +207,7 @@ export const resolvers: Resolvers = {
       }
     },
     // Mark the feedback round as complete
-    completeFeedback: async (_, { planId, planFeedbackId, summaryText }, context: MyContext): Promise<PlanFeedback> => {
+    completeFeedback: async (_, { planId, planFeedbackId, summaryText, sendEmail = true }, context: MyContext): Promise<PlanFeedback> => {
       const reference = 'completeFeedback resolver';
       try {
         if (isAuthorized(context.token)) {
@@ -237,6 +241,21 @@ export const resolvers: Resolvers = {
             if (!updatedFeedback) {
               throw NotFoundError(`PlanFeedback with ID ${planFeedbackId} not found`);
             }
+
+            if (sendEmail) {
+              const planURL = `/projects/${project.id}/plans/${planId}`;
+              const adminName = [context.token.givenName, context.token.surName]
+                .filter(Boolean).join(' ');
+
+              await sendFeedbackCompleteEmail(
+                context,
+                plan.createdById,
+                adminName,
+                plan.title,
+                planURL,
+              );
+            }
+
             return updatedFeedback;
 
           }

--- a/src/resolvers/plan.ts
+++ b/src/resolvers/plan.ts
@@ -56,6 +56,10 @@ export const resolvers: Resolvers = {
         }
 
         const project = await Project.findById(reference, context, plan.projectId);
+        if (!project) {
+          throw NotFoundError(`Project with ID ${plan.projectId} not found`);
+        }
+
         if (await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.COMMENT)) {
           return plan;
         }
@@ -286,7 +290,7 @@ export const resolvers: Resolvers = {
 
   Plan: {
     // The user who owns/created the plan
-    planOwner: async (parent: Plan, _, context: MyContext): Promise<User> => {
+    planCreator: async (parent: Plan, _, context: MyContext): Promise<User> => {
       if (parent?.createdById) {
         return await User.findById('plan.createdBy resolver', context, parent.createdById);
       }

--- a/src/resolvers/plan.ts
+++ b/src/resolvers/plan.ts
@@ -4,6 +4,7 @@ import { Plan, PlanSearchResult, PlanSectionProgress, PlanProgress, PlanStatus, 
 import { prepareObjectForLogs } from "../logger";
 import { AuthenticationError, ForbiddenError, InternalServerError, NotFoundError } from "../utils/graphQLErrors";
 import { Project } from "../models/Project";
+import { User } from "../models/User";
 import { isAuthorized } from "../services/authService";
 import { hasPermissionOnProject } from "../services/projectService";
 import { PlanMember } from "../models/Member";
@@ -284,6 +285,13 @@ export const resolvers: Resolvers = {
   },
 
   Plan: {
+    // The user who owns/created the plan
+    planOwner: async (parent: Plan, _, context: MyContext): Promise<User> => {
+      if (parent?.createdById) {
+        return await User.findById('plan.createdBy resolver', context, parent.createdById);
+      }
+      return null;
+    },
     // The project the plan is associated with
     project: async (parent: Plan, _, context: MyContext): Promise<Project> => {
       if (parent?.projectId) {

--- a/src/schemas/feedback.ts
+++ b/src/schemas/feedback.ts
@@ -22,7 +22,7 @@ export const typeDefs = gql`
     "Request a round of admin feedback"
     requestFeedback(planId: Int!, messageToOrg: String): PlanFeedback
     "Mark the feedback round as complete"
-    completeFeedback(planId: Int!, planFeedbackId: Int!, summaryText: String): PlanFeedback
+    completeFeedback(planId: Int!, planFeedbackId: Int!, summaryText: String, sendEmail: Boolean): PlanFeedback
     "Add feedback comment for an answer within a round of feedback"
     addFeedbackComment(planId: Int!, planFeedbackId: Int!, answerId: Int!, commentText: String!): PlanFeedbackComment
     "Update feedback comment for an answer within a round of feedback"

--- a/src/schemas/plan.ts
+++ b/src/schemas/plan.ts
@@ -125,7 +125,7 @@ export const typeDefs = gql`
     "The user who created the Object"
     createdById: Int
     "The user who created the plan"
-    planOwner: User
+    planCreator: User
     "The timestamp when the Object was created"
     created: String
     "The user who last modified the Object"

--- a/src/schemas/plan.ts
+++ b/src/schemas/plan.ts
@@ -124,6 +124,8 @@ export const typeDefs = gql`
     id: Int
     "The user who created the Object"
     createdById: Int
+    "The user who created the plan"
+    planOwner: User
     "The timestamp when the Object was created"
     created: String
     "The user who last modified the Object"

--- a/src/services/__tests__/emailService.spec.ts
+++ b/src/services/__tests__/emailService.spec.ts
@@ -18,7 +18,8 @@ import {
   sendEmailConfirmationNotification,
   sendProjectCollaborationEmail,
   sendTemplateCollaborationEmail,
-  sendProjectCollaboratorsCommentsAddedEmail
+  sendProjectCollaboratorsCommentsAddedEmail,
+  sendFeedbackCompleteEmail,
 } from "../emailService";
 import { generalConfig } from "../../config/generalConfig";
 import { emailConfig } from "../../config/emailConfig";
@@ -216,6 +217,98 @@ describe('sendEmail', () => {
 
     expect(sent).toBe(false);
     expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it('should send plan owner an email when feedback is complete', async () => {
+    jest.spyOn(logger, 'info');
+    const email = casual.email;
+    const planOwnerUserId = casual.integer(1, 99);
+    const adminName = `${casual.first_name} ${casual.last_name}`;
+    const planTitle = casual.sentence;
+    const planURL = casual.url;
+    const user = new User({
+      id: planOwnerUserId,
+      givenName: casual.first_name,
+      surName: casual.last_name,
+      notify_on_feedback_complete: true,
+    });
+    (User.findById as jest.Mock) = jest.fn().mockResolvedValueOnce(user);
+    jest.spyOn(User.prototype, 'getEmail').mockResolvedValue(email);
+    const sent = await sendFeedbackCompleteEmail(context, planOwnerUserId, adminName, planTitle, planURL);
+
+    const expectedSubject = `${subjectPrefix} - ${emailSubjects.feedbackComplete}`;
+    const planOwnerName = [user.givenName, user.surName].filter(Boolean).join(' ');
+    const domain = generalConfig.domain;
+    const expectedMessage = emailMessages.feedbackComplete
+      .replace('%{planOwnerName}', planOwnerName)
+      .replace('%{adminName}', adminName)
+      .replace('%{planUrl}', `${domain}${planURL}`)
+      .replace('%{planTitle}', planTitle)
+      .replace('%{profileUrl}', `${domain}/account/profile`)
+      .replace('%{helpDeskEmail}', emailConfig.helpDeskAddress)
+      .replace('%{helpUrl}', `${domain}/help`);
+
+    expect(sent).toBe(true);
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    // sendEmail should have been called once
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendEmail).toHaveBeenCalledWith({
+      "bcc": "",
+      "cc": "",
+      "from": `"${generalConfig.applicationName}" <${emailConfig.doNotReplyAddress}>`,
+      "html": expectedMessage,
+      "replyTo": emailConfig.helpDeskAddress,
+      "sender": emailConfig.doNotReplyAddress,
+      "subject": expectedSubject,
+      "to": email,
+    });
+  });
+
+  it('should return false when user has notify_on_feedback_complete disabled', async () => {
+    const planOwnerUserId = casual.integer(1, 99);
+    const user = new User({
+      id: planOwnerUserId,
+      givenName: casual.first_name,
+      surName: casual.last_name,
+      notify_on_feedback_complete: false,
+    });
+    (User.findById as jest.Mock) = jest.fn().mockResolvedValueOnce(user);
+
+    const sent = await sendFeedbackCompleteEmail(
+      context,
+      planOwnerUserId,
+      casual.full_name,
+      casual.sentence,
+      casual.url,
+    );
+
+    expect(sent).toBe(false);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it('should log an error and return false when the plan owner has no email address', async () => {
+    jest.spyOn(context.logger, 'error');
+    const planOwnerUserId = casual.integer(1, 99);
+    const user = new User({
+      id: planOwnerUserId,
+      givenName: casual.first_name,
+      surName: casual.last_name,
+      notify_on_feedback_complete: true,
+    });
+    (User.findById as jest.Mock) = jest.fn().mockResolvedValueOnce(user);
+    jest.spyOn(User.prototype, 'getEmail').mockResolvedValue(null);
+
+    const sent = await sendFeedbackCompleteEmail(
+      context,
+      planOwnerUserId,
+      casual.full_name,
+      casual.sentence,
+      casual.url,
+    );
+
+    expect(sent).toBe(false);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(context.logger.error).toHaveBeenCalledTimes(1);
   });
 
   it('should send feedback request emails to all collaborators', async () => {

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -225,12 +225,12 @@ export const sendProjectCollaboratorsCommentsAddedEmail = async (
 
 export const sendFeedbackCompleteEmail = async (
   context: MyContext,
-  planOwnerUserId: number,
+  feedbackRequestedById: number,
   adminName: string,
   planTitle: string,
   planURL: string,
 ): Promise<boolean> => {
-  const user = await User.findById('sendFeedbackCompleteEmail', context, planOwnerUserId);
+  const user = await User.findById('sendFeedbackCompleteEmail', context, feedbackRequestedById);
   if (!user?.notify_on_feedback_complete) {
     return false;
   }
@@ -238,8 +238,8 @@ export const sendFeedbackCompleteEmail = async (
   const emailAddress = await user.getEmail(context);
   if (!emailAddress) {
     context.logger.error(
-      prepareObjectForLogs({ planOwnerUserId }),
-      `User with ID ${planOwnerUserId} does not have an email address and cannot be sent a feedback complete email`
+      prepareObjectForLogs({ feedbackRequestedById }),
+      `User with ID ${feedbackRequestedById} does not have an email address and cannot be sent a feedback complete email`
     );
     return false;
   }

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -15,6 +15,7 @@ export const emailSubjects = {
   templateCollaboration: 'You were invited to collaborate on a template',
   projectCollaboratorCommentsAdded: 'New comments added to the plan',
   feedbackRequest: 'You have been requested to provide feedback on a data management plan',
+  feedbackComplete: 'Feedback on your data management plan is complete',
 }
 
 export const emailMessages = {
@@ -29,6 +30,15 @@ export const emailMessages = {
 `,
   projectCollaboratorCommentsAdded: `
 <p>New comments were added to the plan.</p>
+`,
+  feedbackComplete: `
+<p>Hello %{planOwnerName},</p>
+<p>%{adminName} has finished providing feedback on the plan "<a href="%{planUrl}">%{planTitle}</a>".
+Comments can be found in the 'Write plan' tab on the right side of the page (Guidance/Comments).</p>
+<p>Thank you,<br>The DMP Tool team</p>
+<p><small>You may change your notification preferences on your <a href="%{profileUrl}">profile page</a>.
+Please do not reply to this email. If you have any questions or need help, please contact us at
+<a href="mailto:%{helpDeskEmail}">%{helpDeskEmail}</a> or visit the <a href="%{helpUrl}">Help Page</a>.</small></p>
 `,
 }
 
@@ -173,7 +183,7 @@ export const sendProjectCollaborationEmail = async (
       context.logger.error(prepareObjectForLogs({ userId }), `User with ID ${userId} does not have an email address and cannot be sent a project collaboration email`);
       return false;
     }
-    // Use the user's primary email address, regardless of what was provided
+
     toAddress = emailAddress;
   }
 
@@ -211,6 +221,49 @@ export const sendProjectCollaboratorsCommentsAddedEmail = async (
     );
   }
   return true;
+}
+
+export const sendFeedbackCompleteEmail = async (
+  context: MyContext,
+  planOwnerUserId: number,
+  adminName: string,
+  planTitle: string,
+  planURL: string,
+): Promise<boolean> => {
+  const user = await User.findById('sendFeedbackCompleteEmail', context, planOwnerUserId);
+  if (!user?.notify_on_feedback_complete) {
+    return false;
+  }
+
+  const emailAddress = await user.getEmail(context);
+  if (!emailAddress) {
+    context.logger.error(
+      prepareObjectForLogs({ planOwnerUserId }),
+      `User with ID ${planOwnerUserId} does not have an email address and cannot be sent a feedback complete email`
+    );
+    return false;
+  }
+
+  const planOwnerName = [user.givenName, user.surName].filter(Boolean).join(' ');
+  const domain = generalConfig.domain;
+  const message = emailMessages.feedbackComplete
+    .replace('%{planOwnerName}', planOwnerName)
+    .replace('%{adminName}', adminName)
+    .replace('%{planUrl}', `${domain}${planURL}`)
+    .replace('%{planTitle}', planTitle)
+    .replace('%{profileUrl}', `${domain}/account/profile`)
+    .replace('%{helpDeskEmail}', emailConfig.helpDeskAddress)
+    .replace('%{helpUrl}', `${domain}/help`);
+
+  return await sendEmail(
+    context,
+    'FeedbackComplete',
+    [emailAddress],
+    [],
+    [],
+    emailSubjects.feedbackComplete,
+    message
+  );
 }
 
 export const sendFeedbackRequestEmail = async (

--- a/src/types.ts
+++ b/src/types.ts
@@ -1812,6 +1812,7 @@ export type MutationArchiveTemplateArgs = {
 export type MutationCompleteFeedbackArgs = {
   planFeedbackId: Scalars['Int']['input'];
   planId: Scalars['Int']['input'];
+  sendEmail?: InputMaybe<Scalars['Boolean']['input']>;
   summaryText?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -2387,6 +2388,8 @@ export type Plan = {
   modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
   modifiedById?: Maybe<Scalars['Int']['output']>;
+  /** The user who created the plan */
+  planOwner?: Maybe<User>;
   /** The progress the user has made within the plan */
   progress?: Maybe<PlanProgress>;
   /** The project the plan is associated with */
@@ -6956,6 +6959,7 @@ export type PlanResolvers<ContextType = MyContext, ParentType extends ResolversP
   members?: Resolver<Maybe<Array<ResolversTypes['PlanMember']>>, ParentType, ContextType>;
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  planOwner?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
   progress?: Resolver<Maybe<ResolversTypes['PlanProgress']>, ParentType, ContextType>;
   project?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType>;
   registered?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2389,7 +2389,7 @@ export type Plan = {
   /** The user who last modified the Object */
   modifiedById?: Maybe<Scalars['Int']['output']>;
   /** The user who created the plan */
-  planOwner?: Maybe<User>;
+  planCreator?: Maybe<User>;
   /** The progress the user has made within the plan */
   progress?: Maybe<PlanProgress>;
   /** The project the plan is associated with */
@@ -6959,7 +6959,7 @@ export type PlanResolvers<ContextType = MyContext, ParentType extends ResolversP
   members?: Resolver<Maybe<Array<ResolversTypes['PlanMember']>>, ParentType, ContextType>;
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  planOwner?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+  planCreator?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
   progress?: Resolver<Maybe<ResolversTypes['PlanProgress']>, ParentType, ContextType>;
   project?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType>;
   registered?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;


### PR DESCRIPTION
## Description

- Updated `completedFeedback` resolver to send an email to the plan owner when feedback is marked as complete, and added a `sendEmail` boolean flag to input variables to stop an email from being sent
- Added `planOwner` field to the `plan` query response so that client can get plan owner affiliation.uri for feedback pages
- Added `feedback.spec.ts` unit tests for the feedback resolver

Fixes # ([331](https://github.com/CDLUC3/dmptool-apollo-server/issues/331))([198](https://github.com/CDLUC3/dmptool-doc/issues/198))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested and added unit tests


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules