### PR TITLE
Updates for readOnly on ProjectOverview page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.1.0
 
 ### Added
+- Added `isProjectReadOnlyForCurrentUser` in `projectService.ts` that is shared between the `plan` and `project` query resolvers,and added `readOnly` field to the `Project` schema [#244]
 - Added `findPrimaryUserByProjectId` method to `Collaborator` model [#225]
 - Added a new `researchDomainByURI` resolver
 - Added override for protobufjs

--- a/src/resolvers/plan.ts
+++ b/src/resolvers/plan.ts
@@ -4,10 +4,12 @@ import { Plan, PlanSearchResult, PlanSectionProgress, PlanProgress, PlanStatus, 
 import { prepareObjectForLogs } from "../logger";
 import { AuthenticationError, ForbiddenError, InternalServerError, NotFoundError } from "../utils/graphQLErrors";
 import { Project } from "../models/Project";
-import { User, UserRole } from "../models/User";
-import { ProjectCollaborator } from "../models/Collaborator";
+import { User } from "../models/User";
 import { isAuthorized } from "../services/authService";
-import { hasPermissionOnProject } from "../services/projectService";
+import {
+  hasPermissionOnProject,
+  isProjectReadOnlyForCurrentUser
+} from "../services/projectService";
 import { PlanMember } from "../models/Member";
 import { PlanFunding } from "../models/Funding";
 import { PlanFeedback } from "../models/PlanFeedback";
@@ -21,11 +23,6 @@ import {
   saveMaDMPVersion
 } from "../services/planService";
 import { AlternateIdentifier } from "../models/AlternateIdentifier";
-
-const WRITE_ACCESS_LEVELS = new Set([
-  ProjectCollaboratorAccessLevel.OWN,
-  ProjectCollaboratorAccessLevel.PRIMARY,
-]);
 
 
 export const resolvers: Resolvers = {
@@ -69,26 +66,8 @@ export const resolvers: Resolvers = {
         }
 
         if (await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.COMMENT)) {
-          // If user is a collaborator on the project, then readOnly = false
-          const callerCollaborator = await ProjectCollaborator.findByUserIdAndProjectId(
-            reference, context, context.token?.id, project.id
-          );
-          if (WRITE_ACCESS_LEVELS.has(callerCollaborator?.accessLevel)) {
-            return Object.assign(plan, { readOnly: false }) as Plan & { readOnly: boolean };
-          }
-
-          // Super Admins always have readOnly access to all plans
-          if (context.token?.role === UserRole.SUPERADMIN) {
-            return Object.assign(plan, { readOnly: true }) as Plan & { readOnly: boolean };
-          }
-
-          // If the user is an ADMIN under the same org as the primary, they have readOnly access
-          const primaryCollaborator = await ProjectCollaborator.findPrimaryUserByProjectId(reference, context, project.id);
-          if ((primaryCollaborator.affiliationId === context.token?.affiliationId) && context.token?.role === UserRole.ADMIN) {
-            return Object.assign(plan, { readOnly: true }) as Plan & { readOnly: boolean };
-          }
-
-          return Object.assign(plan, { readOnly: true }) as Plan & { readOnly: boolean };
+          const readOnly = await isProjectReadOnlyForCurrentUser(reference, context, project);
+          return Object.assign(plan, { readOnly }) as Plan & { readOnly: boolean };
         }
         throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {

--- a/src/resolvers/project.ts
+++ b/src/resolvers/project.ts
@@ -18,6 +18,7 @@ import { ProjectMember } from '../models/Member';
 import {
   ensureDefaultProjectContact,
   hasPermissionOnProject,
+  isProjectReadOnlyForCurrentUser,
   setCurrentUserAsProjectOwner
 } from '../services/projectService';
 import { Affiliation } from '../models/Affiliation';
@@ -119,7 +120,8 @@ export const resolvers: Resolvers = {
           }
 
           if (await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.COMMENT)) {
-            return project;
+            const readOnly = await isProjectReadOnlyForCurrentUser(reference, context, project);
+            return Object.assign(project, { readOnly }) as Project & { readOnly: boolean };
           }
         }
         throw context?.token ? ForbiddenError() : AuthenticationError();

--- a/src/schemas/project.ts
+++ b/src/schemas/project.ts
@@ -1,7 +1,7 @@
 import gql from "graphql-tag";
-import {mergeTypeDefs} from "@graphql-tools/merge";
-import {typeDefs as memberTypeDefs} from "./member"
-import {typeDefs as funderTypeDefs} from "./funding"
+import { mergeTypeDefs } from "@graphql-tools/merge";
+import { typeDefs as memberTypeDefs } from "./member"
+import { typeDefs as funderTypeDefs } from "./funding"
 
 export const projectTypeDefs = gql`
   extend type Query {
@@ -129,6 +129,8 @@ export const projectTypeDefs = gql`
     fundings: [ProjectFunding!]
     "The plans that are associated with the research project"
     plans: [PlanSearchResult!]
+    "Indicates that the project is not editable by the user (i.e. readOnly = true means the user cannot edit the project)"
+    readOnly: Boolean
   }
 
   "A collection of errors related to the Project"

--- a/src/services/__tests__/projectService.spec.ts
+++ b/src/services/__tests__/projectService.spec.ts
@@ -9,10 +9,12 @@ import { Project } from "../../models/Project";
 import { isAdmin, isSuperAdmin } from "../authService";
 import {
   ensureDefaultProjectContact,
-  hasPermissionOnProject, setCurrentUserAsProjectOwner
+  hasPermissionOnProject,
+  setCurrentUserAsProjectOwner,
+  isProjectReadOnlyForCurrentUser,
 } from "../projectService";
 import { ProjectCollaborator, ProjectCollaboratorAccessLevel } from "../../models/Collaborator";
-import { User } from "../../models/User";
+import { User, UserRole } from "../../models/User";
 import { ProjectMember } from "../../models/Member";
 import { MemberRole } from "../../models/MemberRole";
 import { MyContext } from "../../context";
@@ -356,5 +358,125 @@ describe('ensureDefaultProjectContact', () => {
 
     expect(await ensureDefaultProjectContact(context, project)).toBe(true);
     ProjectMember.findPrimaryContact = originalFindPrimaryContact;
+  });
+});
+
+describe('isProjectReadOnlyForCurrentUser', () => {
+  let project: Project;
+  let mockFindByUserIdAndProjectId: jest.SpyInstance;
+  let mockFindPrimaryUserByProjectId: jest.SpyInstance;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    context = await buildMockContextWithToken(logger);
+
+    project = new Project({
+      id: casual.integer(1, 999),
+      title: casual.sentence,
+    });
+
+    mockFindByUserIdAndProjectId = jest.spyOn(ProjectCollaborator, 'findByUserIdAndProjectId');
+    mockFindPrimaryUserByProjectId = jest.spyOn(ProjectCollaborator, 'findPrimaryUserByProjectId');
+  });
+
+  afterEach(() => {
+    mockFindByUserIdAndProjectId.mockRestore();
+    mockFindPrimaryUserByProjectId.mockRestore();
+  });
+
+  it('returns false (not read-only) if caller has OWN access level', async () => {
+    mockFindByUserIdAndProjectId.mockResolvedValueOnce({
+      accessLevel: ProjectCollaboratorAccessLevel.OWN,
+    });
+
+    const result = await isProjectReadOnlyForCurrentUser('test', context, project);
+
+    expect(result).toBe(false);
+    expect(mockFindByUserIdAndProjectId).toHaveBeenCalledTimes(1);
+    expect(mockFindPrimaryUserByProjectId).toHaveBeenCalledTimes(0);
+  });
+
+  it('returns false (not read-only) if caller has PRIMARY access level', async () => {
+    mockFindByUserIdAndProjectId.mockResolvedValueOnce({
+      accessLevel: ProjectCollaboratorAccessLevel.PRIMARY,
+    });
+
+    const result = await isProjectReadOnlyForCurrentUser('test', context, project);
+
+    expect(result).toBe(false);
+    expect(mockFindByUserIdAndProjectId).toHaveBeenCalledTimes(1);
+    expect(mockFindPrimaryUserByProjectId).toHaveBeenCalledTimes(0);
+  });
+
+  it('returns true (read-only) if caller has EDIT access level', async () => {
+    mockFindByUserIdAndProjectId.mockResolvedValueOnce({
+      accessLevel: ProjectCollaboratorAccessLevel.EDIT,
+    });
+
+    const result = await isProjectReadOnlyForCurrentUser('test', context, project);
+
+    expect(result).toBe(true);
+    expect(mockFindByUserIdAndProjectId).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns true (read-only) if caller is a SUPERADMIN without write access', async () => {
+    mockFindByUserIdAndProjectId.mockResolvedValueOnce({
+      accessLevel: ProjectCollaboratorAccessLevel.EDIT,
+    });
+    context.token = { ...context.token, role: UserRole.SUPERADMIN };
+
+    const result = await isProjectReadOnlyForCurrentUser('test', context, project);
+
+    expect(result).toBe(true);
+    expect(mockFindPrimaryUserByProjectId).toHaveBeenCalledTimes(0);
+  });
+
+  it('returns true (read-only) if caller is an ADMIN with same affiliation as primary collaborator', async () => {
+    const sharedAffiliationId = casual.integer(1, 999);
+    mockFindByUserIdAndProjectId.mockResolvedValueOnce({
+      accessLevel: ProjectCollaboratorAccessLevel.EDIT,
+    });
+    mockFindPrimaryUserByProjectId.mockResolvedValueOnce({
+      affiliationId: sharedAffiliationId,
+    });
+    context.token = {
+      ...context.token,
+      role: UserRole.ADMIN,
+      affiliationId: sharedAffiliationId,
+    };
+
+    const result = await isProjectReadOnlyForCurrentUser('test', context, project);
+
+    expect(result).toBe(true);
+    expect(mockFindPrimaryUserByProjectId).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns true (read-only) if caller is an ADMIN with a different affiliation than the primary collaborator', async () => {
+    mockFindByUserIdAndProjectId.mockResolvedValueOnce({
+      accessLevel: ProjectCollaboratorAccessLevel.EDIT,
+    });
+    mockFindPrimaryUserByProjectId.mockResolvedValueOnce({
+      affiliationId: casual.integer(1, 499),
+    });
+    context.token = {
+      ...context.token,
+      role: UserRole.ADMIN,
+      affiliationId: casual.integer(500, 999),
+    };
+
+    const result = await isProjectReadOnlyForCurrentUser('test', context, project);
+
+    expect(result).toBe(true);
+    expect(mockFindPrimaryUserByProjectId).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns true (read-only) if caller has no collaborator record', async () => {
+    mockFindByUserIdAndProjectId.mockResolvedValueOnce(null);
+
+    const result = await isProjectReadOnlyForCurrentUser('test', context, project);
+
+    expect(result).toBe(true);
+    expect(mockFindByUserIdAndProjectId).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -2,11 +2,16 @@ import { MyContext } from "../context";
 import { prepareObjectForLogs } from "../logger";
 import { ProjectCollaborator, ProjectCollaboratorAccessLevel } from "../models/Collaborator";
 import { Project } from "../models/Project";
-import { User } from "../models/User";
+import { User, UserRole } from "../models/User";
 import { isAdmin, isSuperAdmin } from "./authService";
 import { isNullOrUndefined } from "../utils/helpers";
 import { ProjectMember } from "../models/Member";
 import { MemberRole } from "../models/MemberRole";
+
+const WRITE_ACCESS_LEVELS = new Set([
+  ProjectCollaboratorAccessLevel.OWN,
+  ProjectCollaboratorAccessLevel.PRIMARY,
+]);
 
 // Determine whether the specified user has permission to access the Section
 export const hasPermissionOnProject = async (
@@ -69,6 +74,41 @@ export const hasPermissionOnProject = async (
   const payload = { projectId: project?.id, userId: context.token?.id };
   context.logger.error(prepareObjectForLogs(payload), `AUTH failure: ${reference}`);
   return false;
+}
+
+// Determine whether the current user should be restricted to read-only access.
+export const isProjectReadOnlyForCurrentUser = async (
+  reference: string,
+  context: MyContext,
+  project: Project,
+): Promise<boolean> => {
+  const callerCollaborator = await ProjectCollaborator.findByUserIdAndProjectId(
+    reference,
+    context,
+    context.token?.id,
+    project.id,
+  );
+
+  if (WRITE_ACCESS_LEVELS.has(callerCollaborator?.accessLevel)) {
+    return false;
+  }
+
+  if (context.token?.role === UserRole.SUPERADMIN) {
+    return true;
+  }
+
+  if (context.token?.role === UserRole.ADMIN) {
+    const primaryCollaborator = await ProjectCollaborator.findPrimaryUserByProjectId(
+      reference,
+      context,
+      project.id,
+    );
+    if (primaryCollaborator?.affiliationId === context.token?.affiliationId) {
+      return true;
+    }
+  }
+
+  return true;
 }
 
 // Set the current user as the owner of the project

--- a/src/types.ts
+++ b/src/types.ts
@@ -2824,6 +2824,8 @@ export type Project = {
   modifiedById?: Maybe<Scalars['Int']['output']>;
   /** The plans that are associated with the research project */
   plans?: Maybe<Array<PlanSearchResult>>;
+  /** Indicates that the project is not editable by the user (i.e. readOnly = true means the user cannot edit the project) */
+  readOnly?: Maybe<Scalars['Boolean']['output']>;
   /** The type of research being done */
   researchDomain?: Maybe<ResearchDomain>;
   /** The estimated date the research project will begin (use YYYY-MM-DD format) */
@@ -7278,6 +7280,7 @@ export type ProjectResolvers<ContextType = MyContext, ParentType extends Resolve
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   plans?: Resolver<Maybe<Array<ResolversTypes['PlanSearchResult']>>, ParentType, ContextType>;
+  readOnly?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   researchDomain?: Resolver<Maybe<ResolversTypes['ResearchDomain']>, ParentType, ContextType>;
   startDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;


### PR DESCRIPTION
## Description

- Added `isProjectReadOnlyForCurrentUser` in `projectService.ts` that is shared between the `plan` and `project` query resolvers,and added `readOnly` field to the `Project` schema

Fixes # ([244](https://github.com/CDLUC3/dmptool-doc/issues/244))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested and added new unit tests


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules