### PR TITLE
Added findByDMPId to plans resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.1.0
 
 ### Added
+- Added `findByDMPId` to plan resolver
 - Added `defaultTemplate` query to the `versionedTemplate` schema and a corresponding resolver
 - Added `markAsDefaultTemplate` mutation to the `template` resolver (superadmin only)
 - Added `setDefaultTemplate` function to the `TemplateService`

--- a/src/resolvers/plan.ts
+++ b/src/resolvers/plan.ts
@@ -73,6 +73,32 @@ export const resolvers: Resolvers = {
       }
     },
 
+    // Find a Plan by its DMP id
+    planByDMPId: async(_, { dmpId }, context: MyContext): Promise<Plan> => {
+      const reference = 'planByDMPId resolver';
+      try {
+        const plan = await Plan.findByDMPId(reference, context, dmpId);
+        if (isNullOrUndefined(plan)) {
+          throw NotFoundError(`Plan with DMP id, ${dmpId}, not found`);
+        }
+
+        const project = await Project.findById(reference, context, plan.projectId);
+        if (isNullOrUndefined(project)) {
+          throw NotFoundError(`Project with ID, ${plan.projectId}, not found`);
+        }
+
+        if (await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.COMMENT)) {
+          return plan;
+        }
+        throw context?.token ? ForbiddenError() : AuthenticationError();
+      } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+
+        context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
+        throw InternalServerError();
+      }
+    },
+
     // Lookup a Plan by its alternate identifier
     planByAlternateIdentifier: async(_, { alternateIdentifier }, context: MyContext): Promise<Plan> => {
       const reference = 'planByAlternateIdentifier resolver';

--- a/src/schemas/plan.ts
+++ b/src/schemas/plan.ts
@@ -8,6 +8,8 @@ export const typeDefs = gql`
     "Get a specific plan"
     plan(planId: Int!): Plan
 
+    "Lookup a plan by its DMP id"
+    planByDMPId(dmpId: String!): Plan
     "Lookup a plan by an alternate identifier"
     planByAlternateIdentifier(alternateIdentifier: String!): Plan
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3226,6 +3226,8 @@ export type Query = {
   plan?: Maybe<Plan>;
   /** Lookup a plan by an alternate identifier */
   planByAlternateIdentifier?: Maybe<Plan>;
+  /** Lookup a plan by its DMP id */
+  planByDMPId?: Maybe<Plan>;
   /** Get all rounds of admin feedback for the plan */
   planFeedback?: Maybe<Array<Maybe<PlanFeedback>>>;
   /** Get all of the comments associated with the round of admin feedback */
@@ -3516,6 +3518,11 @@ export type QueryPlanArgs = {
 
 export type QueryPlanByAlternateIdentifierArgs = {
   alternateIdentifier: Scalars['String']['input'];
+};
+
+
+export type QueryPlanByDmpIdArgs = {
+  dmpId: Scalars['String']['input'];
 };
 
 
@@ -7467,6 +7474,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   myVersionedTemplates?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedTemplateSearchResult']>>>, ParentType, ContextType>;
   plan?: Resolver<Maybe<ResolversTypes['Plan']>, ParentType, ContextType, RequireFields<QueryPlanArgs, 'planId'>>;
   planByAlternateIdentifier?: Resolver<Maybe<ResolversTypes['Plan']>, ParentType, ContextType, RequireFields<QueryPlanByAlternateIdentifierArgs, 'alternateIdentifier'>>;
+  planByDMPId?: Resolver<Maybe<ResolversTypes['Plan']>, ParentType, ContextType, RequireFields<QueryPlanByDmpIdArgs, 'dmpId'>>;
   planFeedback?: Resolver<Maybe<Array<Maybe<ResolversTypes['PlanFeedback']>>>, ParentType, ContextType, RequireFields<QueryPlanFeedbackArgs, 'planId'>>;
   planFeedbackComments?: Resolver<Maybe<Array<Maybe<ResolversTypes['PlanFeedbackComment']>>>, ParentType, ContextType, RequireFields<QueryPlanFeedbackCommentsArgs, 'planFeedbackId' | 'planId'>>;
   planFeedbackStatus?: Resolver<Maybe<ResolversTypes['PlanFeedbackStatus']>, ParentType, ContextType, RequireFields<QueryPlanFeedbackStatusArgs, 'planId'>>;


### PR DESCRIPTION
## Description

Part of work for [#213](https://github.com/CDLUC3/dmptool-doc/issues/213)

- Add a new `findByDMPId` query to the plans resolver

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested in Apollo explorer

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules