### PR TITLE
Add isDefault flag to MemberRole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.1.0
 
 ### Added
+- Added new `setDefaultMemberRole` mutation to member roles resolver.
 - Added local seed data for a Template that includes a research output question type, and a project/plan that uses it.
 - Added `PRIMARY` ProjectCollaboratorAccessLevel [#227]
 - Added `findByUserIdAndProjectId function to Collaborator model [#227]
@@ -70,6 +71,7 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated `MemberRole` schema to include `isDefault` flag and added a `setDefaultMemberRole` mutation.
 - Refactored the `saveMaDMPVersion` function in `planService` to use the shared functionality from `@dmptool/utils` package to write directly to Dynamo rather than sending SQS messages.
 - Updated `updateProjectCollaborator` resolver to use new collaborator service functions to validate access level change and to demote an existing `primary` permission, before promoting another collaborator [#227]
 - Updated permissions for who can `requestFeedback` [#227]

--- a/src/models/MemberRole.ts
+++ b/src/models/MemberRole.ts
@@ -4,6 +4,7 @@ import { validateURL } from "../utils/helpers";
 import { MySqlModel } from "./MySqlModel";
 
 export const DEFAULT_DMPTOOL_MEMBER_ROLE_URL = 'https://dmptool.org/contributor_roles/';
+
 export class MemberRole extends MySqlModel {
   public displayOrder: number;
   public uri: string;

--- a/src/resolvers/memberRole.ts
+++ b/src/resolvers/memberRole.ts
@@ -5,11 +5,13 @@ import { MemberRole } from "../models/MemberRole";
 import { MyContext } from '../context';
 import { isSuperAdmin } from '../services/authService';
 import {
-  AuthenticationError, ForbiddenError, InternalServerError,
+  AuthenticationError,
+  ForbiddenError,
+  InternalServerError,
   NotFoundError
 } from '../utils/graphQLErrors';
 import { GraphQLError } from 'graphql';
-import {isNullOrUndefined, normaliseDateTime} from "../utils/helpers";
+import { isNullOrUndefined, normaliseDateTime } from "../utils/helpers";
 
 export const resolvers: Resolvers = {
   Query: {

--- a/src/resolvers/memberRole.ts
+++ b/src/resolvers/memberRole.ts
@@ -4,9 +4,12 @@ import { Resolvers } from "../types";
 import { MemberRole } from "../models/MemberRole";
 import { MyContext } from '../context';
 import { isSuperAdmin } from '../services/authService';
-import { AuthenticationError, ForbiddenError, InternalServerError } from '../utils/graphQLErrors';
+import {
+  AuthenticationError, ForbiddenError, InternalServerError,
+  NotFoundError
+} from '../utils/graphQLErrors';
 import { GraphQLError } from 'graphql';
-import { normaliseDateTime } from "../utils/helpers";
+import {isNullOrUndefined, normaliseDateTime} from "../utils/helpers";
 
 export const resolvers: Resolvers = {
   Query: {
@@ -104,6 +107,46 @@ export const resolvers: Resolvers = {
           const sql = 'DELETE FROM memberRoles WHERE id = ?';
           await context.dataSources.sqlDataSource.query(context, sql, [id.toString()]);
           return original;
+        }
+        throw context?.token ? ForbiddenError() : AuthenticationError();
+      } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+
+        context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
+        throw InternalServerError();
+      }
+    },
+
+    // Set the default member role
+    setDefaultMemberRole: async (_, { id }, context) => {
+      const reference = 'setDefaultMemberRole resolver';
+      const original = await MemberRole.findById(reference, context, id);
+      if (isNullOrUndefined(original)) {
+        throw NotFoundError();
+      }
+
+      try {
+        // If the current user is a superAdmin or an Admin and this is their Affiliation
+        if (isSuperAdmin(context.token)) {
+          const setSql = 'UPDATE memberRoles SET isDefault = true WHERE id = ?';
+          const unsetSql = 'UPDATE memberRoles SET isDefault = false WHERE isDefault = true';
+          // Fetch the original
+          const original = await MemberRole.defaultRole(context, reference);
+          const newOne = await MemberRole.findById(reference, context, id);
+
+          try {
+            // Unset the original and then set the new one
+            await context.dataSources.sqlDataSource.query(context, unsetSql, []);
+            await context.dataSources.sqlDataSource.query(context, setSql, [id.toString()]);
+            newOne.isDefault = true;
+          } catch (err) {
+            context.logger.error(err, "Unable to set the default member role");
+            // Something went wrong so revert the changes
+            await context.dataSources.sqlDataSource.query(context, unsetSql, []);
+            await context.dataSources.sqlDataSource.query(context, setSql, [original.id.toString()]);
+            newOne.addError('general', 'Unable to set the default member role at this time. Please try again later.');
+          }
+          return newOne;
         }
         throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {

--- a/src/schemas/memberRole.ts
+++ b/src/schemas/memberRole.ts
@@ -17,6 +17,8 @@ export const typeDefs = gql`
     updateMemberRole(id: Int!, url: URL!, label: String!, displayOrder: Int!, description: String): MemberRole
     "Delete the member role"
     removeMemberRole(id: Int!): MemberRole
+    "Mark the member role as the default role"
+    setDefaultMemberRole(id: Int!): MemberRole
   }
 
   type MemberRole {
@@ -41,6 +43,8 @@ export const typeDefs = gql`
     uri: String!
     "A longer description of the member role useful for tooltips"
     description: String
+    "Whether this is the default role"
+    isDefault: Boolean
   }
 
   "A collection of errors related to the member role"

--- a/src/types.ts
+++ b/src/types.ts
@@ -1231,6 +1231,8 @@ export type MemberRole = {
   errors?: Maybe<MemberRoleErrors>;
   /** The unique identifer for the Object */
   id?: Maybe<Scalars['Int']['output']>;
+  /** Whether this is the default role */
+  isDefault?: Maybe<Scalars['Boolean']['output']>;
   /** The Ui label to display for the member role */
   label: Scalars['String']['output'];
   /** The timestamp when the Object was last modifed */
@@ -1513,6 +1515,8 @@ export type Mutation = {
   requirements?: Maybe<Scalars['String']['output']>;
   /** Resend an invite to a ProjectCollaborator */
   resendInviteToProjectCollaborator?: Maybe<ProjectCollaborator>;
+  /** Mark the member role as the default role */
+  setDefaultMemberRole?: Maybe<MemberRole>;
   /** Designate the email as the current user's primary email address */
   setPrimaryUserEmail?: Maybe<Array<Maybe<UserEmail>>>;
   /** Set the user's ORCID */
@@ -2032,6 +2036,11 @@ export type MutationRequestFeedbackArgs = {
 
 export type MutationResendInviteToProjectCollaboratorArgs = {
   projectCollaboratorId: Scalars['Int']['input'];
+};
+
+
+export type MutationSetDefaultMemberRoleArgs = {
+  id: Scalars['Int']['input'];
 };
 
 
@@ -6739,6 +6748,7 @@ export type MemberRoleResolvers<ContextType = MyContext, ParentType extends Reso
   displayOrder?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   errors?: Resolver<Maybe<ResolversTypes['MemberRoleErrors']>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  isDefault?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -6873,6 +6883,7 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   requestFeedback?: Resolver<Maybe<ResolversTypes['PlanFeedback']>, ParentType, ContextType, RequireFields<MutationRequestFeedbackArgs, 'planId'>>;
   requirements?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   resendInviteToProjectCollaborator?: Resolver<Maybe<ResolversTypes['ProjectCollaborator']>, ParentType, ContextType, RequireFields<MutationResendInviteToProjectCollaboratorArgs, 'projectCollaboratorId'>>;
+  setDefaultMemberRole?: Resolver<Maybe<ResolversTypes['MemberRole']>, ParentType, ContextType, RequireFields<MutationSetDefaultMemberRoleArgs, 'id'>>;
   setPrimaryUserEmail?: Resolver<Maybe<Array<Maybe<ResolversTypes['UserEmail']>>>, ParentType, ContextType, RequireFields<MutationSetPrimaryUserEmailArgs, 'email'>>;
   setUserOrcid?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationSetUserOrcidArgs, 'orcid'>>;
   superSyncPlanMaDMP?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationSuperSyncPlanMaDmpArgs, 'planId'>>;


### PR DESCRIPTION
## Description

Part of work for [#213](https://github.com/CDLUC3/dmptool-doc/issues/213)

- Add `isDefault` flag to `MemberRole` schema
- Add `setDefaultMemberRole` mutation to `MemberRole` schema and resolver. We had the ability for super admins to add, update and create Member Roles but not a specific way to set the default.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

All tests pass. Verified I could change the default member role in apollo explorer. Verified that I could request the `isDefault` property in queries

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules