### PR TITLE
Updates related to "readOnly view of  plan, and feedback commenting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.1.0
 
 ### Added
+- Added `findPrimaryUserByProjectId` method to `Collaborator` model [#225]
 - Added override for protobufjs
 - Added `findByDMPId` to plan resolver
 - Added `defaultTemplate` query to the `versionedTemplate` schema and a corresponding resolver
@@ -80,6 +81,9 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated `plan` query resolver to return `readOnly` info based on different criteria, that include use of new `primary` collaborator access level [#225]
+- Updated `removeAnswerComment` answer mutation to use updated `canDeleteComment` helper function at `src/services/contentPermissions` [#225]
+- Updated `addFeedbackComment`, `updateFeedbackComment` and `removeFeedbackComment` in `feedback` resolver to use new logic to determine authorization [#225]
 - Updated `TemplateService` to ensure that the `isDefault` flag is propagated when creating a template version
 - Updated `Plan` schema to include `alternateIdentifiers` as a chained resolver.
 - Refactored the `saveMaDMPVersion` function in `planService` to use the shared functionality from `@dmptool/utils` package to write directly to Dynamo rather than sending SQS messages.

--- a/src/models/Collaborator.ts
+++ b/src/models/Collaborator.ts
@@ -234,10 +234,13 @@ export enum ProjectCollaboratorAccessLevel {
 }
 
 // An individual that has permission to work on a Project and it's plans
+export interface ProjectCollaboratorWithUser extends ProjectCollaborator {
+  affiliationId: string | null;
+}
+
 export class ProjectCollaborator extends Collaborator {
   public projectId: number;
   public accessLevel: ProjectCollaboratorAccessLevel;
-  public affiliationId: string;
 
   private tableName = 'projectCollaborators';
 
@@ -246,7 +249,6 @@ export class ProjectCollaborator extends Collaborator {
 
     this.projectId = options.projectId ?? null;
     this.accessLevel = options.accessLevel ?? ProjectCollaboratorAccessLevel.COMMENT;
-    this.affiliationId = options.affiliationId ?? null;
   }
 
   // Verify that the projectId is present
@@ -270,6 +272,7 @@ export class ProjectCollaborator extends Collaborator {
       this.email,
     );
 
+    console.log("***Current collaborator", currentCollaborator);
     if (currentCollaborator) {
       currentCollaborator.addError('general', 'Collaborator has already been added');
       return currentCollaborator
@@ -398,6 +401,7 @@ export class ProjectCollaborator extends Collaborator {
     userId: number,
     projectId: number
   ): Promise<ProjectCollaborator> {
+    console.log("***User ID and projectId***", userId, projectId);
     const sql = 'SELECT * FROM projectCollaborators WHERE userId = ? AND projectId = ?';
     const results = await ProjectCollaborator.query(context, sql, [userId?.toString(), projectId?.toString()], reference);
     return Array.isArray(results) && results.length > 0 ? new ProjectCollaborator(results[0]) : null;
@@ -585,7 +589,7 @@ export class ProjectCollaborator extends Collaborator {
     reference: string,
     context: MyContext,
     projectId: number,
-  ): Promise<ProjectCollaborator> {
+  ): Promise<ProjectCollaboratorWithUser | null> {
     const sql = `SELECT  pc.id AS collaboratorId, pc.projectId, pc.email, pc.accessLevel, pc.created AS collaboratorCreated,
     u.id AS userId, u.affiliationId, u.active
     FROM projectCollaborators pc
@@ -595,6 +599,7 @@ export class ProjectCollaborator extends Collaborator {
     `;
     const vals = [projectId?.toString()];
     const results = await ProjectCollaborator.query(context, sql, vals, reference);
-    return Array.isArray(results) && results.length > 0 ? new ProjectCollaborator(results[0]) : null;
+    if (!Array.isArray(results) || results.length === 0) return null;
+    return Object.assign(new ProjectCollaborator(results[0]), { affiliationId: results[0].affiliationId ?? null }) as ProjectCollaboratorWithUser;
   }
 }

--- a/src/models/Collaborator.ts
+++ b/src/models/Collaborator.ts
@@ -237,6 +237,7 @@ export enum ProjectCollaboratorAccessLevel {
 export class ProjectCollaborator extends Collaborator {
   public projectId: number;
   public accessLevel: ProjectCollaboratorAccessLevel;
+  public affiliationId: string;
 
   private tableName = 'projectCollaborators';
 
@@ -245,6 +246,7 @@ export class ProjectCollaborator extends Collaborator {
 
     this.projectId = options.projectId ?? null;
     this.accessLevel = options.accessLevel ?? ProjectCollaboratorAccessLevel.COMMENT;
+    this.affiliationId = options.affiliationId ?? null;
   }
 
   // Verify that the projectId is present
@@ -576,5 +578,23 @@ export class ProjectCollaborator extends Collaborator {
       hasNextPage,
       availableSortFields: ['u.surName', 'u.givenName', 'ue.email'],
     };
+  }
+
+  // Get primary user for project
+  static async findPrimaryUserByProjectId(
+    reference: string,
+    context: MyContext,
+    projectId: number,
+  ): Promise<ProjectCollaborator> {
+    const sql = `SELECT  pc.id AS collaboratorId, pc.projectId, pc.email, pc.accessLevel, pc.created AS collaboratorCreated,
+    u.id AS userId, u.affiliationId, u.active
+    FROM projectCollaborators pc
+    INNER JOIN users u ON pc.userId = u.id
+    WHERE pc.projectId = ? AND u.active = 1
+    AND pc.accessLevel = "PRIMARY"
+    `;
+    const vals = [projectId?.toString()];
+    const results = await ProjectCollaborator.query(context, sql, vals, reference);
+    return Array.isArray(results) && results.length > 0 ? new ProjectCollaborator(results[0]) : null;
   }
 }

--- a/src/models/Collaborator.ts
+++ b/src/models/Collaborator.ts
@@ -592,7 +592,7 @@ export class ProjectCollaborator extends Collaborator {
     u.id AS userId, u.affiliationId, u.active
     FROM projectCollaborators pc
     INNER JOIN users u ON pc.userId = u.id
-    WHERE pc.projectId = ? AND u.active = 1
+    WHERE pc.projectId = ?
     AND pc.accessLevel = "PRIMARY"
     `;
     const vals = [projectId?.toString()];

--- a/src/models/Collaborator.ts
+++ b/src/models/Collaborator.ts
@@ -272,7 +272,6 @@ export class ProjectCollaborator extends Collaborator {
       this.email,
     );
 
-    console.log("***Current collaborator", currentCollaborator);
     if (currentCollaborator) {
       currentCollaborator.addError('general', 'Collaborator has already been added');
       return currentCollaborator
@@ -401,7 +400,6 @@ export class ProjectCollaborator extends Collaborator {
     userId: number,
     projectId: number
   ): Promise<ProjectCollaborator> {
-    console.log("***User ID and projectId***", userId, projectId);
     const sql = 'SELECT * FROM projectCollaborators WHERE userId = ? AND projectId = ?';
     const results = await ProjectCollaborator.query(context, sql, [userId?.toString(), projectId?.toString()], reference);
     return Array.isArray(results) && results.length > 0 ? new ProjectCollaborator(results[0]) : null;

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -497,6 +497,9 @@ export class Plan extends MySqlModel {
   public registeredById: number;
   public registered: string;
 
+  // This is set when plan query is called to relay that plan is not editable by the user (i.e. readOnly = true means the user cannot edit the plan)
+  public readOnly: boolean;
+
   private static tableName = 'plans';
 
   constructor(options) {

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -770,6 +770,8 @@ export class Plan extends MySqlModel {
 
         // Update the plan
         const result = await Plan.update(context, Plan.tableName, this, reference, [], noTouch);
+        // The result of the update function is just a boolean indicating whether the update query succeeded or not, 
+        // so if it succeeded we need to re-query to get the updated plan with all the new values
         if (result) {
           return await Plan.findById(reference, context, this.id);
         }

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -88,29 +88,29 @@ export class PlanSearchResult {
    */
   static async findByProjectId(reference: string, context: MyContext, projectId: number): Promise<PlanSearchResult[]> {
     const sql = 'SELECT p.id, ' +
-                'CONCAT(cu.givenName, CONCAT(\' \', cu.surName)) createdBy, p.created, ' +
-                'CONCAT(cm.givenName, CONCAT(\' \', cm.surName)) modifiedBy, p.modified, ' +
-                'p.versionedTemplateId, p.title, p.status, p.visibility, p.dmpId, ' +
-                'CONCAT(cr.givenName, CONCAT(\' \', cr.surName)) registeredBy, p.registered, p.featured, ' +
-                'GROUP_CONCAT(DISTINCT CONCAT(prc.givenName, CONCAT(\' \', prc.surName, ' +
-                  'CONCAT(\' (\', CONCAT(r.label, \')\'))))) members, ' +
-                'GROUP_CONCAT(DISTINCT fundings.name) funding ' +
-              'FROM plans p ' +
-                'LEFT JOIN users cu ON cu.id = p.createdById ' +
-                'LEFT JOIN users cm ON cm.id = p.modifiedById ' +
-                'LEFT JOIN users cr ON cr.id = p.registeredById ' +
-                'LEFT JOIN planMembers plc ON plc.planId = p.id ' +
-                  'LEFT JOIN projectMembers prc ON prc.id = plc.projectMemberId ' +
-                  'LEFT JOIN planMemberRoles plcr ON plc.id = plcr.planMemberId ' +
-                    'LEFT JOIN memberRoles r ON plcr.memberRoleId = r.id ' +
-                'LEFT JOIN planFundings ON planFundings.planId = p.id ' +
-                  'LEFT JOIN projectFundings ON projectFundings.id = planFundings.projectFundingId ' +
-                    'LEFT JOIN affiliations fundings ON projectFundings.affiliationId = fundings.uri ' +
-              'WHERE p.projectId = ? ' +
-              'GROUP BY p.id, cu.givenName, cu.surName, cm.givenName, cm.surName, ' +
-                'p.title, p.status, p.visibility, ' +
-                'p.dmpId, cr.givenName, cr.surName, p.registered, p.featured ' +
-              'ORDER BY p.created DESC;';
+      'CONCAT(cu.givenName, CONCAT(\' \', cu.surName)) createdBy, p.created, ' +
+      'CONCAT(cm.givenName, CONCAT(\' \', cm.surName)) modifiedBy, p.modified, ' +
+      'p.versionedTemplateId, p.title, p.status, p.visibility, p.dmpId, ' +
+      'CONCAT(cr.givenName, CONCAT(\' \', cr.surName)) registeredBy, p.registered, p.featured, ' +
+      'GROUP_CONCAT(DISTINCT CONCAT(prc.givenName, CONCAT(\' \', prc.surName, ' +
+      'CONCAT(\' (\', CONCAT(r.label, \')\'))))) members, ' +
+      'GROUP_CONCAT(DISTINCT fundings.name) funding ' +
+      'FROM plans p ' +
+      'LEFT JOIN users cu ON cu.id = p.createdById ' +
+      'LEFT JOIN users cm ON cm.id = p.modifiedById ' +
+      'LEFT JOIN users cr ON cr.id = p.registeredById ' +
+      'LEFT JOIN planMembers plc ON plc.planId = p.id ' +
+      'LEFT JOIN projectMembers prc ON prc.id = plc.projectMemberId ' +
+      'LEFT JOIN planMemberRoles plcr ON plc.id = plcr.planMemberId ' +
+      'LEFT JOIN memberRoles r ON plcr.memberRoleId = r.id ' +
+      'LEFT JOIN planFundings ON planFundings.planId = p.id ' +
+      'LEFT JOIN projectFundings ON projectFundings.id = planFundings.projectFundingId ' +
+      'LEFT JOIN affiliations fundings ON projectFundings.affiliationId = fundings.uri ' +
+      'WHERE p.projectId = ? ' +
+      'GROUP BY p.id, cu.givenName, cu.surName, cm.givenName, cm.surName, ' +
+      'p.title, p.status, p.visibility, ' +
+      'p.dmpId, cr.givenName, cr.surName, p.registered, p.featured ' +
+      'ORDER BY p.created DESC;';
     const results = await Plan.query(context, sql, [projectId?.toString()], reference);
     return Array.isArray(results) ? results.map((entry) => new PlanSearchResult(entry)) : [];
   }
@@ -497,9 +497,6 @@ export class Plan extends MySqlModel {
   public registeredById: number;
   public registered: string;
 
-  // This is set when plan query is called to relay that plan is not editable by the user (i.e. readOnly = true means the user cannot edit the plan)
-  public readOnly?: boolean;
-
   private static tableName = 'plans';
 
   constructor(options) {
@@ -672,7 +669,7 @@ export class Plan extends MySqlModel {
         this.title = resolveNamingCollision(this.title, existingPlanTitles);
 
         // Create the new Plan
-        const newId = await Plan.insert(context, Plan.tableName, this, reference, ['readOnly']);
+        const newId = await Plan.insert(context, Plan.tableName, this, reference);
 
         // Create the original version snapshot of the DMP
         if (newId) {
@@ -772,7 +769,7 @@ export class Plan extends MySqlModel {
         this.prepForSave();
 
         // Update the plan
-        const result = await Plan.update(context, Plan.tableName, this, reference, ['readOnly'], noTouch);
+        const result = await Plan.update(context, Plan.tableName, this, reference, [], noTouch);
         if (result) {
           return await Plan.findById(reference, context, this.id);
         }

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -498,7 +498,7 @@ export class Plan extends MySqlModel {
   public registered: string;
 
   // This is set when plan query is called to relay that plan is not editable by the user (i.e. readOnly = true means the user cannot edit the plan)
-  public readOnly: boolean;
+  public readOnly?: boolean;
 
   private static tableName = 'plans';
 
@@ -672,7 +672,7 @@ export class Plan extends MySqlModel {
         this.title = resolveNamingCollision(this.title, existingPlanTitles);
 
         // Create the new Plan
-        const newId = await Plan.insert(context, Plan.tableName, this, reference);
+        const newId = await Plan.insert(context, Plan.tableName, this, reference, ['readOnly']);
 
         // Create the original version snapshot of the DMP
         if (newId) {
@@ -772,13 +772,11 @@ export class Plan extends MySqlModel {
         this.prepForSave();
 
         // Update the plan
-        let updated = await Plan.update(context, Plan.tableName, this, reference, [], noTouch) as Plan;
-        if (updated) {
-          updated = new Plan(updated);
-          if (updated && !updated.hasErrors()) {
-            return new Plan(updated);
-          }
+        const result = await Plan.update(context, Plan.tableName, this, reference, ['readOnly'], noTouch);
+        if (result) {
+          return await Plan.findById(reference, context, this.id);
         }
+        this.addError('general', 'Unable to update the plan');
       }
     } else {
       // This plan has never been saved before so we cannot update it!

--- a/src/models/__tests__/Collaborator.spec.ts
+++ b/src/models/__tests__/Collaborator.spec.ts
@@ -889,6 +889,93 @@ describe('ProjectCollaborator', () => {
     });
   });
 
+  describe('findPrimaryUserByProjectId', () => {
+    const originalQuery = ProjectCollaborator.query;
+
+    let localQuery;
+    let projectId;
+
+    beforeEach(async () => {
+      jest.resetAllMocks();
+      projectId = casual.integer(1, 999);
+
+      localQuery = jest.fn();
+      (ProjectCollaborator.query as jest.Mock) = localQuery;
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      ProjectCollaborator.query = originalQuery;
+    });
+
+    it('returns null when no results are found', async () => {
+      localQuery.mockResolvedValueOnce([]);
+
+      const result = await ProjectCollaborator.findPrimaryUserByProjectId(
+        'Test', context, projectId
+      );
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when query returns a non-array', async () => {
+      localQuery.mockResolvedValueOnce(null);
+
+      const result = await ProjectCollaborator.findPrimaryUserByProjectId(
+        'Test', context, projectId
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns a ProjectCollaboratorWithUser with affiliationId from the result row', async () => {
+      const affiliationId = casual.uuid;
+      const row = {
+        collaboratorId: casual.integer(1, 99),
+        projectId,
+        email: casual.email,
+        accessLevel: 'PRIMARY',
+        collaboratorCreated: new Date().toISOString(),
+        userId: casual.integer(1, 99),
+        affiliationId,
+        active: 1,
+      };
+      localQuery.mockResolvedValueOnce([row]);
+
+      const result = await ProjectCollaborator.findPrimaryUserByProjectId(
+        'Test', context, projectId
+      );
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(localQuery).toHaveBeenCalledWith(
+        context,
+        expect.stringContaining('pc.accessLevel = "PRIMARY"'),
+        [projectId.toString()],
+        'Test',
+      );
+      expect(result).toBeInstanceOf(ProjectCollaborator);
+      expect(result.affiliationId).toEqual(affiliationId);
+    });
+
+    it('sets affiliationId to null when the row has no affiliationId', async () => {
+      const row = {
+        collaboratorId: casual.integer(1, 99),
+        projectId,
+        email: casual.email,
+        accessLevel: 'PRIMARY',
+        collaboratorCreated: new Date().toISOString(),
+        userId: casual.integer(1, 99),
+        affiliationId: null,
+        active: 1,
+      };
+      localQuery.mockResolvedValueOnce([row]);
+
+      const result = await ProjectCollaborator.findPrimaryUserByProjectId(
+        'Test', context, projectId
+      );
+      expect(result).toBeInstanceOf(ProjectCollaborator);
+      expect(result.affiliationId).toBeNull();
+    });
+  });
+
   describe('findPotentialCollaboratorByORCID', () => {
     const originalFindByOrcid = User.findByOrcid;
     const originalProjectMemberFindByOrcid = ProjectCollaborator.findPotentialCollaboratorByORCID;

--- a/src/models/__tests__/Plan.spec.ts
+++ b/src/models/__tests__/Plan.spec.ts
@@ -441,7 +441,7 @@ describe('PlanSectionProgress.findByPlanId', () => {
     const customSection1 = { id: 10, name: 'Custom1', pinnedSectionType: 'BASE', pinnedSectionId: 1, totalQuestions: 3 };
     // Circular: customSection2 pinned to customSection1, customSection1 pinned to customSection2
     const customSection2 = { id: 11, name: 'Custom2', pinnedSectionType: 'CUSTOM', pinnedSectionId: 10, totalQuestions: 2 };
-        // Now, customSection1 is also pinned to customSection2 (circular)
+    // Now, customSection1 is also pinned to customSection2 (circular)
     customSection1.pinnedSectionId = 11;
     localQuery.mockResolvedValueOnce([baseSection]); // base sections
 
@@ -987,7 +987,8 @@ describe('create', () => {
       context,
       'plans',
       expect.objectContaining({ title: 'My Project 4' }),
-      'Plan.create'
+      'Plan.create',
+      ['readOnly']
     );
     expect(result.title).toBe('My Project 4');
 
@@ -1048,6 +1049,7 @@ describe('update', () => {
     localValidator.mockResolvedValue(true);
 
     updateQuery.mockResolvedValueOnce(plan);
+    const findById = jest.spyOn(Plan, 'findById').mockResolvedValueOnce(plan);
 
     const result = await plan.update(context);
 
@@ -1055,6 +1057,7 @@ describe('update', () => {
     expect(updateQuery).toHaveBeenCalledTimes(1);
     expect(Object.keys(result.errors).length).toBe(0);
     expect(result).toBeInstanceOf(Plan);
+    findById.mockRestore();
   });
 
   it('does not do any versioning if noTouch is true', async () => {
@@ -1063,12 +1066,14 @@ describe('update', () => {
     localValidator.mockResolvedValue(true);
 
     updateQuery.mockResolvedValueOnce(plan);
+    const findById = jest.spyOn(Plan, 'findById').mockResolvedValueOnce(plan);
 
     const result = await plan.update(context, true);
     expect(localValidator).toHaveBeenCalledTimes(1);
     expect(updateQuery).toHaveBeenCalledTimes(1);
     expect(Object.keys(result.errors).length).toBe(0);
     expect(result).toBeInstanceOf(Plan);
+    findById.mockRestore();
   });
 
   it('does not do any versioning if the Plan update failed', async () => {
@@ -1081,7 +1086,7 @@ describe('update', () => {
     const result = await plan.update(context);
     expect(localValidator).toHaveBeenCalledTimes(1);
     expect(updateQuery).toHaveBeenCalledTimes(1);
-    expect(Object.keys(result.errors).length).toBe(0);
+    expect(Object.keys(result.errors).length).toBe(1);
     expect(result).toBeInstanceOf(Plan);
   });
 });

--- a/src/models/__tests__/Plan.spec.ts
+++ b/src/models/__tests__/Plan.spec.ts
@@ -987,8 +987,7 @@ describe('create', () => {
       context,
       'plans',
       expect.objectContaining({ title: 'My Project 4' }),
-      'Plan.create',
-      ['readOnly']
+      'Plan.create'
     );
     expect(result.title).toBe('My Project 4');
 

--- a/src/resolvers/__tests__/feedback.spec.ts
+++ b/src/resolvers/__tests__/feedback.spec.ts
@@ -102,6 +102,7 @@ beforeEach(async () => {
   );
   jest.spyOn(User, 'findById').mockResolvedValue(new User({ id: casual.integer(1, 9999) }));
   jest.spyOn(ProjectCollaborator, 'findByProjectId').mockResolvedValue([]);
+  jest.spyOn(ProjectCollaborator, 'findPrimaryUserByProjectId').mockResolvedValue(null);
   jest.spyOn(Affiliation, 'findByURI').mockResolvedValue(
     new Affiliation({ uri: affiliationId, feedbackEmails: [casual.email] })
   );
@@ -547,7 +548,7 @@ describe('addFeedbackComment mutation', () => {
     expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
   });
 
-  it('returns a 403 when the user is not an admin', async () => {
+  it('returns a 403 when the user is neither a collaborator nor an admin', async () => {
     const resp = await executeQuery(
       query, { planId, planFeedbackId, answerId, commentText: casual.sentence }, researcherToken
     );
@@ -569,9 +570,16 @@ describe('addFeedbackComment mutation', () => {
   });
 
   it('returns a 404 when the feedback record is not found', async () => {
+    const primaryCollaborator = Object.assign(
+      new ProjectCollaborator({ projectId: project.id, email: casual.email }),
+      { affiliationId }
+    );
+    jest.spyOn(ProjectCollaborator, 'findPrimaryUserByProjectId').mockResolvedValue(
+      primaryCollaborator as import('../../models/Collaborator').ProjectCollaboratorWithUser
+    );
     jest.spyOn(PlanFeedback, 'findById').mockResolvedValue(null);
     const resp = await executeQuery(
-      query, { planId, planFeedbackId, answerId, commentText: casual.sentence }, superAdminToken
+      query, { planId, planFeedbackId, answerId, commentText: casual.sentence }, adminToken
     );
 
     assert(resp.body.kind === 'single');
@@ -580,6 +588,13 @@ describe('addFeedbackComment mutation', () => {
   });
 
   it('returns a 403 when the feedback round is already completed', async () => {
+    const primaryCollaborator = Object.assign(
+      new ProjectCollaborator({ projectId: project.id, email: casual.email }),
+      { affiliationId }
+    );
+    jest.spyOn(ProjectCollaborator, 'findPrimaryUserByProjectId').mockResolvedValue(
+      primaryCollaborator as import('../../models/Collaborator').ProjectCollaboratorWithUser
+    );
     const completedFeedback = new PlanFeedback({
       ...feedback,
       completed: getCurrentDate(),
@@ -587,7 +602,7 @@ describe('addFeedbackComment mutation', () => {
     jest.spyOn(PlanFeedback, 'findById').mockResolvedValue(completedFeedback);
 
     const resp = await executeQuery(
-      query, { planId, planFeedbackId, answerId, commentText: casual.sentence }, superAdminToken
+      query, { planId, planFeedbackId, answerId, commentText: casual.sentence }, adminToken
     );
 
     assert(resp.body.kind === 'single');
@@ -601,6 +616,24 @@ describe('addFeedbackComment mutation', () => {
       query,
       { planId, planFeedbackId, answerId, commentText: casual.sentence },
       superAdminToken,
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeUndefined();
+    expect(resp.body.singleResult.data.addFeedbackComment.id).toEqual(feedbackComment.id);
+    expect(PlanFeedbackComment.prototype.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds the comment when the user is a collaborator even if feedback is not open', async () => {
+    // Collaborators can always comment regardless of feedback state
+    project.createdById = researcherToken.id;
+    const closedFeedback = new PlanFeedback({ ...feedback, completed: getCurrentDate() });
+    jest.spyOn(PlanFeedback, 'findById').mockResolvedValue(closedFeedback);
+
+    const resp = await executeQuery(
+      query,
+      { planId, planFeedbackId, answerId, commentText: casual.sentence },
+      researcherToken,
     );
 
     assert(resp.body.kind === 'single');
@@ -654,7 +687,8 @@ describe('updateFeedbackComment mutation', () => {
     expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
   });
 
-  it('returns a 403 when the user is not an admin', async () => {
+  it('returns a 403 when the user is not the comment creator', async () => {
+    // feedbackComment.createdById does not match researcherToken.id
     const resp = await executeQuery(
       query,
       { planId, planFeedbackCommentId: feedbackComment.id, commentText: casual.sentence },
@@ -722,6 +756,24 @@ describe('updateFeedbackComment mutation', () => {
     expect(resp.body.singleResult.data.updateFeedbackComment.id).toEqual(updatedComment.id);
     expect(PlanFeedbackComment.prototype.update).toHaveBeenCalledTimes(1);
   });
+
+  it('allows a non-admin researcher to update their own comment', async () => {
+    feedbackComment.createdById = researcherToken.id;
+    const newText = casual.sentence;
+    const updatedComment = new PlanFeedbackComment({ ...feedbackComment, commentText: newText });
+    jest.spyOn(PlanFeedbackComment.prototype, 'update').mockResolvedValue(updatedComment);
+
+    const resp = await executeQuery(
+      query,
+      { planId, planFeedbackCommentId: feedbackComment.id, commentText: newText },
+      researcherToken,
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeUndefined();
+    expect(resp.body.singleResult.data.updateFeedbackComment.id).toEqual(updatedComment.id);
+    expect(PlanFeedbackComment.prototype.update).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -763,7 +815,8 @@ describe('removeFeedbackComment mutation', () => {
     expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
   });
 
-  it('returns a 403 when the user has no permission on the project', async () => {
+  it('returns a 403 when the user is not the comment creator or a PRIMARY collaborator', async () => {
+    // feedbackComment.createdById is random and primaryCollaborator is null (global mock)
     const resp = await executeQuery(
       query, { planId, planFeedbackCommentId: feedbackComment.id }, researcherToken
     );
@@ -785,10 +838,8 @@ describe('removeFeedbackComment mutation', () => {
     expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
   });
 
-  it('returns a 403 when the user has no permission to delete the comment', async () => {
-    project.createdById = researcherToken.id;
-    // feedbackComment.createdById and plan.createdById don't match researcherToken.id
-    // and no OWN-level collaborators
+  it('returns a 403 when the user is neither the comment creator nor the PRIMARY collaborator', async () => {
+    // feedbackComment.createdById is random and primaryCollaborator is null (global mock)
     const resp = await executeQuery(
       query, { planId, planFeedbackCommentId: feedbackComment.id }, researcherToken
     );
@@ -796,6 +847,28 @@ describe('removeFeedbackComment mutation', () => {
     assert(resp.body.kind === 'single');
     expect(resp.body.singleResult.errors).toBeDefined();
     expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('deletes the comment when the user is the PRIMARY collaborator', async () => {
+    // feedbackComment.createdById does NOT match researcherToken.id
+    // but researcherToken IS the primary collaborator
+    const primaryCollaborator = Object.assign(
+      new ProjectCollaborator({ projectId: project.id, email: researcherToken.email }),
+      { affiliationId: researcherToken.affiliationId }
+    );
+    primaryCollaborator.userId = researcherToken.id;
+    jest.spyOn(ProjectCollaborator, 'findPrimaryUserByProjectId').mockResolvedValue(
+      primaryCollaborator as import('../../models/Collaborator').ProjectCollaboratorWithUser
+    );
+
+    const resp = await executeQuery(
+      query, { planId, planFeedbackCommentId: feedbackComment.id }, researcherToken
+    );
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeUndefined();
+    expect(resp.body.singleResult.data.removeFeedbackComment.id).toEqual(feedbackComment.id);
+    expect(PlanFeedbackComment.prototype.delete).toHaveBeenCalledTimes(1);
   });
 
   it('deletes the comment and returns it when the user is the comment creator', async () => {

--- a/src/resolvers/answer.ts
+++ b/src/resolvers/answer.ts
@@ -275,17 +275,15 @@ export const resolvers: Resolvers = {
             if (!answerComment) {
               throw NotFoundError(`Answer comment ${answerCommentId} not found`);
             }
-            // Get project collaborators emails, minus the user's own email
-            const collaborators = await ProjectCollaborator.findByProjectId(reference, context, plan.projectId);
+            // Get primaryCollaborator for the project to check permissions against
+            const primaryCollaborator = await ProjectCollaborator.findPrimaryUserByProjectId(reference, context, project.id);
 
-            // Allow deletion by comment creator, plan creator, or OWN-level collaborator
+            // A comment can be deleted by the comment creator or a PRIMARY-level collaborator
             if (canDeleteComment({
               commentCreatedById: answerComment.createdById,
-              planCreatedById: plan.createdById,
               userId: context.token.id,
-              collaborators
+              primaryCollaborator
             })) {
-              // Delete the comment
               return await answerComment.delete(context);
             }
 

--- a/src/resolvers/feedback.ts
+++ b/src/resolvers/feedback.ts
@@ -130,7 +130,7 @@ export const resolvers: Resolvers = {
         if (!project) {
           throw NotFoundError(`Project with ID ${projectId} not found`);
         }
-        if (await hasPermissionOnProject(context, project)) {
+        if (await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.COMMENT)) {
           return await PlanFeedback.statusForPlan(reference, context, planId);
         }
 
@@ -280,40 +280,42 @@ export const resolvers: Resolvers = {
     addFeedbackComment: async (_, { planId, planFeedbackId, answerId, commentText }, context: MyContext): Promise<PlanFeedbackComment> => {
       const reference = 'addFeedbackComment resolver';
       try {
-        // All collaborators can always submit feedback comments, but org admins/superadmins can only submit feedback comments when feedback is open
-        const plan = await Plan.findById(reference, context, planId);
-        if (!plan) throw NotFoundError(`Plan with ID ${planId} not found`);
+        if (isAuthorized(context.token)) {
+          // All collaborators can always submit feedback comments, but org admins/superadmins can only submit feedback comments when feedback is open
+          const plan = await Plan.findById(reference, context, planId);
+          if (!plan) throw NotFoundError(`Plan with ID ${planId} not found`);
 
-        const project = await Project.findById(reference, context, plan.projectId);
-        if (!project?.id) throw NotFoundError(`Project with ID ${plan.projectId} not found`);
+          const project = await Project.findById(reference, context, plan.projectId);
+          if (!project?.id) throw NotFoundError(`Project with ID ${plan.projectId} not found`);
 
-        const primaryCollaborator = await ProjectCollaborator.findPrimaryUserByProjectId(reference, context, project.id);
+          const primaryCollaborator = await ProjectCollaborator.findPrimaryUserByProjectId(reference, context, project.id);
 
-        const isCollaborator = await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.COMMENT);
-        const isAdminOfSameOrg = isSuperAdmin(context.token) || (isAdmin(context.token) && context.token.affiliationId === primaryCollaborator.affiliationId);
+          const isCollaborator = await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.COMMENT);
+          const isAdminOfSameOrg = isSuperAdmin(context.token) || (isAdmin(context.token) && context.token.affiliationId === primaryCollaborator.affiliationId);
 
-        if (!isCollaborator && !isAdminOfSameOrg) {
-          throw context?.token ? ForbiddenError() : AuthenticationError();
-        }
-
-        // Admins/superadmins who are not collaborators can only comment when feedback is open
-        if (!isCollaborator && isAdminOfSameOrg) {
-          const feedback = await PlanFeedback.findById(reference, context, planFeedbackId);
-          if (!feedback) throw NotFoundError(`Feedback with ID ${planFeedbackId} not found`);
-
-          if (!feedback.requested || feedback.completed !== null) {
-            throw ForbiddenError(`Feedback with ID ${planFeedbackId} is not requested or is already completed`);
+          if (!isCollaborator && !isAdminOfSameOrg) {
+            throw context?.token ? ForbiddenError() : AuthenticationError();
           }
+
+          // Admins/superadmins who are not collaborators can only comment when feedback is open
+          if (!isCollaborator && isAdminOfSameOrg) {
+            const feedback = await PlanFeedback.findById(reference, context, planFeedbackId);
+            if (!feedback) throw NotFoundError(`Feedback with ID ${planFeedbackId} not found`);
+
+            if (!feedback.requested || feedback.completed !== null) {
+              throw ForbiddenError(`Feedback with ID ${planFeedbackId} is not requested or is already completed`);
+            }
+          }
+
+          // Notify collaborators (excluding the commenter) that a comment was added
+          const collaborators = await ProjectCollaborator.findByProjectId(reference, context, project.id);
+          const collaboratorEmails = collaborators.map(c => c.email).filter(email => email !== context.token.email);
+          await sendProjectCollaboratorsCommentsAddedEmail(context, collaboratorEmails);
+
+          const feedbackComment = new PlanFeedbackComment({ answerId, feedbackId: planFeedbackId, commentText });
+          return await feedbackComment.create(context);
         }
-
-        // Notify collaborators (excluding the commenter) that a comment was added
-        const collaborators = await ProjectCollaborator.findByProjectId(reference, context, project.id);
-        const collaboratorEmails = collaborators.map(c => c.email).filter(email => email !== context.token.email);
-        await sendProjectCollaboratorsCommentsAddedEmail(context, collaboratorEmails);
-
-        const feedbackComment = new PlanFeedbackComment({ answerId, feedbackId: planFeedbackId, commentText });
-        return await feedbackComment.create(context);
-
+        throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {
         if (err instanceof GraphQLError) throw err;
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
@@ -323,20 +325,25 @@ export const resolvers: Resolvers = {
     // Update feedback comment for an answer within a round of feedback
     updateFeedbackComment: async (_, { planId, planFeedbackCommentId, commentText }, context: MyContext): Promise<PlanFeedbackComment> => {
       const reference = 'updateFeedbackComment resolver';
-      console.log("***Updating feedback comment with ID", planFeedbackCommentId);
       try {
-        if (!context?.token) throw AuthenticationError();
+        if (isAuthorized(context.token)) {
+          const plan = await Plan.findById(reference, context, planId);
+          if (!plan) throw NotFoundError(`Plan with ID ${planId} not found`);
 
-        const feedbackComment = await PlanFeedbackComment.findById(reference, context, planFeedbackCommentId);
-        if (!feedbackComment) throw NotFoundError(`Feedback comment with ID ${planFeedbackCommentId} not found`);
+          const project = await Project.findById(reference, context, plan.projectId);
+          if (!project?.id) throw NotFoundError(`Project with ID ${plan.projectId} not found`);
 
-        if (feedbackComment.createdById !== context.token.id) {
-          throw ForbiddenError(`You can only update your own comments`);
+          const feedbackComment = await PlanFeedbackComment.findById(reference, context, planFeedbackCommentId);
+          if (!feedbackComment) throw NotFoundError(`Feedback comment with ID ${planFeedbackCommentId} not found`);
+
+          if (feedbackComment.createdById !== context.token.id) {
+            throw ForbiddenError(`You can only update your own comments`);
+          }
+
+          feedbackComment.commentText = commentText;
+          return await feedbackComment.update(context);
         }
-
-        feedbackComment.commentText = commentText;
-        return await feedbackComment.update(context);
-
+        throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {
         if (err instanceof GraphQLError) throw err;
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
@@ -347,29 +354,30 @@ export const resolvers: Resolvers = {
     removeFeedbackComment: async (_, { planId, planFeedbackCommentId }, context: MyContext): Promise<PlanFeedbackComment> => {
       const reference = 'removeFeedbackComment resolver';
       try {
-        if (!context?.token) throw AuthenticationError();
+        if (isAuthorized(context.token)) {
+          const plan = await Plan.findById(reference, context, planId);
+          if (!plan) throw NotFoundError(`Plan with ID ${planId} not found`);
 
-        const feedbackComment = await PlanFeedbackComment.findById(reference, context, planFeedbackCommentId);
-        if (!feedbackComment) throw NotFoundError(`Feedback comment with ID ${planFeedbackCommentId} not found`);
+          const project = await Project.findById(reference, context, plan.projectId);
+          if (!project?.id) throw NotFoundError(`Project with ID ${plan.projectId} not found`);
 
-        const plan = await Plan.findById(reference, context, planId);
-        if (!plan) throw NotFoundError(`Plan with ID ${planId} not found`);
+          const feedbackComment = await PlanFeedbackComment.findById(reference, context, planFeedbackCommentId);
+          if (!feedbackComment) throw NotFoundError(`Feedback comment with ID ${planFeedbackCommentId} not found`);
 
-        const project = await Project.findById(reference, context, plan.projectId);
-        if (!project?.id) throw NotFoundError(`Project with ID ${plan.projectId} not found`);
+          const primaryCollaborator = await ProjectCollaborator.findPrimaryUserByProjectId(reference, context, project.id);
 
-        const primaryCollaborator = await ProjectCollaborator.findPrimaryUserByProjectId(reference, context, project.id);
-        const isPrimaryCollaborator = primaryCollaborator?.userId === context.token.id;
-        const isOwnComment = feedbackComment.createdById === context.token.id;
+          // A comment can be deleted by the comment creator or a PRIMARY-level collaborator
+          if (canDeleteComment({
+            commentCreatedById: feedbackComment.createdById,
+            userId: context.token.id,
+            primaryCollaborator
+          })) {
+            return await feedbackComment.delete(context);
+          }
 
-
-        // Primary collaborator can delete anyone's comments; others can only delete their own
-        if (!isPrimaryCollaborator && !isOwnComment) {
-          throw ForbiddenError(`You can only remove your own comments`);
+          throw ForbiddenError(`Inadequate permission to delete feedback comment ${feedbackComment.id}`);
         }
-
-        return await feedbackComment.delete(context);
-
+        throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {
         if (err instanceof GraphQLError) throw err;
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);

--- a/src/resolvers/feedback.ts
+++ b/src/resolvers/feedback.ts
@@ -280,100 +280,65 @@ export const resolvers: Resolvers = {
     addFeedbackComment: async (_, { planId, planFeedbackId, answerId, commentText }, context: MyContext): Promise<PlanFeedbackComment> => {
       const reference = 'addFeedbackComment resolver';
       try {
-        // if the user is an admin
-        if (isAdmin(context.token)) {
-          const plan = await Plan.findById(reference, context, planId);
-          if (!plan) {
-            throw NotFoundError(`Plan with ID ${planId} not found`);
-          }
+        // All collaborators can always submit feedback comments, but org admins/superadmins can only submit feedback comments when feedback is open
+        const plan = await Plan.findById(reference, context, planId);
+        if (!plan) throw NotFoundError(`Plan with ID ${planId} not found`);
 
-          // Get versionedTemplate associated with the plan
-          const versionedTemplate = await VersionedTemplate.findById(reference, context, plan.versionedTemplateId);
+        const project = await Project.findById(reference, context, plan.projectId);
+        if (!project?.id) throw NotFoundError(`Project with ID ${plan.projectId} not found`);
 
-          // If the user is a superAdmin or an admin for the same affiliation
-          if (isSuperAdmin(context.token) || (isAdmin(context.token) && context.token.affiliationId === versionedTemplate.ownerId)) {
+        const primaryCollaborator = await ProjectCollaborator.findPrimaryUserByProjectId(reference, context, project.id);
 
-            const project = await Project.findById(reference, context, plan.projectId);
-            if (!project) {
-              throw NotFoundError(`Project with ID ${plan.projectId} not found`);
-            }
-            if (!project.id) {
-              throw NotFoundError(`Project with ID ${plan.projectId} has no ID`);
-            }
+        const isCollaborator = await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.COMMENT);
+        const isAdminOfSameOrg = isSuperAdmin(context.token) || (isAdmin(context.token) && context.token.affiliationId === primaryCollaborator.affiliationId);
 
+        if (!isCollaborator && !isAdminOfSameOrg) {
+          throw context?.token ? ForbiddenError() : AuthenticationError();
+        }
 
-            const feedback = await PlanFeedback.findById(reference, context, planFeedbackId);
-            if (!feedback) {
-              throw NotFoundError(`Feedback with ID ${planFeedbackId} not found`);
-            }
+        // Admins/superadmins who are not collaborators can only comment when feedback is open
+        if (!isCollaborator && isAdminOfSameOrg) {
+          const feedback = await PlanFeedback.findById(reference, context, planFeedbackId);
+          if (!feedback) throw NotFoundError(`Feedback with ID ${planFeedbackId} not found`);
 
-            // ADMINs and SUPERADMINS can only add comments if feedback is requested and has not yet been completed
-            if (!feedback.requested || (feedback.requested && feedback.completed !== null)) {
-              throw ForbiddenError(`Feedback with ID ${planFeedbackId} is not requested`);
-            }
-
-            // Send out email to project collaborators to let them know that comments were added
-            // Get project collaborators emails, minus the user's own email
-            const collaborators = await ProjectCollaborator.findByProjectId(reference, context, project.id);
-            // Filter out the user's own email if it exists in the collaborators list
-            const collaboratorEmails = collaborators.map(c => c.email).filter(email => email !== context.token.email);
-
-            await sendProjectCollaboratorsCommentsAddedEmail(context, collaboratorEmails)
-
-            const feedbackComment = new PlanFeedbackComment({ answerId, feedbackId: planFeedbackId, commentText });
-            return await feedbackComment.create(context);
-
+          if (!feedback.requested || feedback.completed !== null) {
+            throw ForbiddenError(`Feedback with ID ${planFeedbackId} is not requested or is already completed`);
           }
         }
-        throw context?.token ? ForbiddenError() : AuthenticationError();
+
+        // Notify collaborators (excluding the commenter) that a comment was added
+        const collaborators = await ProjectCollaborator.findByProjectId(reference, context, project.id);
+        const collaboratorEmails = collaborators.map(c => c.email).filter(email => email !== context.token.email);
+        await sendProjectCollaboratorsCommentsAddedEmail(context, collaboratorEmails);
+
+        const feedbackComment = new PlanFeedbackComment({ answerId, feedbackId: planFeedbackId, commentText });
+        return await feedbackComment.create(context);
+
       } catch (err) {
         if (err instanceof GraphQLError) throw err;
-
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
         throw InternalServerError();
       }
     },
-    //Update feedback comment for an answer within a round of feedback
+    // Update feedback comment for an answer within a round of feedback
     updateFeedbackComment: async (_, { planId, planFeedbackCommentId, commentText }, context: MyContext): Promise<PlanFeedbackComment> => {
       const reference = 'updateFeedbackComment resolver';
+      console.log("***Updating feedback comment with ID", planFeedbackCommentId);
       try {
-        // if the user is an admin
-        if (isAdmin(context.token)) {
-          const plan = await Plan.findById(reference, context, planId);
-          if (!plan) {
-            throw NotFoundError(`Plan with ID ${planId} not found`);
-          }
+        if (!context?.token) throw AuthenticationError();
 
-          // Get versionedTemplate associated with the plan
-          const versionedTemplate = await VersionedTemplate.findById(reference, context, plan.versionedTemplateId);
+        const feedbackComment = await PlanFeedbackComment.findById(reference, context, planFeedbackCommentId);
+        if (!feedbackComment) throw NotFoundError(`Feedback comment with ID ${planFeedbackCommentId} not found`);
 
-          // If the user is a superAdmin or an admin for the same affiliation
-          if (isSuperAdmin(context.token) || (isAdmin(context.token) && context.token.affiliationId === versionedTemplate.ownerId)) {
-
-            const project = await Project.findById(reference, context, plan.projectId);
-            if (!project) {
-              throw NotFoundError(`Project with ID ${plan.projectId} not found`);
-            }
-
-            // Get referenced feedbackComment
-            const feedbackComment = await PlanFeedbackComment.findById(reference, context, planFeedbackCommentId);
-
-            if (!feedbackComment) {
-              throw NotFoundError(`Feedback comment with id ${planFeedbackCommentId} not found`);
-            }
-
-            // Only user who added the comment can update it
-            if (feedbackComment.createdById === context.token.id) {
-              // Update the comment
-              feedbackComment.commentText = commentText;
-              return await feedbackComment.update(context);
-            }
-          }
+        if (feedbackComment.createdById !== context.token.id) {
+          throw ForbiddenError(`You can only update your own comments`);
         }
-        throw context?.token ? ForbiddenError() : AuthenticationError();
+
+        feedbackComment.commentText = commentText;
+        return await feedbackComment.update(context);
+
       } catch (err) {
         if (err instanceof GraphQLError) throw err;
-
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
         throw InternalServerError();
       }
@@ -382,50 +347,35 @@ export const resolvers: Resolvers = {
     removeFeedbackComment: async (_, { planId, planFeedbackCommentId }, context: MyContext): Promise<PlanFeedbackComment> => {
       const reference = 'removeFeedbackComment resolver';
       try {
-        if (isAuthorized(context.token)) {
-          const plan = await Plan.findById(reference, context, planId);
-          if (!plan) {
-            throw NotFoundError(`Plan with ID ${planId} not found`);
-          }
-          const project = await Project.findById(reference, context, plan.projectId);
-          if (!project) {
-            throw NotFoundError(`Project with ID ${plan.projectId} not found`);
-          }
+        if (!context?.token) throw AuthenticationError();
 
-          if (await hasPermissionOnProject(context, project)) {
-            // Get referenced feedbackComment
-            const feedbackComment = await PlanFeedbackComment.findById(reference, context, planFeedbackCommentId);
+        const feedbackComment = await PlanFeedbackComment.findById(reference, context, planFeedbackCommentId);
+        if (!feedbackComment) throw NotFoundError(`Feedback comment with ID ${planFeedbackCommentId} not found`);
 
-            if (!feedbackComment) {
-              throw NotFoundError(`Feedback comment with id ${planFeedbackCommentId} not found`);
-            }
+        const plan = await Plan.findById(reference, context, planId);
+        if (!plan) throw NotFoundError(`Plan with ID ${planId} not found`);
 
-            // Get project collaborators emails
-            const collaborators = await ProjectCollaborator.findByProjectId(reference, context, plan.projectId);
+        const project = await Project.findById(reference, context, plan.projectId);
+        if (!project?.id) throw NotFoundError(`Project with ID ${plan.projectId} not found`);
 
-            // Allow deletion by comment creator, plan creator, or OWN-level collaborator
-            if (canDeleteComment({
-              commentCreatedById: feedbackComment.createdById,
-              planCreatedById: plan.createdById,
-              userId: context.token.id,
-              collaborators
-            })) {
-              // Delete the comment
-              return await feedbackComment.delete(context);
-            }
+        const primaryCollaborator = await ProjectCollaborator.findPrimaryUserByProjectId(reference, context, project.id);
+        const isPrimaryCollaborator = primaryCollaborator?.userId === context.token.id;
+        const isOwnComment = feedbackComment.createdById === context.token.id;
 
-            throw ForbiddenError(`Inadequate permission to delete feedback comment ${feedbackComment.id}`)
 
-          }
+        // Primary collaborator can delete anyone's comments; others can only delete their own
+        if (!isPrimaryCollaborator && !isOwnComment) {
+          throw ForbiddenError(`You can only remove your own comments`);
         }
-        throw context?.token ? ForbiddenError() : AuthenticationError();
+
+        return await feedbackComment.delete(context);
+
       } catch (err) {
         if (err instanceof GraphQLError) throw err;
-
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
         throw InternalServerError();
       }
-    }
+    },
   },
 
   PlanFeedback: {

--- a/src/resolvers/guidance.ts
+++ b/src/resolvers/guidance.ts
@@ -21,6 +21,7 @@ import { GraphQLError } from "graphql";
 import { isNullOrUndefined, normaliseDateTime } from "../utils/helpers";
 import { hasPublishedFlag } from "./guidanceGroup";
 import { Plan } from "../models/Plan";
+import { ProjectCollaboratorAccessLevel } from "../models/Collaborator";
 
 export const resolvers: Resolvers = {
   Query: {
@@ -108,7 +109,7 @@ export const resolvers: Resolvers = {
           }
 
           const project = await Project.findById(reference, context, plan.projectId);
-          if (await hasPermissionOnProject(context, project)) {
+          if (await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.COMMENT)) {
             const sources = await getGuidanceSourcesForPlan(
               context,
               planId,

--- a/src/resolvers/plan.ts
+++ b/src/resolvers/plan.ts
@@ -25,7 +25,6 @@ import { AlternateIdentifier } from "../models/AlternateIdentifier";
 const WRITE_ACCESS_LEVELS = new Set([
   ProjectCollaboratorAccessLevel.OWN,
   ProjectCollaboratorAccessLevel.PRIMARY,
-  ProjectCollaboratorAccessLevel.EDIT,
 ]);
 
 
@@ -57,8 +56,6 @@ export const resolvers: Resolvers = {
     // Find the plan by its id
     plan: async (_, { planId }, context: MyContext): Promise<Plan> => {
       const reference = 'plan resolver';
-      console.log("***Context token", context.token);
-
       try {
         const plan = await Plan.findById(reference, context, planId);
 
@@ -72,13 +69,10 @@ export const resolvers: Resolvers = {
         }
 
         if (await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.COMMENT)) {
-          const userId = context.token?.id;
-          const projectId = project.id;
           // If user is a collaborator on the project, then readOnly = false
           const callerCollaborator = await ProjectCollaborator.findByUserIdAndProjectId(
             reference, context, context.token?.id, project.id
           );
-          console.log("***Caller collaborator", callerCollaborator);
           if (WRITE_ACCESS_LEVELS.has(callerCollaborator?.accessLevel)) {
             return Object.assign(plan, { readOnly: false }) as Plan & { readOnly: boolean };
           }
@@ -94,7 +88,7 @@ export const resolvers: Resolvers = {
             return Object.assign(plan, { readOnly: true }) as Plan & { readOnly: boolean };
           }
 
-          return plan;
+          return Object.assign(plan, { readOnly: true }) as Plan & { readOnly: boolean };
         }
         throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {
@@ -334,6 +328,7 @@ export const resolvers: Resolvers = {
             throw NotFoundError(`Plan with id ${planId} not found`);
           }
           const project = await Project.findById(reference, context, plan.projectId);
+
           if (await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.OWN)) {
             plan.status = status as PlanStatus;
             const updated = await plan.update(context);
@@ -342,6 +337,7 @@ export const resolvers: Resolvers = {
               // Update the maDMP version of the record
               await saveMaDMPVersion(reference, context, updated.id);
             }
+            return updated;
           }
         }
         throw context?.token ? ForbiddenError() : AuthenticationError();
@@ -370,6 +366,7 @@ export const resolvers: Resolvers = {
               // Update the maDMP version of the record
               await saveMaDMPVersion(reference, context, updated.id);
             }
+            return updated;
           }
         }
         throw context?.token ? ForbiddenError() : AuthenticationError();

--- a/src/resolvers/plan.ts
+++ b/src/resolvers/plan.ts
@@ -4,7 +4,8 @@ import { Plan, PlanSearchResult, PlanSectionProgress, PlanProgress, PlanStatus, 
 import { prepareObjectForLogs } from "../logger";
 import { AuthenticationError, ForbiddenError, InternalServerError, NotFoundError } from "../utils/graphQLErrors";
 import { Project } from "../models/Project";
-import { User } from "../models/User";
+import { User, UserRole } from "../models/User";
+import { ProjectCollaborator } from "../models/Collaborator";
 import { isAuthorized } from "../services/authService";
 import { hasPermissionOnProject } from "../services/projectService";
 import { PlanMember } from "../models/Member";
@@ -19,7 +20,14 @@ import {
   ensureDefaultPlanContact,
   saveMaDMPVersion
 } from "../services/planService";
-import {AlternateIdentifier} from "../models/AlternateIdentifier";
+import { AlternateIdentifier } from "../models/AlternateIdentifier";
+
+const WRITE_ACCESS_LEVELS = new Set([
+  ProjectCollaboratorAccessLevel.OWN,
+  ProjectCollaboratorAccessLevel.PRIMARY,
+  ProjectCollaboratorAccessLevel.EDIT,
+]);
+
 
 export const resolvers: Resolvers = {
   Query: {
@@ -49,6 +57,8 @@ export const resolvers: Resolvers = {
     // Find the plan by its id
     plan: async (_, { planId }, context: MyContext): Promise<Plan> => {
       const reference = 'plan resolver';
+      console.log("***Context token", context.token);
+
       try {
         const plan = await Plan.findById(reference, context, planId);
 
@@ -62,6 +72,28 @@ export const resolvers: Resolvers = {
         }
 
         if (await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.COMMENT)) {
+          const userId = context.token?.id;
+          const projectId = project.id;
+          // If user is a collaborator on the project, then readOnly = false
+          const callerCollaborator = await ProjectCollaborator.findByUserIdAndProjectId(
+            reference, context, context.token?.id, project.id
+          );
+          console.log("***Caller collaborator", callerCollaborator);
+          if (WRITE_ACCESS_LEVELS.has(callerCollaborator?.accessLevel)) {
+            return Object.assign(plan, { readOnly: false }) as Plan & { readOnly: boolean };
+          }
+
+          // Super Admins always have readOnly access to all plans
+          if (context.token?.role === UserRole.SUPERADMIN) {
+            return Object.assign(plan, { readOnly: true }) as Plan & { readOnly: boolean };
+          }
+
+          // If the user is an ADMIN under the same org as the primary, they have readOnly access
+          const primaryCollaborator = await ProjectCollaborator.findPrimaryUserByProjectId(reference, context, project.id);
+          if ((primaryCollaborator.affiliationId === context.token?.affiliationId) && context.token?.role === UserRole.ADMIN) {
+            return Object.assign(plan, { readOnly: true }) as Plan & { readOnly: boolean };
+          }
+
           return plan;
         }
         throw context?.token ? ForbiddenError() : AuthenticationError();
@@ -74,7 +106,7 @@ export const resolvers: Resolvers = {
     },
 
     // Find a Plan by its DMP id
-    planByDMPId: async(_, { dmpId }, context: MyContext): Promise<Plan> => {
+    planByDMPId: async (_, { dmpId }, context: MyContext): Promise<Plan> => {
       const reference = 'planByDMPId resolver';
       try {
         const plan = await Plan.findByDMPId(reference, context, dmpId);
@@ -100,7 +132,7 @@ export const resolvers: Resolvers = {
     },
 
     // Lookup a Plan by its alternate identifier
-    planByAlternateIdentifier: async(_, { alternateIdentifier }, context: MyContext): Promise<Plan> => {
+    planByAlternateIdentifier: async (_, { alternateIdentifier }, context: MyContext): Promise<Plan> => {
       const reference = 'planByAlternateIdentifier resolver';
       try {
         const identifier: AlternateIdentifier = await AlternateIdentifier.findByAlternateIdentifier(

--- a/src/schemas/plan.ts
+++ b/src/schemas/plan.ts
@@ -189,6 +189,9 @@ export const typeDefs = gql`
 
     "Alternate identifiers for the plan"
     alternateIdentifiers: [AlternateIdentifier!]
+
+    "Indicates that the plan is not editable by the user (i.e. readOnly = true means the user cannot edit the plan)"
+    readOnly: Boolean!
   }
 
   type AlternateIdentifier {

--- a/src/schemas/plan.ts
+++ b/src/schemas/plan.ts
@@ -191,7 +191,7 @@ export const typeDefs = gql`
     alternateIdentifiers: [AlternateIdentifier!]
 
     "Indicates that the plan is not editable by the user (i.e. readOnly = true means the user cannot edit the plan)"
-    readOnly: Boolean!
+    readOnly: Boolean
   }
 
   type AlternateIdentifier {

--- a/src/services/__tests__/commentPermissions.spec.ts
+++ b/src/services/__tests__/commentPermissions.spec.ts
@@ -1,0 +1,61 @@
+import { canDeleteComment } from '../commentPermissions';
+import {
+  ProjectCollaborator,
+  ProjectCollaboratorAccessLevel,
+} from '../../models/Collaborator';
+
+describe('canDeleteComment', () => {
+  it('returns true when the user is the comment creator', () => {
+    const result = canDeleteComment({
+      commentCreatedById: 10,
+      userId: 10,
+      primaryCollaborator: null,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('returns true when the user is the PRIMARY collaborator', () => {
+    const primaryCollaborator = new ProjectCollaborator({
+      projectId: 1,
+      email: 'primary@example.com',
+      userId: 20,
+      accessLevel: ProjectCollaboratorAccessLevel.PRIMARY,
+    });
+
+    const result = canDeleteComment({
+      commentCreatedById: 10,
+      userId: 20,
+      primaryCollaborator,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when the user is neither creator nor PRIMARY collaborator', () => {
+    const primaryCollaborator = new ProjectCollaborator({
+      projectId: 1,
+      email: 'primary@example.com',
+      userId: 30,
+      accessLevel: ProjectCollaboratorAccessLevel.PRIMARY,
+    });
+
+    const result = canDeleteComment({
+      commentCreatedById: 10,
+      userId: 20,
+      primaryCollaborator,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when there is no primary collaborator and user is not creator', () => {
+    const result = canDeleteComment({
+      commentCreatedById: 10,
+      userId: 20,
+      primaryCollaborator: null,
+    });
+
+    expect(result).toBe(false);
+  });
+});

--- a/src/services/__tests__/guidanceService.spec.ts
+++ b/src/services/__tests__/guidanceService.spec.ts
@@ -678,7 +678,7 @@ describe("getGuidanceSourcesForPlan", () => {
     );
 
     expect(VersionedQuestion.findById).toHaveBeenCalled();
-    expect(result).toHaveLength(1);
+    expect(result).toHaveLength(2);
     expect(result[0]).toMatchObject({ id: "bestPractice", type: "BEST_PRACTICE" });
   });
 
@@ -819,7 +819,7 @@ describe("getGuidanceSourcesForPlan", () => {
     expect(VersionedCustomQuestion.findById).toHaveBeenCalled();
     // getSectionTags uses the versionedSectionId (7), not the versionedTemplateId (973)
     expect((PlanGuidance.query as jest.Mock).mock.calls[0][2]).toEqual(["7"]);
-    expect(result).toHaveLength(1);
+    expect(result).toHaveLength(2);
     expect(result[0]).toMatchObject({ id: "bestPractice", type: "BEST_PRACTICE" });
   });
 
@@ -847,7 +847,7 @@ describe("getGuidanceSourcesForPlan", () => {
     expect(VersionedCustomQuestion.findById).toHaveBeenCalled();
     // getSectionTagsMap uses the versionedTemplateId (973), not the versionedSectionId
     expect((PlanGuidance.query as jest.Mock).mock.calls[0][2]).toEqual(["973"]);
-    expect(result).toHaveLength(1);
+    expect(result).toHaveLength(2);
     expect(result[0]).toMatchObject({ id: "bestPractice", type: "BEST_PRACTICE" });
   });
 

--- a/src/services/commentPermissions.ts
+++ b/src/services/commentPermissions.ts
@@ -1,21 +1,16 @@
 import { ProjectCollaborator } from "../models/Collaborator";
 
-// Can delete a comment if comment creator, plan creator, or OWN-level collaborator
+// Can delete a comment if comment creator or Primary-level collaborator
 export function canDeleteComment({
   commentCreatedById,
-  planCreatedById,
   userId,
-  collaborators
+  primaryCollaborator
 }: {
   commentCreatedById?: number,
-  planCreatedById?: number,
   userId: number,
-  collaborators: ProjectCollaborator[]
+  primaryCollaborator?: ProjectCollaborator | null
 }): boolean {
-  const isCommentCreator = commentCreatedById === userId;
-  const isPlanCreator = planCreatedById === userId;
-  const isOwnCollaborator = collaborators.some(
-    c => c.userId === userId && c.accessLevel === "OWN"
-  );
-  return isCommentCreator || isPlanCreator || isOwnCollaborator;
+  const isOwnComment = commentCreatedById === userId;
+  const isPrimaryCollaborator = primaryCollaborator?.userId === userId;
+  return isOwnComment || isPrimaryCollaborator;
 }

--- a/src/services/guidanceService.ts
+++ b/src/services/guidanceService.ts
@@ -564,52 +564,47 @@ export async function getGuidanceSourcesForPlan(
     // 3. Template Owner's Guidance
     // ============================================================
     if (templateOwnerUri && !processedOrgURIs.has(templateOwnerUri)) {
-      const templateOwnerSelection = userSelections.find(
-        selection => selection.affiliationId === templateOwnerUri
-      );
+      const affiliation = await Affiliation.findByURI(reference, context, templateOwnerUri);
 
-      if (templateOwnerSelection) {
-        const affiliation = await Affiliation.findByURI(reference, context, templateOwnerUri);
+      if (affiliation) {
+        // Fetch TAG-BASED guidance
+        const tagBasedGuidance = await VersionedGuidance.findByAffiliationAndTagIds(
+          reference,
+          context,
+          templateOwnerUri,
+          sectionTagIds
+        );
 
-        if (affiliation) {
-          // Fetch TAG-BASED guidance
-          const tagBasedGuidance = await VersionedGuidance.findByAffiliationAndTagIds(
-            reference,
-            context,
-            templateOwnerUri,
-            sectionTagIds
-          );
+        const items = groupGuidanceByTag(tagBasedGuidance, sectionTagIds, tagsMap);
 
-          const items = groupGuidanceByTag(tagBasedGuidance, sectionTagIds, tagsMap);
-
-          // Only prepend section-level guidanceText for versioned sections/questions.
-          // For custom sections/questions, the content was created by the user's institution —
-          // the template owner has no guidance to contribute here.
-          if (guidanceText && !customSectionId && !customQuestionId) {
-            items.unshift({
-              title: affiliation.displayName || affiliation.name,
-              guidanceText
-            });
-          }
-
-          // Always include template owner as a source, even with no guidance for a custom section
-          // so that the Guidance Panel can show "no guidance available"
-          guidanceSources.push({
-            id: `affiliation-${templateOwnerUri}`,
-            type: GuidanceSourceType.TEMPLATE_OWNER,
-            label: affiliation.displayName || affiliation.name,
-            shortName: (affiliation.acronyms && affiliation.acronyms[0]) ||
-              affiliation.displayName ||
-              affiliation.name,
-            orgURI: templateOwnerUri,
-            items,
-            hasGuidance: true
+        // Only prepend section-level guidanceText for versioned sections/questions.
+        // For custom sections/questions, the content was created by the user's institution —
+        // the template owner has no guidance to contribute here.
+        if (guidanceText && !customSectionId && !customQuestionId) {
+          items.unshift({
+            title: affiliation.displayName || affiliation.name,
+            guidanceText
           });
-
-          processedOrgURIs.add(templateOwnerUri);
-
         }
+
+        // Always include template owner as a source, even with no guidance for a custom section
+        // so that the Guidance Panel can show "no guidance available"
+        guidanceSources.push({
+          id: `affiliation-${templateOwnerUri}`,
+          type: GuidanceSourceType.TEMPLATE_OWNER,
+          label: affiliation.displayName || affiliation.name,
+          shortName: (affiliation.acronyms && affiliation.acronyms[0]) ||
+            affiliation.displayName ||
+            affiliation.name,
+          orgURI: templateOwnerUri,
+          items,
+          hasGuidance: true
+        });
+
+        processedOrgURIs.add(templateOwnerUri);
+
       }
+
     }
 
     // ============================================================

--- a/src/types.ts
+++ b/src/types.ts
@@ -2449,6 +2449,8 @@ export type Plan = {
   progress?: Maybe<PlanProgress>;
   /** The project the plan is associated with */
   project?: Maybe<Project>;
+  /** Indicates that the plan is not editable by the user (i.e. readOnly = true means the user cannot edit the plan) */
+  readOnly: Scalars['Boolean']['output'];
   /** The timestamp for when the Plan was registered */
   registered?: Maybe<Scalars['String']['output']>;
   /** The individual who registered the plan */
@@ -7069,6 +7071,7 @@ export type PlanResolvers<ContextType = MyContext, ParentType extends ResolversP
   planCreator?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
   progress?: Resolver<Maybe<ResolversTypes['PlanProgress']>, ParentType, ContextType>;
   project?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType>;
+  readOnly?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   registered?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   registeredById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   status?: Resolver<Maybe<ResolversTypes['PlanStatus']>, ParentType, ContextType>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2450,7 +2450,7 @@ export type Plan = {
   /** The project the plan is associated with */
   project?: Maybe<Project>;
   /** Indicates that the plan is not editable by the user (i.e. readOnly = true means the user cannot edit the plan) */
-  readOnly: Scalars['Boolean']['output'];
+  readOnly?: Maybe<Scalars['Boolean']['output']>;
   /** The timestamp for when the Plan was registered */
   registered?: Maybe<Scalars['String']['output']>;
   /** The individual who registered the plan */
@@ -7071,7 +7071,7 @@ export type PlanResolvers<ContextType = MyContext, ParentType extends ResolversP
   planCreator?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
   progress?: Resolver<Maybe<ResolversTypes['PlanProgress']>, ParentType, ContextType>;
   project?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType>;
-  readOnly?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  readOnly?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   registered?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   registeredById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   status?: Resolver<Maybe<ResolversTypes['PlanStatus']>, ParentType, ContextType>;


### PR DESCRIPTION
## Description

- Added `findPrimaryUserByProjectId` method to `Collaborator` model
- Updated `plan` query resolver to return `readOnly` info based on different criteria, that include use of new `primary` collaborator access level
- Updated `removeAnswerComment` answer mutation to use updated `canDeleteComment` helper function at `src/services/contentPermissions`
- Updated `addFeedbackComment`, `updateFeedbackComment` and `removeFeedbackComment` in `feedback` resolver to use new logic to determine authorization

Fixes # ([225](https://github.com/CDLUC3/dmptool-doc/issues/225))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested and tested with updated and new unit tests


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [*] Any dependent changes have been merged and published in downstream modules
* - frontend changes related to this are in this PR: https://github.com/CDLUC3/dmptool-ui/pull/1277