### PR TITLE
Added support for Admin Notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v1.1.0
 
 ### Added
+- Added `adminNotifications` model, resolver and db table. [#570]
+- Added `findByIdWithTemplateName` method to `TemplateCustomization` model so that we can return the template name [#570]
 - Added the `generateLogoUploadURL` and `finalizeLogoUpload` resolvers to the `affiliation` schema.
 - Added new data migration to remove `logoURI` column from `affiliations`. The URI is now generated on the fly by the resolver.
 - Added new `src/datasource/s3.ts` file to provide the CDN URL and to generate presigned URLs for S3 objects.
@@ -90,6 +92,7 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated `requestFeedback`, `addTemplate` and `publishTemplateCustomization` resolvers to add a record to the `adminNotifications` table [#570]
 - Updated `awsConfig` to move SES properties underneath the `ses` property
 - Updated `uuid` and `@testcontainers/mysql` dependencies
 - Updated methods for the `PlanSectionProgress` class to return `totalRequiredQuestions` and `answeredRequiredQuestions`, and updated unit tests and `PlanSectionProgress` schema [#249]

--- a/data-migrations/2026-06-11-0907-create-adminNotifications.sql
+++ b/data-migrations/2026-06-11-0907-create-adminNotifications.sql
@@ -1,5 +1,6 @@
 CREATE TABLE `adminNotifications` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `userId` int unsigned NOT NULL,
   `notificationType` varchar(50) NOT NULL,
   `affiliationId` varchar(255) NOT NULL,
   `metadata` json DEFAULT NULL,
@@ -11,6 +12,8 @@ CREATE TABLE `adminNotifications` (
   PRIMARY KEY (`id`),
   KEY `affiliationId` (`affiliationId`),
   KEY `notificationType` (`notificationType`),
+  KEY `userId` (`userId`),
+  CONSTRAINT `adminNotifications_ibfk_5` FOREIGN KEY (`userId`) REFERENCES `users` (`id`),
   CONSTRAINT `adminNotifications_ibfk_2` FOREIGN KEY (`affiliationId`) REFERENCES `affiliations` (`uri`),
   CONSTRAINT `adminNotifications_ibfk_3` FOREIGN KEY (`createdById`) REFERENCES `users` (`id`),
   CONSTRAINT `adminNotifications_ibfk_4` FOREIGN KEY (`modifiedById`) REFERENCES `users` (`id`)

--- a/data-migrations/2026-06-11-0907-create-adminNotifications.sql
+++ b/data-migrations/2026-06-11-0907-create-adminNotifications.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `adminNotifications` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `notificationType` varchar(50) NOT NULL,
+  `affiliationId` varchar(255) NOT NULL,
+  `metadata` json DEFAULT NULL,
+  `isRead` tinyint(1) NOT NULL DEFAULT 0,
+  `createdById` int unsigned NOT NULL,
+  `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `modifiedById` int unsigned NOT NULL,
+  `modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `affiliationId` (`affiliationId`),
+  KEY `notificationType` (`notificationType`),
+  CONSTRAINT `adminNotifications_ibfk_2` FOREIGN KEY (`affiliationId`) REFERENCES `affiliations` (`uri`),
+  CONSTRAINT `adminNotifications_ibfk_3` FOREIGN KEY (`createdById`) REFERENCES `users` (`id`),
+  CONSTRAINT `adminNotifications_ibfk_4` FOREIGN KEY (`modifiedById`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/src/models/AdminNotifications.ts
+++ b/src/models/AdminNotifications.ts
@@ -1,0 +1,192 @@
+import { MyContext } from "../context";
+import {
+  PaginationOptionsForCursors,
+  PaginationOptionsForOffsets,
+  PaginatedQueryResults,
+  PaginationType,
+  PaginationOptions
+} from "../types/general";
+import { AdminNotificationType } from "../types";
+import { MySqlModel } from "./MySqlModel";
+import { isNullOrUndefined } from "../utils/helpers";
+
+export interface AdminNotificationMetadata {
+  planId?: number;
+  templateId?: number;
+  templateCustomizationId?: number;
+}
+
+export interface AdminNotificationOptions {
+  notificationType: AdminNotificationType;
+  metadata?: AdminNotificationMetadata;
+  affiliationId?: string;
+  isRead?: boolean;
+}
+
+export class AdminNotificationResults extends MySqlModel {
+  public notificationType: AdminNotificationType;
+  public metadata: AdminNotificationMetadata;
+  public affiliationId: string;
+  public isRead: boolean;
+
+  constructor(options) {
+    super(options.id, options.created, options.createdById, options.modified, options.modifiedById, options.errors);
+
+    this.notificationType = options.notificationType;
+    this.metadata = options.metadata ?? {};
+    this.affiliationId = options.affiliationId;
+    this.isRead = options.isRead ?? false;
+  }
+
+  static async findByAffiliationId(
+    reference: string,
+    context: MyContext,
+    affiliationId: string | null,
+    options: PaginationOptions = AdminNotificationResults.getDefaultPaginationOptions(),
+    isRead?: boolean,
+  ): Promise<PaginatedQueryResults<AdminNotificationResults>> {
+
+    // SuperAdmins get all notifications, Admins only get their affiliation's notifications
+    const whereFilters: string[] = [];
+    const values: string[] = [];
+
+    if (affiliationId) {
+      whereFilters.push('affiliationId = ?');
+      values.push(affiliationId);
+    }
+
+    if (isRead !== undefined) {
+      whereFilters.push(`isRead = ${isRead}`);
+    }
+
+
+    if (isNullOrUndefined(options.sortField)) options.sortField = 'created';
+    if (isNullOrUndefined(options.sortDir)) options.sortDir = 'DESC';
+
+    options.countField = 'id';
+
+    let opts;
+    if (options.type === PaginationType.OFFSET) {
+      opts = options as PaginationOptionsForOffsets;
+    } else {
+      opts = options as PaginationOptionsForCursors;
+      opts.cursorField = 'id';
+    }
+
+    const sqlStatement = 'SELECT adminNotifications.* FROM adminNotifications';
+
+    return AdminNotificationResults.queryWithPagination(
+      context,
+      sqlStatement,
+      whereFilters,
+      '',
+      values,
+      opts,
+      reference,
+    );
+  }
+
+  static async findReadByAffiliationId(
+    reference: string,
+    context: MyContext,
+    affiliationId: string | null,
+    options?: PaginationOptions,
+  ) {
+    return AdminNotificationResults.findByAffiliationId(reference, context, affiliationId, options, true);
+  }
+
+  static async findUnreadByAffiliationId(
+    reference: string,
+    context: MyContext,
+    affiliationId: string | null,
+    options?: PaginationOptions,
+  ) {
+    return AdminNotificationResults.findByAffiliationId(reference, context, affiliationId, options, false);
+  }
+}
+
+export class AdminNotification extends MySqlModel {
+  public notificationType: AdminNotificationType;
+  public metadata: AdminNotificationMetadata;
+  public affiliationId: string;
+  public isRead: boolean;
+
+  private tableName = 'adminNotifications';
+
+  constructor(options) {
+    super(options.id, options.created, options.createdById, options.modified, options.modifiedById, options.errors);
+
+    this.notificationType = options.notificationType;
+    this.metadata = options.metadata ?? {};
+    this.affiliationId = options.affiliationId;
+    this.isRead = options.isRead ?? false;
+  }
+
+  async isValid(): Promise<boolean> {
+    await super.isValid();
+
+    if (!this.notificationType) this.addError('notificationType', "Notification type can't be blank");
+
+    const validTypes: AdminNotificationType[] = ['FEEDBACK_REQUESTED', 'TEMPLATE_CREATED', 'TEMPLATE_CUSTOMIZATION_CHANGED'];
+    if (!validTypes.includes(this.notificationType)) {
+      this.addError('notificationType', `Notification type must be one of: ${validTypes.join(', ')}`);
+    }
+
+    return Object.keys(this.errors).length === 0;
+  }
+
+  async markAsRead(context: MyContext): Promise<AdminNotification | null> {
+    if (!this.id) {
+      this.addError('general', 'AdminNotification has never been saved');
+      return this;
+    }
+    this.isRead = true;
+    return await this.update(context);
+  }
+
+  async markAsUnRead(context: MyContext): Promise<AdminNotification | null> {
+    if (!this.id) {
+      this.addError('general', 'AdminNotification has never been saved');
+      return this;
+    }
+    this.isRead = false;
+    return await this.update(context);
+  }
+
+
+  async create(context: MyContext): Promise<AdminNotification | null> {
+    const reference = 'AdminNotification.create';
+
+    if (await this.isValid()) {
+      const newId = await AdminNotification.insert(context, this.tableName, this, reference);
+      if (!newId) {
+        context.logger.error(`${reference}, ERROR: Failed to create AdminNotification.`);
+        this.addError('general', 'AdminNotification was not created successfully');
+        return new AdminNotification(this);
+      }
+      return await AdminNotification.findById(reference, context, newId);
+    }
+    return new AdminNotification(this);
+  }
+
+  async update(context: MyContext, noTouch = false): Promise<AdminNotification | null> {
+    const reference = 'AdminNotification.update';
+    if (this.id) {
+      if (await this.isValid()) {
+        const updated = await AdminNotification.update(context, this.tableName, this, reference, [], noTouch);
+        if (updated) {
+          return await AdminNotification.findById(reference, context, this.id);
+        }
+      }
+    } else {
+      this.addError('general', 'AdminNotification has never been saved');
+    }
+    return this;
+  }
+
+  static async findById(reference: string, context: MyContext, id: number): Promise<AdminNotification | null> {
+    const sql = `SELECT * FROM adminNotifications WHERE id = ?`;
+    const results = await AdminNotification.query(context, sql, [id?.toString()], reference);
+    return Array.isArray(results) && results.length > 0 ? new AdminNotification(results[0]) : null;
+  }
+}

--- a/src/models/AdminNotifications.ts
+++ b/src/models/AdminNotifications.ts
@@ -196,7 +196,7 @@ export class AdminNotification extends MySqlModel {
     INSERT INTO adminNotifications (userId, notificationType, affiliationId, metadata, createdById, modifiedById, created, modified)
     SELECT u.id, ?, ?, ?, ?, ?, NOW(), NOW()
     FROM users AS u
-    WHERE (u.role = 'ADMIN' OR u.role = 'SUPER_ADMIN') AND u.affiliationId = ?
+    WHERE (u.role = 'ADMIN' OR u.role = 'SUPERADMIN') AND u.affiliationId = ?
   `;
     const values = [
       notificationType,

--- a/src/models/AdminNotifications.ts
+++ b/src/models/AdminNotifications.ts
@@ -15,19 +15,12 @@ export interface AdminNotificationMetadata {
   templateId?: number;
   templateCustomizationId?: number;
 }
-
-export interface AdminNotificationOptions {
-  notificationType: AdminNotificationType;
-  metadata?: AdminNotificationMetadata;
-  affiliationId?: string;
-  isRead?: boolean;
-}
-
 export class AdminNotificationResults extends MySqlModel {
   public notificationType: AdminNotificationType;
   public metadata: AdminNotificationMetadata;
   public affiliationId: string;
   public isRead: boolean;
+  public userId: number;
 
   constructor(options) {
     super(options.id, options.created, options.createdById, options.modified, options.modifiedById, options.errors);
@@ -36,29 +29,29 @@ export class AdminNotificationResults extends MySqlModel {
     this.metadata = options.metadata ?? {};
     this.affiliationId = options.affiliationId;
     this.isRead = options.isRead ?? false;
+    this.userId = options.userId;
   }
 
-  static async findByAffiliationId(
+  static async findByUserId(
     reference: string,
     context: MyContext,
-    affiliationId: string | null,
+    userId: number | null,
     options: PaginationOptions = AdminNotificationResults.getDefaultPaginationOptions(),
     isRead?: boolean,
   ): Promise<PaginatedQueryResults<AdminNotificationResults>> {
 
-    // SuperAdmins get all notifications, Admins only get their affiliation's notifications
+    // SuperAdmins get all notifications (userId is null), Admins only get their own
     const whereFilters: string[] = [];
     const values: string[] = [];
 
-    if (affiliationId) {
-      whereFilters.push('affiliationId = ?');
-      values.push(affiliationId);
+    if (userId) {
+      whereFilters.push('userId = ?');
+      values.push(userId.toString());
     }
 
     if (isRead !== undefined) {
-      whereFilters.push(`isRead = ${isRead}`);
+      whereFilters.push(`isRead = ${isRead ? 1 : 0}`);
     }
-
 
     if (isNullOrUndefined(options.sortField)) options.sortField = 'created';
     if (isNullOrUndefined(options.sortDir)) options.sortDir = 'DESC';
@@ -86,22 +79,22 @@ export class AdminNotificationResults extends MySqlModel {
     );
   }
 
-  static async findReadByAffiliationId(
+  static async findReadByUserId(
     reference: string,
     context: MyContext,
-    affiliationId: string | null,
+    userId: number | null,
     options?: PaginationOptions,
   ) {
-    return AdminNotificationResults.findByAffiliationId(reference, context, affiliationId, options, true);
+    return AdminNotificationResults.findByUserId(reference, context, userId, options, true);
   }
 
-  static async findUnreadByAffiliationId(
+  static async findUnreadByUserId(
     reference: string,
     context: MyContext,
-    affiliationId: string | null,
+    userId: number | null,
     options?: PaginationOptions,
   ) {
-    return AdminNotificationResults.findByAffiliationId(reference, context, affiliationId, options, false);
+    return AdminNotificationResults.findByUserId(reference, context, userId, options, false);
   }
 }
 
@@ -110,6 +103,7 @@ export class AdminNotification extends MySqlModel {
   public metadata: AdminNotificationMetadata;
   public affiliationId: string;
   public isRead: boolean;
+  public userId: number;
 
   private tableName = 'adminNotifications';
 
@@ -120,6 +114,7 @@ export class AdminNotification extends MySqlModel {
     this.metadata = options.metadata ?? {};
     this.affiliationId = options.affiliationId;
     this.isRead = options.isRead ?? false;
+    this.userId = options.userId;
   }
 
   async isValid(): Promise<boolean> {
@@ -188,5 +183,30 @@ export class AdminNotification extends MySqlModel {
     const sql = `SELECT * FROM adminNotifications WHERE id = ?`;
     const results = await AdminNotification.query(context, sql, [id?.toString()], reference);
     return Array.isArray(results) && results.length > 0 ? new AdminNotification(results[0]) : null;
+  }
+
+  static async addNotificationForAffiliation(
+    reference: string,
+    context: MyContext,
+    affiliationId: string,
+    notificationType: AdminNotificationType,
+    metadata?: AdminNotificationMetadata,
+  ): Promise<boolean> {
+    const sql = `
+    INSERT INTO adminNotifications (userId, notificationType, affiliationId, metadata, createdById, modifiedById, created, modified)
+    SELECT u.id, ?, ?, ?, ?, ?, NOW(), NOW()
+    FROM users AS u
+    WHERE (u.role = 'ADMIN' OR u.role = 'SUPER_ADMIN') AND u.affiliationId = ?
+  `;
+    const values = [
+      notificationType,
+      affiliationId,
+      JSON.stringify(metadata ?? {}),
+      context.token.id.toString(),
+      context.token.id.toString(),
+      affiliationId,
+    ];
+    const result = await AdminNotification.query(context, sql, values, reference);
+    return Array.isArray(result) && result.length > 0;
   }
 }

--- a/src/models/TemplateCustomization.ts
+++ b/src/models/TemplateCustomization.ts
@@ -764,7 +764,8 @@ export class TemplateCustomization extends MySqlModel {
           context,
           TemplateCustomization.tableName,
           this,
-          ref
+          ref,
+          ['templateName'] //skip templateName as it is not a real column in the database and is only used for convenience when fetching a customization with its template name
         );
         return await TemplateCustomization.findById(ref, context, newId);
       }
@@ -799,7 +800,7 @@ export class TemplateCustomization extends MySqlModel {
           TemplateCustomization.tableName,
           this,
           ref,
-          [],
+          ['templateName'],
           noTouch
         );
         return await TemplateCustomization.findById(ref, context, this.id);

--- a/src/models/TemplateCustomization.ts
+++ b/src/models/TemplateCustomization.ts
@@ -580,6 +580,8 @@ export class TemplateCustomization extends MySqlModel {
   public latestPublishedDate: string;
   // Whether the customization has been modified since it was last published
   public isDirty: boolean;
+  // The name of the parent template, included for convenience when fetching a customization with its template name
+  public templateName?: string;
 
   static tableName = 'templateCustomizations';
 
@@ -595,6 +597,7 @@ export class TemplateCustomization extends MySqlModel {
     this.latestPublishedVersionId = options.latestPublishedVersionId;
     this.latestPublishedDate = options.latestPublishedDate;
     this.isDirty = options.isDirty ?? false;
+    this.templateName = options.templateName;
   }
 
   /**
@@ -960,5 +963,31 @@ export class TemplateCustomization extends MySqlModel {
       reference
     )
     return Array.isArray(results) ? results.map(c => new TemplateCustomization(c)) : [];
+  }
+
+  /**
+   * Find the TemplateCustomization with the name of the base template it is customizing by its id
+   * @param reference 
+   * @param context 
+   * @param templateCustomizationId 
+   * @returns 
+   */
+  static async findByIdWithTemplateName(
+    reference: string,
+    context: MyContext,
+    templateCustomizationId: number
+  ): Promise<TemplateCustomization & { name?: string } | null> {
+    const results = await TemplateCustomization.query(
+      context,
+      `SELECT tc.*, t.name AS templateName
+      FROM ${TemplateCustomization.tableName} tc
+      JOIN templates t ON tc.templateId = t.id
+      WHERE tc.id = ?`,
+      [templateCustomizationId?.toString()],
+      reference
+    );
+    return Array.isArray(results) && results.length > 0
+      ? new TemplateCustomization(results[0])
+      : null;
   }
 }

--- a/src/models/__tests__/AdminNotification.spec.ts
+++ b/src/models/__tests__/AdminNotification.spec.ts
@@ -1,0 +1,352 @@
+import casual from "casual";
+import { AdminNotification, AdminNotificationResults } from "../AdminNotifications";
+import { buildMockContextWithToken } from "../../__mocks__/context";
+import { logger } from "../../logger";
+import { AdminNotificationType } from "../../types";
+
+jest.mock('../../context.ts');
+
+// ─── Shared test data ────────────────────────────────────────────────────────
+
+const validNotificationData = {
+  id: casual.integer(1, 999),
+  notificationType: 'FEEDBACK_REQUESTED' as AdminNotificationType,
+  affiliationId: 'https://ror.org/03yrm5c26',
+  metadata: { planId: casual.integer(1, 999) },
+  isRead: false,
+  createdById: casual.integer(1, 999),
+  modifiedById: casual.integer(1, 999),
+  created: new Date().toISOString(),
+  modified: new Date().toISOString(),
+};
+
+// ─── AdminNotification ───────────────────────────────────────────────────────
+
+describe('AdminNotification', () => {
+  let context;
+  let notification: AdminNotification;
+
+  beforeEach(async () => {
+    context = await buildMockContextWithToken(logger);
+    notification = new AdminNotification(validNotificationData);
+  });
+
+  describe('constructor', () => {
+    it('should initialize options as expected', () => {
+      expect(notification.notificationType).toEqual(validNotificationData.notificationType);
+      expect(notification.affiliationId).toEqual(validNotificationData.affiliationId);
+      expect(notification.metadata).toEqual(validNotificationData.metadata);
+      expect(notification.isRead).toEqual(validNotificationData.isRead);
+    });
+
+    it('should default isRead to false if not provided', () => {
+      const n = new AdminNotification({ ...validNotificationData, isRead: undefined });
+      expect(n.isRead).toBe(false);
+    });
+
+    it('should default metadata to empty object if not provided', () => {
+      const n = new AdminNotification({ ...validNotificationData, metadata: undefined });
+      expect(n.metadata).toEqual({});
+    });
+  });
+
+  describe('isValid', () => {
+    it('should return true for a valid notification', async () => {
+      const result = await notification.isValid();
+      expect(result).toBe(true);
+      expect(Object.keys(notification.errors).length).toBe(0);
+    });
+
+    it('should return false if notificationType is missing', async () => {
+      notification.notificationType = undefined;
+      const result = await notification.isValid();
+      expect(result).toBe(false);
+      expect(notification.errors['notificationType']).toBeTruthy();
+    });
+
+    it('should return false if notificationType is not a valid enum value', async () => {
+      notification.notificationType = 'INVALID_TYPE' as AdminNotificationType;
+      const result = await notification.isValid();
+      expect(result).toBe(false);
+      expect(notification.errors['notificationType']).toBeTruthy();
+    });
+
+    it('should be valid for TEMPLATE_CREATED type', async () => {
+      notification.notificationType = 'TEMPLATE_CREATED' as AdminNotificationType;
+      const result = await notification.isValid();
+      expect(result).toBe(true);
+    });
+
+    it('should be valid for TEMPLATE_CUSTOMIZATION_CHANGED type', async () => {
+      notification.notificationType = 'TEMPLATE_CUSTOMIZATION_CHANGED' as AdminNotificationType;
+      const result = await notification.isValid();
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('markAsRead', () => {
+    it('should set isRead to true and call update', async () => {
+      const mockUpdate = jest.fn().mockResolvedValue({ ...notification, isRead: true });
+      notification.update = mockUpdate;
+
+      await notification.markAsRead(context);
+
+      expect(notification.isRead).toBe(true);
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    it('should add an error and return this if id is not set', async () => {
+      notification.id = undefined;
+      const result = await notification.markAsRead(context);
+      expect(result.errors['general']).toBeTruthy();
+    });
+  });
+
+  describe('markAsUnRead', () => {
+    it('should set isRead to false and call update', async () => {
+      notification.isRead = true;
+      const mockUpdate = jest.fn().mockResolvedValue({ ...notification, isRead: false });
+      notification.update = mockUpdate;
+
+      await notification.markAsUnRead(context);
+
+      expect(notification.isRead).toBe(false);
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    it('should add an error and return this if id is not set', async () => {
+      notification.id = undefined;
+      const result = await notification.markAsUnRead(context);
+      expect(result.errors['general']).toBeTruthy();
+    });
+  });
+
+  describe('create', () => {
+    const originalInsert = AdminNotification.insert;
+    const originalFindById = AdminNotification.findById;
+    let mockInsert: jest.Mock;
+    let mockFindById: jest.Mock;
+
+    beforeEach(() => {
+      mockInsert = jest.fn().mockResolvedValue(validNotificationData.id);
+      (AdminNotification.insert as jest.Mock) = mockInsert;
+
+      mockFindById = jest.fn().mockResolvedValue(notification);
+      (AdminNotification.findById as jest.Mock) = mockFindById;
+    });
+
+    afterEach(() => {
+      AdminNotification.insert = originalInsert;
+      AdminNotification.findById = originalFindById;
+    });
+
+    it('should insert and return the new notification when valid', async () => {
+      const fresh = new AdminNotification({ ...validNotificationData, id: undefined });
+      const result = await fresh.create(context);
+      expect(mockInsert).toHaveBeenCalledTimes(1);
+      expect(mockFindById).toHaveBeenCalledTimes(1);
+      expect(Object.keys(result.errors).length).toBe(0);
+    });
+
+    it('should add an error if insert returns no id', async () => {
+      mockInsert.mockResolvedValueOnce(null);
+      const fresh = new AdminNotification({ ...validNotificationData, id: undefined });
+      const result = await fresh.create(context);
+      expect(result.errors['general']).toBeTruthy();
+    });
+
+    it('should return notification with errors if isValid fails', async () => {
+      const fresh = new AdminNotification({ ...validNotificationData, id: undefined, notificationType: undefined });
+      const result = await fresh.create(context);
+      expect(mockInsert).not.toHaveBeenCalled();
+      expect(result.errors['notificationType']).toBeTruthy();
+    });
+  });
+
+  describe('update', () => {
+    const originalUpdate = AdminNotification.update;
+    const originalFindById = AdminNotification.findById;
+    let mockUpdate: jest.Mock;
+    let mockFindById: jest.Mock;
+
+    beforeEach(() => {
+      mockUpdate = jest.fn().mockResolvedValue(new AdminNotification(validNotificationData));
+      (AdminNotification.update as jest.Mock) = mockUpdate;
+
+      mockFindById = jest.fn().mockResolvedValue(new AdminNotification(validNotificationData));
+      (AdminNotification.findById as jest.Mock) = mockFindById;
+    });
+
+    afterEach(() => {
+      AdminNotification.update = originalUpdate;
+      AdminNotification.findById = originalFindById;
+    });
+
+    it('should call update and return the updated notification when valid', async () => {
+      const result = await notification.update(context);
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+      expect(mockFindById).toHaveBeenCalledTimes(1);
+      expect(Object.keys(result.errors).length).toBe(0);
+    });
+
+    it('should add an error if id is not set', async () => {
+      const fresh = new AdminNotification({ ...validNotificationData, id: undefined });
+      const result = await fresh.update(context);
+      expect(result.errors['general']).toBeTruthy();
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should return this with errors if isValid fails', async () => {
+      const fresh = new AdminNotification({ ...validNotificationData, notificationType: undefined });
+      const result = await fresh.update(context);
+      expect(mockUpdate).not.toHaveBeenCalled();
+      expect(result.errors['notificationType']).toBeTruthy();
+    });
+  });
+
+  describe('findById', () => {
+    const originalQuery = AdminNotification.query;
+    let mockQuery: jest.Mock;
+
+    beforeEach(() => {
+      mockQuery = jest.fn();
+      (AdminNotification.query as jest.Mock) = mockQuery;
+    });
+
+    afterEach(() => {
+      AdminNotification.query = originalQuery;
+    });
+
+    it('should return the notification when a result is found', async () => {
+      mockQuery.mockResolvedValueOnce([validNotificationData]);
+      const result = await AdminNotification.findById('Test', context, validNotificationData.id);
+      const expectedSql = 'SELECT * FROM adminNotifications WHERE id = ?';
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      expect(mockQuery).toHaveBeenCalledWith(context, expectedSql, [validNotificationData.id.toString()], 'Test');
+      expect(result).toBeInstanceOf(AdminNotification);
+    });
+
+    it('should return null when no result is found', async () => {
+      mockQuery.mockResolvedValueOnce([]);
+      const result = await AdminNotification.findById('Test', context, validNotificationData.id);
+      expect(result).toBeNull();
+    });
+  });
+});
+
+// ─── AdminNotificationResults ─────────────────────────────────────────────────
+
+describe('AdminNotificationResults', () => {
+  let context;
+
+  beforeEach(async () => {
+    context = await buildMockContextWithToken(logger);
+  });
+
+  describe('constructor', () => {
+    it('should initialize options as expected', () => {
+      const result = new AdminNotificationResults(validNotificationData);
+      expect(result.notificationType).toEqual(validNotificationData.notificationType);
+      expect(result.affiliationId).toEqual(validNotificationData.affiliationId);
+      expect(result.metadata).toEqual(validNotificationData.metadata);
+      expect(result.isRead).toEqual(validNotificationData.isRead);
+    });
+
+    it('should default isRead to false if not provided', () => {
+      const result = new AdminNotificationResults({ ...validNotificationData, isRead: undefined });
+      expect(result.isRead).toBe(false);
+    });
+
+    it('should default metadata to empty object if not provided', () => {
+      const result = new AdminNotificationResults({ ...validNotificationData, metadata: undefined });
+      expect(result.metadata).toEqual({});
+    });
+  });
+
+  describe('findByAffiliationId', () => {
+    const originalQuery = AdminNotificationResults.queryWithPagination;
+    let mockQuery: jest.Mock;
+
+    beforeEach(() => {
+      mockQuery = jest.fn().mockResolvedValue({ items: [], totalCount: 0 });
+      (AdminNotificationResults.queryWithPagination as jest.Mock) = mockQuery;
+    });
+
+    afterEach(() => {
+      AdminNotificationResults.queryWithPagination = originalQuery;
+    });
+
+    it('should filter by affiliationId when provided', async () => {
+      await AdminNotificationResults.findByAffiliationId('Test', context, 'https://ror.org/123');
+      const [, , whereFilters, , values] = mockQuery.mock.calls[0];
+      expect(whereFilters).toContain('affiliationId = ?');
+      expect(values).toContain('https://ror.org/123');
+    });
+
+    it('should not filter by affiliationId when null (superAdmin)', async () => {
+      await AdminNotificationResults.findByAffiliationId('Test', context, null);
+      const [, , whereFilters, , values] = mockQuery.mock.calls[0];
+      expect(whereFilters).not.toContain('affiliationId = ?');
+      expect(values).toHaveLength(0);
+    });
+
+    it('should filter by isRead = true when provided', async () => {
+      await AdminNotificationResults.findByAffiliationId('Test', context, null, undefined, true);
+      const [, , whereFilters] = mockQuery.mock.calls[0];
+      expect(whereFilters).toContain('isRead = true');
+    });
+
+    it('should filter by isRead = false when provided', async () => {
+      await AdminNotificationResults.findByAffiliationId('Test', context, null, undefined, false);
+      const [, , whereFilters] = mockQuery.mock.calls[0];
+      expect(whereFilters).toContain('isRead = false');
+    });
+
+    it('should not filter by isRead when not provided', async () => {
+      await AdminNotificationResults.findByAffiliationId('Test', context, null);
+      const [, , whereFilters] = mockQuery.mock.calls[0];
+      expect(whereFilters.some((f: string) => f.includes('isRead'))).toBe(false);
+    });
+
+    it('should use cursor pagination by default', async () => {
+      await AdminNotificationResults.findByAffiliationId('Test', context, null);
+      const [, , , , , opts] = mockQuery.mock.calls[0];
+      expect(opts.cursorField).toBe('id');
+    });
+
+    it('should sort by created DESC by default', async () => {
+      await AdminNotificationResults.findByAffiliationId('Test', context, null);
+      const [, , , , , opts] = mockQuery.mock.calls[0];
+      expect(opts.sortField).toBe('created');
+      expect(opts.sortDir).toBe('DESC');
+    });
+  });
+
+  describe('findReadByAffiliationId', () => {
+    it('should call findByAffiliationId with isRead = true', async () => {
+      const mockFind = jest.fn().mockResolvedValue({ items: [], totalCount: 0 });
+      const original = AdminNotificationResults.findByAffiliationId;
+      (AdminNotificationResults.findByAffiliationId as jest.Mock) = mockFind;
+
+      await AdminNotificationResults.findReadByAffiliationId('Test', context, 'https://ror.org/123');
+
+      expect(mockFind).toHaveBeenCalledWith('Test', context, 'https://ror.org/123', undefined, true);
+
+      AdminNotificationResults.findByAffiliationId = original;
+    });
+  });
+
+  describe('findUnreadByAffiliationId', () => {
+    it('should call findByAffiliationId with isRead = false', async () => {
+      const mockFind = jest.fn().mockResolvedValue({ items: [], totalCount: 0 });
+      const original = AdminNotificationResults.findByAffiliationId;
+      (AdminNotificationResults.findByAffiliationId as jest.Mock) = mockFind;
+
+      await AdminNotificationResults.findUnreadByAffiliationId('Test', context, 'https://ror.org/123');
+
+      expect(mockFind).toHaveBeenCalledWith('Test', context, 'https://ror.org/123', undefined, false);
+
+      AdminNotificationResults.findByAffiliationId = original;
+    });
+  });
+});

--- a/src/models/__tests__/AdminNotification.spec.ts
+++ b/src/models/__tests__/AdminNotification.spec.ts
@@ -263,7 +263,7 @@ describe('AdminNotificationResults', () => {
     });
   });
 
-  describe('findByAffiliationId', () => {
+  describe('findByUserId', () => {
     const originalQuery = AdminNotificationResults.queryWithPagination;
     let mockQuery: jest.Mock;
 
@@ -276,77 +276,77 @@ describe('AdminNotificationResults', () => {
       AdminNotificationResults.queryWithPagination = originalQuery;
     });
 
-    it('should filter by affiliationId when provided', async () => {
-      await AdminNotificationResults.findByAffiliationId('Test', context, 'https://ror.org/123');
+    it('should filter by userId when provided', async () => {
+      await AdminNotificationResults.findByUserId('Test', context, 123);
       const [, , whereFilters, , values] = mockQuery.mock.calls[0];
-      expect(whereFilters).toContain('affiliationId = ?');
-      expect(values).toContain('https://ror.org/123');
+      expect(whereFilters).toContain('userId = ?');
+      expect(values).toContain('123');
     });
 
-    it('should not filter by affiliationId when null (superAdmin)', async () => {
-      await AdminNotificationResults.findByAffiliationId('Test', context, null);
+    it('should not filter by userId when null (superAdmin)', async () => {
+      await AdminNotificationResults.findByUserId('Test', context, null);
       const [, , whereFilters, , values] = mockQuery.mock.calls[0];
-      expect(whereFilters).not.toContain('affiliationId = ?');
+      expect(whereFilters).not.toContain('userId = ?');
       expect(values).toHaveLength(0);
     });
 
     it('should filter by isRead = true when provided', async () => {
-      await AdminNotificationResults.findByAffiliationId('Test', context, null, undefined, true);
+      await AdminNotificationResults.findByUserId('Test', context, null, undefined, true);
       const [, , whereFilters] = mockQuery.mock.calls[0];
-      expect(whereFilters).toContain('isRead = true');
+      expect(whereFilters).toContain('isRead = 1');
     });
 
     it('should filter by isRead = false when provided', async () => {
-      await AdminNotificationResults.findByAffiliationId('Test', context, null, undefined, false);
+      await AdminNotificationResults.findByUserId('Test', context, null, undefined, false);
       const [, , whereFilters] = mockQuery.mock.calls[0];
-      expect(whereFilters).toContain('isRead = false');
+      expect(whereFilters).toContain('isRead = 0');
     });
 
     it('should not filter by isRead when not provided', async () => {
-      await AdminNotificationResults.findByAffiliationId('Test', context, null);
+      await AdminNotificationResults.findByUserId('Test', context, null);
       const [, , whereFilters] = mockQuery.mock.calls[0];
       expect(whereFilters.some((f: string) => f.includes('isRead'))).toBe(false);
     });
 
     it('should use cursor pagination by default', async () => {
-      await AdminNotificationResults.findByAffiliationId('Test', context, null);
+      await AdminNotificationResults.findByUserId('Test', context, null);
       const [, , , , , opts] = mockQuery.mock.calls[0];
       expect(opts.cursorField).toBe('id');
     });
 
     it('should sort by created DESC by default', async () => {
-      await AdminNotificationResults.findByAffiliationId('Test', context, null);
+      await AdminNotificationResults.findByUserId('Test', context, null);
       const [, , , , , opts] = mockQuery.mock.calls[0];
       expect(opts.sortField).toBe('created');
       expect(opts.sortDir).toBe('DESC');
     });
   });
 
-  describe('findReadByAffiliationId', () => {
-    it('should call findByAffiliationId with isRead = true', async () => {
+  describe('findReadByUserId', () => {
+    it('should call findByUserId with isRead = true', async () => {
       const mockFind = jest.fn().mockResolvedValue({ items: [], totalCount: 0 });
-      const original = AdminNotificationResults.findByAffiliationId;
-      (AdminNotificationResults.findByAffiliationId as jest.Mock) = mockFind;
+      const original = AdminNotificationResults.findByUserId;
+      (AdminNotificationResults.findByUserId as jest.Mock) = mockFind;
 
-      await AdminNotificationResults.findReadByAffiliationId('Test', context, 'https://ror.org/123');
+      await AdminNotificationResults.findReadByUserId('Test', context, 123);
 
-      expect(mockFind).toHaveBeenCalledWith('Test', context, 'https://ror.org/123', undefined, true);
+      expect(mockFind).toHaveBeenCalledWith('Test', context, 123, undefined, true);
 
-      AdminNotificationResults.findByAffiliationId = original;
+      AdminNotificationResults.findByUserId = original;
     });
   });
 
-  describe('findUnreadByAffiliationId', () => {
-    it('should call findByAffiliationId with isRead = false', async () => {
+  describe('findUnreadByUserId', () => {
+    it('should call findByUserId with isRead = false', async () => {
       const mockFind = jest.fn().mockResolvedValue({ items: [], totalCount: 0 });
-      const original = AdminNotificationResults.findByAffiliationId;
-      (AdminNotificationResults.findByAffiliationId as jest.Mock) = mockFind;
+      const original = AdminNotificationResults.findByUserId;
+      (AdminNotificationResults.findByUserId as jest.Mock) = mockFind;
 
-      await AdminNotificationResults.findUnreadByAffiliationId('Test', context, 'https://ror.org/123');
+      await AdminNotificationResults.findUnreadByUserId('Test', context, 123);
 
-      expect(mockFind).toHaveBeenCalledWith('Test', context, 'https://ror.org/123', undefined, false);
+      expect(mockFind).toHaveBeenCalledWith('Test', context, 123, undefined, false);
 
-      AdminNotificationResults.findByAffiliationId = original;
+      AdminNotificationResults.findByUserId = original;
     });
   });
 });

--- a/src/models/__tests__/TemplateCustomization.spec.ts
+++ b/src/models/__tests__/TemplateCustomization.spec.ts
@@ -489,7 +489,8 @@ describe('TemplateCustomization', () => {
         mockContext,
         TemplateCustomization.tableName,
         customization,
-        'TemplateCustomization.create'
+        'TemplateCustomization.create',
+        ['templateName'] // skipKeys
       );
       expect(findBySpy).toHaveBeenCalledWith('TemplateCustomization.create', mockContext, 100);
       expect(result).toBe(mockCreated);
@@ -539,7 +540,7 @@ describe('TemplateCustomization', () => {
         TemplateCustomization.tableName,
         customization,
         'TemplateCustomization.update',
-        [],
+        ['templateName'], // skipKeys
         false
       );
       expect(result).toBe(mockUpdated);
@@ -569,7 +570,7 @@ describe('TemplateCustomization', () => {
         TemplateCustomization.tableName,
         customization,
         'TemplateCustomization.update',
-        [],
+        ['templateName'], // skipKeys
         true
       );
       expect(result).toBe(mockUpdated);

--- a/src/models/__tests__/TemplateCustomization.spec.ts
+++ b/src/models/__tests__/TemplateCustomization.spec.ts
@@ -880,6 +880,74 @@ describe('TemplateCustomization', () => {
       expect(result[1].id).toBe(124);
     });
   });
+
+  describe('static findByIdWithTemplateName()', () => {
+    it('should return null when no results are found', async () => {
+      const querySpy = jest.spyOn(TemplateCustomization, 'query').mockResolvedValue([]);
+
+      const result = await TemplateCustomization.findByIdWithTemplateName('test-ref', mockContext, 123);
+
+      expect(querySpy).toHaveBeenCalledWith(
+        mockContext,
+        expect.stringContaining('SELECT tc.*'),
+        ['123'],
+        'test-ref'
+      );
+      expect(result).toBeNull();
+    });
+
+    it('should return null when results is not an array', async () => {
+      jest.spyOn(TemplateCustomization, 'query').mockResolvedValue(null);
+
+      const result = await TemplateCustomization.findByIdWithTemplateName('test-ref', mockContext, 123);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return a TemplateCustomization instance with templateName when found', async () => {
+      const mockData = {
+        id: 123,
+        affiliationId: 'affil-123',
+        templateId: 1,
+        currentVersionedTemplateId: 10,
+        status: 'DRAFT',
+        migrationStatus: 'OK',
+        templateName: 'My Funder Template',
+      };
+
+      const querySpy = jest.spyOn(TemplateCustomization, 'query').mockResolvedValue([mockData]);
+
+      const result = await TemplateCustomization.findByIdWithTemplateName('test-ref', mockContext, 123);
+
+      expect(querySpy).toHaveBeenCalledWith(
+        mockContext,
+        expect.stringContaining('JOIN templates t ON tc.templateId = t.id'),
+        ['123'],
+        'test-ref'
+      );
+      expect(result).toBeInstanceOf(TemplateCustomization);
+      expect(result.id).toBe(123);
+      expect(result.templateName).toBe('My Funder Template');
+    });
+
+    it('should join to templates table to get templateName', async () => {
+      const querySpy = jest.spyOn(TemplateCustomization, 'query').mockResolvedValue([]);
+
+      await TemplateCustomization.findByIdWithTemplateName('test-ref', mockContext, 123);
+
+      const calledSql = querySpy.mock.calls[0][1] as string;
+      expect(calledSql).toContain('t.name AS templateName');
+      expect(calledSql).toContain('JOIN templates t ON tc.templateId = t.id');
+    });
+
+    it('should return null when templateCustomizationId is not found', async () => {
+      jest.spyOn(TemplateCustomization, 'query').mockResolvedValue([]);
+
+      const result = await TemplateCustomization.findByIdWithTemplateName('test-ref', mockContext, 999);
+
+      expect(result).toBeNull();
+    });
+  });
 });
 
 describe('TemplateCustomizationOverview', () => {
@@ -970,7 +1038,7 @@ describe('TemplateCustomizationOverview', () => {
       );
 
       expect(mockContext.logger.error).toHaveBeenCalledWith(
-        {templateCustomizationId: 1},
+        { templateCustomizationId: 1 },
         'Unable to find template customization'
       );
       expect(result).toBeUndefined();
@@ -2133,7 +2201,7 @@ describe('TemplateCustomizationOverview', () => {
       const mockUpdated = new TemplateCustomization({
         ...mockCustomization,
         isDirty: true,
-        errors: {general: 'Some error'}
+        errors: { general: 'Some error' }
       });
 
       jest.spyOn(TemplateCustomization, 'findById').mockResolvedValue(mockCustomization);

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -6,6 +6,7 @@ import { orcidScalar } from './resolvers/scalars/orcid';
 import { rorScalar } from './resolvers/scalars/ror';
 import { md5Scalar } from "./resolvers/scalars/md5";
 
+import { resolvers as adminNotificationResolvers } from './resolvers/adminNotifications';
 import { resolvers as affiliationResolvers } from './resolvers/affiliation';
 import { resolvers as answerResolvers } from './resolvers/answer';
 import { resolvers as collaboratorResolvers } from './resolvers/collaborator';
@@ -49,7 +50,7 @@ const scalarResolvers = {
 
 export const resolvers: IResolvers = mergeResolvers([
   scalarResolvers,
-
+  adminNotificationResolvers,
   affiliationResolvers,
   answerResolvers,
   collaboratorResolvers,

--- a/src/resolvers/__tests__/adminNotifications.spec.ts
+++ b/src/resolvers/__tests__/adminNotifications.spec.ts
@@ -1,0 +1,694 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import casual from "casual";
+
+jest.mock('../../services/authService', () => ({
+  ...jest.requireActual('../../services/authService'),
+  authenticatedResolver: jest.fn((ref, level, resolver) => resolver),
+  isSuperAdmin: jest.fn().mockReturnValue(false),
+  isAdmin: jest.fn().mockReturnValue(true),
+}));
+
+import { ApolloServer } from "@apollo/server";
+import { typeDefs } from "../../schema";
+import { resolvers } from '../../resolver';
+import { logger } from "../../logger";
+import { JWTAccessToken } from "../../services/tokenService";
+import { UserRole } from "../../models/User";
+import { buildContext, mockToken } from "../../__mocks__/context";
+import { AdminNotificationResults, AdminNotification } from "../../models/AdminNotifications";
+import { Plan } from "../../models/Plan";
+import { Template } from "../../models/Template";
+import { TemplateCustomization } from "../../models/TemplateCustomization";
+import { PlanFeedback } from "../../models/PlanFeedback";
+import { User } from "../../models/User";
+import { isSuperAdmin, isAdmin } from '../../services/authService';
+
+jest.mock('../../context.ts');
+jest.mock('../../datasources/cache');
+
+jest.mock('../../models/AdminNotifications', () => ({
+  AdminNotificationResults: {
+    findReadByAffiliationId: jest.fn(),
+    findUnreadByAffiliationId: jest.fn(),
+    findByAffiliationId: jest.fn(),
+  },
+  AdminNotification: Object.assign(
+    jest.fn().mockImplementation(() => ({
+      create: jest.fn(),
+      markAsRead: jest.fn(),
+      markAsUnRead: jest.fn(),
+      addError: jest.fn(),
+      errors: {},
+    })),
+    {
+      findById: jest.fn(),
+    }
+  ),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+let testServer: ApolloServer;
+let adminToken: JWTAccessToken;
+let superAdminToken: JWTAccessToken;
+let researcherToken: JWTAccessToken;
+let affiliationId: string;
+
+async function executeQuery(
+  query: string,
+  variables: any,
+  token: JWTAccessToken
+): Promise<any> {
+  const context = buildContext(logger, token, null);
+  return await testServer.executeOperation(
+    { query, variables },
+    { contextValue: context }
+  );
+}
+
+function buildMockNotification(overrides = {}) {
+  return {
+    id: casual.integer(1, 999),
+    notificationType: 'FEEDBACK_REQUESTED',
+    affiliationId: casual.url,
+    metadata: { planId: casual.integer(1, 999) },
+    isRead: false,
+    createdById: casual.integer(1, 999),
+    created: new Date().toISOString(),
+    modified: new Date().toISOString(),
+    errors: {},
+    ...overrides,
+  };
+}
+
+function buildPaginatedResult(items: any[], totalCount = items.length) {
+  return {
+    items,
+    totalCount,
+    hasNextPage: false,
+    hasPreviousPage: false,
+    nextCursor: null,
+    currentOffset: 0,
+  };
+}
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+
+  testServer = new ApolloServer({ typeDefs, resolvers });
+
+  affiliationId = casual.url;
+
+  adminToken = await mockToken();
+  adminToken.affiliationId = affiliationId;
+  adminToken.role = UserRole.ADMIN;
+
+  superAdminToken = await mockToken();
+  superAdminToken.role = UserRole.SUPERADMIN;
+
+  researcherToken = await mockToken();
+  researcherToken.role = UserRole.RESEARCHER;
+
+  // Spy on chained resolver model methods — use spyOn to keep real constructors intact
+  jest.spyOn(Plan, 'findById').mockResolvedValue(null);
+  jest.spyOn(Template, 'findById').mockResolvedValue(null);
+  jest.spyOn(TemplateCustomization, 'findByIdWithTemplateName').mockResolvedValue(null);
+  jest.spyOn(PlanFeedback, 'findByPlanId').mockResolvedValue([]);
+  jest.spyOn(User, 'findById').mockResolvedValue(null);
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  jest.restoreAllMocks();
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('adminNotification resolver', () => {
+
+  // ─── Queries ───────────────────────────────────────────────────────────────
+
+  describe('Query.adminNotificationsUnread', () => {
+    const query = `
+      query adminNotificationsUnread($paginationOptions: PaginationOptions) {
+        adminNotificationsUnread(paginationOptions: $paginationOptions) {
+          totalCount
+          hasNextPage
+          items {
+            id
+            notificationType
+            isRead
+          }
+        }
+      }
+    `;
+
+    it('should return unread notifications for an admin', async () => {
+      const mockNotification = buildMockNotification({ isRead: false });
+      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+        buildPaginatedResult([mockNotification])
+      );
+
+      const result = await executeQuery(query, {}, adminToken);
+
+      expect(result.body.singleResult.data.adminNotificationsUnread.totalCount).toBe(1);
+      expect(result.body.singleResult.data.adminNotificationsUnread.items[0].isRead).toBe(false);
+      expect(AdminNotificationResults.findUnreadByAffiliationId).toHaveBeenCalledWith(
+        'unreadAdminNotifications resolver',
+        expect.any(Object),
+        affiliationId,
+        undefined
+      );
+    });
+
+    it('should pass null affiliationId for superAdmin', async () => {
+      (isSuperAdmin as jest.Mock).mockReturnValue(true);
+      (isAdmin as jest.Mock).mockReturnValue(false);
+      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+        buildPaginatedResult([])
+      );
+
+      await executeQuery(query, {}, superAdminToken);
+
+      expect(AdminNotificationResults.findUnreadByAffiliationId).toHaveBeenCalledWith(
+        'unreadAdminNotifications resolver',
+        expect.any(Object),
+        null,
+        undefined
+      );
+    });
+
+    it('should return an InternalServerError when the query throws', async () => {
+      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockRejectedValue(
+        new Error('DB failure')
+      );
+
+      const result = await executeQuery(query, {}, adminToken);
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toBe('DB failure');
+    });
+  });
+
+  describe('Query.adminNotificationsRead', () => {
+    const query = `
+      query adminNotificationsRead($paginationOptions: PaginationOptions) {
+        adminNotificationsRead(paginationOptions: $paginationOptions) {
+          totalCount
+          hasNextPage
+          items {
+            id
+            notificationType
+            isRead
+          }
+        }
+      }
+    `;
+
+    it('should return read notifications for an admin', async () => {
+      const mockNotification = buildMockNotification({ isRead: true });
+      (AdminNotificationResults.findReadByAffiliationId as jest.Mock).mockResolvedValue(
+        buildPaginatedResult([mockNotification])
+      );
+
+      const result = await executeQuery(query, {}, adminToken);
+
+      expect(result.body.singleResult.data.adminNotificationsRead.totalCount).toBe(1);
+      expect(result.body.singleResult.data.adminNotificationsRead.items[0].isRead).toBe(true);
+      expect(AdminNotificationResults.findReadByAffiliationId).toHaveBeenCalledWith(
+        'adminNotifications resolver',
+        expect.any(Object),
+        affiliationId,
+        undefined
+      );
+    });
+
+    it('should pass null affiliationId for superAdmin', async () => {
+      (isSuperAdmin as jest.Mock).mockReturnValue(true);
+      (isAdmin as jest.Mock).mockReturnValue(false);
+      (AdminNotificationResults.findReadByAffiliationId as jest.Mock).mockResolvedValue(
+        buildPaginatedResult([])
+      );
+
+      await executeQuery(query, {}, superAdminToken);
+
+      expect(AdminNotificationResults.findReadByAffiliationId).toHaveBeenCalledWith(
+        'adminNotifications resolver',
+        expect.any(Object),
+        null,
+        undefined
+      );
+    });
+
+    it('should return an InternalServerError when the query throws', async () => {
+      (AdminNotificationResults.findReadByAffiliationId as jest.Mock).mockRejectedValue(
+        new Error('DB failure')
+      );
+
+      const result = await executeQuery(query, {}, adminToken);
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toBe('DB failure');
+    });
+  });
+
+  describe('Query.adminNotifications', () => {
+    const query = `
+      query adminNotifications($paginationOptions: PaginationOptions) {
+        adminNotifications(paginationOptions: $paginationOptions) {
+          totalCount
+          hasNextPage
+          items {
+            id
+            notificationType
+            isRead
+          }
+        }
+      }
+    `;
+
+    it('should return all notifications for an admin', async () => {
+      const items = [
+        buildMockNotification({ isRead: false }),
+        buildMockNotification({ isRead: true }),
+      ];
+      (AdminNotificationResults.findByAffiliationId as jest.Mock).mockResolvedValue(
+        buildPaginatedResult(items, 2)
+      );
+
+      const result = await executeQuery(query, {}, adminToken);
+
+      expect(result.body.singleResult.data.adminNotifications.totalCount).toBe(2);
+    });
+
+    it('should return an InternalServerError when the query throws', async () => {
+      (AdminNotificationResults.findByAffiliationId as jest.Mock).mockRejectedValue(
+        new Error('DB failure')
+      );
+
+      const result = await executeQuery(query, {}, adminToken);
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toBe('DB failure');
+    });
+  });
+
+  // ─── Mutations ─────────────────────────────────────────────────────────────
+
+  describe('Mutation.addAdminNotification', () => {
+    let input: any;
+    beforeEach(() => {
+      input = {
+        notificationType: 'FEEDBACK_REQUESTED',
+        affiliationId,
+        metadata: { planId: 1 },
+      };
+    });
+    const query = `
+      mutation addAdminNotification($input: AdminNotificationOptions!) {
+        addAdminNotification(input: $input) {
+          id
+          notificationType
+          errors {
+            general
+          }
+        }
+      }
+    `;
+
+    it('should create and return a new notification', async () => {
+      const mockCreated = buildMockNotification({ id: 99 });
+      (AdminNotification as unknown as jest.Mock).mockImplementation(() => ({
+        create: jest.fn().mockResolvedValue(mockCreated),
+        errors: {},
+        addError: jest.fn(),
+      }));
+
+      const result = await executeQuery(query, { input }, adminToken);
+
+      expect(result.body.singleResult.data.addAdminNotification.id).toBe(99);
+    });
+
+    it('should add a general error when create returns no id', async () => {
+      const notificationInstance = {
+        create: jest.fn().mockResolvedValue({ id: null, errors: {} }),
+        errors: {},
+        addError: jest.fn(),
+      };
+      (AdminNotification as unknown as jest.Mock).mockImplementation(() => notificationInstance);
+
+      const result = await executeQuery(query, { input }, adminToken);
+
+      expect(result.body.singleResult.errors).toBeUndefined();
+      expect(notificationInstance.addError).toHaveBeenCalledWith('general', 'Unable to create AdminNotification');
+    });
+
+    it('should return Forbidden when the caller is not authorized', async () => {
+      const result = await executeQuery(query, { input }, researcherToken);
+      expect(result.body.singleResult.errors).toBeDefined();
+    });
+
+    it('should return InternalServerError when create throws', async () => {
+      (AdminNotification as unknown as jest.Mock).mockImplementation(() => ({
+        create: jest.fn().mockRejectedValue(new Error('DB error')),
+        errors: {},
+        addError: jest.fn(),
+      }));
+
+      const result = await executeQuery(query, { input }, adminToken);
+
+      expect(result.body.singleResult.errors[0].message).toBe('DB error');
+    });
+  });
+
+  describe('Mutation.markNotificationAsRead', () => {
+    const query = `
+      mutation markNotificationAsRead($id: Int!) {
+        markNotificationAsRead(id: $id)
+      }
+    `;
+
+    it('should mark a notification as read and return true', async () => {
+      (isSuperAdmin as jest.Mock).mockReturnValue(false);
+      (isAdmin as jest.Mock).mockReturnValue(true);
+
+      const mockNotification = buildMockNotification({ affiliationId });
+      (AdminNotification.findById as jest.Mock).mockResolvedValue({
+        ...mockNotification,
+        markAsRead: jest.fn().mockResolvedValue(mockNotification),
+      });
+
+      const result = await executeQuery(query, { id: mockNotification.id }, adminToken);
+
+      expect(result.body.singleResult.data.markNotificationAsRead).toBe(true);
+    });
+
+    it('should return true when superAdmin marks any notification as read', async () => {
+      (isSuperAdmin as jest.Mock).mockReturnValue(true);
+      (isAdmin as jest.Mock).mockReturnValue(false);
+      const mockNotification = buildMockNotification({ affiliationId: casual.url });
+      (AdminNotification.findById as jest.Mock).mockResolvedValue({
+        ...mockNotification,
+        markAsRead: jest.fn().mockResolvedValue(mockNotification),
+      });
+
+      const result = await executeQuery(query, { id: mockNotification.id }, superAdminToken);
+
+      expect(result.body.singleResult.data.markNotificationAsRead).toBe(true);
+    });
+
+    it('should return NotFound when notification does not exist', async () => {
+      (AdminNotification.findById as jest.Mock).mockResolvedValue(null);
+
+      const result = await executeQuery(query, { id: 999 }, adminToken);
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toBe('AdminNotification with ID 999 not found');
+    });
+
+    it('should return Forbidden when an admin tries to mark another affiliations notification', async () => {
+      const mockNotification = buildMockNotification({ affiliationId: 'https://ror.org/different' });
+      (AdminNotification.findById as jest.Mock).mockResolvedValue({
+        ...mockNotification,
+        markAsRead: jest.fn(),
+      });
+
+      const result = await executeQuery(query, { id: mockNotification.id }, adminToken);
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toBe('Forbidden');
+    });
+
+    it('should return false when markAsRead returns null', async () => {
+      (isSuperAdmin as jest.Mock).mockReturnValue(false);
+      (isAdmin as jest.Mock).mockReturnValue(true);
+      const mockNotification = buildMockNotification({ affiliationId });
+      (AdminNotification.findById as jest.Mock).mockResolvedValue({
+        ...mockNotification,
+        markAsRead: jest.fn().mockResolvedValue(null),
+      });
+
+      const result = await executeQuery(query, { id: mockNotification.id }, adminToken);
+
+      expect(result.body.singleResult.data.markNotificationAsRead).toBe(false);
+    });
+
+    it('should return InternalServerError when findById throws', async () => {
+      (AdminNotification.findById as jest.Mock).mockRejectedValue(new Error('DB error'));
+
+      const result = await executeQuery(query, { id: 1 }, adminToken);
+
+      expect(result.body.singleResult.errors[0].message).toBe('Something went wrong');
+    });
+  });
+
+  describe('Mutation.markNotificationAsUnRead', () => {
+    const query = `
+      mutation markNotificationAsUnRead($id: Int!) {
+        markNotificationAsUnRead(id: $id)
+      }
+    `;
+
+    it('should mark a notification as unread and return true', async () => {
+      (isSuperAdmin as jest.Mock).mockReturnValue(false);
+      (isAdmin as jest.Mock).mockReturnValue(true);
+      const mockNotification = buildMockNotification({ affiliationId });
+      (AdminNotification.findById as jest.Mock).mockResolvedValue({
+        ...mockNotification,
+        markAsUnRead: jest.fn().mockResolvedValue(mockNotification),
+      });
+
+      const result = await executeQuery(query, { id: mockNotification.id }, adminToken);
+
+      expect(result.body.singleResult.data.markNotificationAsUnRead).toBe(true);
+    });
+
+    it('should return NotFound when notification does not exist', async () => {
+      (AdminNotification.findById as jest.Mock).mockResolvedValue(null);
+
+      const result = await executeQuery(query, { id: 999 }, adminToken);
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toBe('AdminNotification with ID 999 not found');
+    });
+
+    it('should return Forbidden when an admin tries to unread another affiliations notification', async () => {
+      const mockNotification = buildMockNotification({ affiliationId: 'https://ror.org/different' });
+      (AdminNotification.findById as jest.Mock).mockResolvedValue({
+        ...mockNotification,
+        markAsUnRead: jest.fn(),
+      });
+
+      const result = await executeQuery(query, { id: mockNotification.id }, adminToken);
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].message).toBe('Forbidden');
+    });
+
+    it('should return false when markAsUnRead returns null', async () => {
+      (isSuperAdmin as jest.Mock).mockReturnValue(false);
+      (isAdmin as jest.Mock).mockReturnValue(true);
+      const mockNotification = buildMockNotification({ affiliationId });
+      (AdminNotification.findById as jest.Mock).mockResolvedValue({
+        ...mockNotification,
+        markAsUnRead: jest.fn().mockResolvedValue(null),
+      });
+
+      const result = await executeQuery(query, { id: mockNotification.id }, adminToken);
+
+      expect(result.body.singleResult.data.markNotificationAsUnRead).toBe(false);
+    });
+
+    it('should return InternalServerError when findById throws', async () => {
+      (AdminNotification.findById as jest.Mock).mockRejectedValue(new Error('DB error'));
+
+      const result = await executeQuery(query, { id: 1 }, adminToken);
+
+      expect(result.body.singleResult.errors[0].message).toBe('Something went wrong');
+    });
+  });
+
+  // ─── Chained resolvers ─────────────────────────────────────────────────────
+
+  describe('AdminNotificationResults chained resolvers', () => {
+    const query = `
+      query adminNotificationsUnread {
+        adminNotificationsUnread {
+          items {
+            id
+            plan { id title }
+            template { id name }
+            templateCustomization { id templateName }
+            feedback { id messageToOrg }
+            createdBy { id givenName surName }
+          }
+        }
+      }
+    `;
+
+    it('should resolve plan when metadata contains planId', async () => {
+      const planId = casual.integer(1, 999);
+      const mockPlan = { id: planId, title: 'My Plan' };
+      const mockNotification = buildMockNotification({ metadata: { planId } });
+
+      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+        buildPaginatedResult([mockNotification])
+      );
+      jest.spyOn(Plan, 'findById').mockResolvedValue(mockPlan as any);
+
+      const result = await executeQuery(query, {}, adminToken);
+
+      expect(result.body.singleResult.data.adminNotificationsUnread.items[0].plan.id).toBe(planId);
+      expect(Plan.findById).toHaveBeenCalledWith(
+        'Chained AdminNotificationResults.plan',
+        expect.any(Object),
+        planId
+      );
+    });
+
+    it('should return null for plan when metadata has no planId', async () => {
+      const mockNotification = buildMockNotification({ metadata: {} });
+      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+        buildPaginatedResult([mockNotification])
+      );
+
+      const result = await executeQuery(query, {}, adminToken);
+
+      expect(result.body.singleResult.data.adminNotificationsUnread.items[0].plan).toBeNull();
+      expect(Plan.findById).not.toHaveBeenCalled();
+    });
+
+    it('should resolve template when metadata contains templateId', async () => {
+      const templateId = casual.integer(1, 999);
+      const mockTemplate = { id: templateId, name: 'My Template' };
+      const mockNotification = buildMockNotification({ metadata: { templateId } });
+
+      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+        buildPaginatedResult([mockNotification])
+      );
+      jest.spyOn(Template, 'findById').mockResolvedValue(mockTemplate as any);
+
+      const result = await executeQuery(query, {}, adminToken);
+
+      expect(result.body.singleResult.data.adminNotificationsUnread.items[0].template.id).toBe(templateId);
+      expect(Template.findById).toHaveBeenCalledWith(
+        'Chained AdminNotificationResults.template',
+        expect.any(Object),
+        templateId
+      );
+    });
+
+    it('should return null for template when metadata has no templateId', async () => {
+      const mockNotification = buildMockNotification({ metadata: {} });
+      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+        buildPaginatedResult([mockNotification])
+      );
+
+      const result = await executeQuery(query, {}, adminToken);
+
+      expect(result.body.singleResult.data.adminNotificationsUnread.items[0].template).toBeNull();
+      expect(Template.findById).not.toHaveBeenCalled();
+    });
+
+    it('should resolve templateCustomization when metadata contains templateCustomizationId', async () => {
+      const templateCustomizationId = casual.integer(1, 999);
+      const mockCustomization = { id: templateCustomizationId, templateName: 'My Template' };
+      const mockNotification = buildMockNotification({ metadata: { templateCustomizationId } });
+
+      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+        buildPaginatedResult([mockNotification])
+      );
+      jest.spyOn(TemplateCustomization, 'findByIdWithTemplateName').mockResolvedValue(mockCustomization as any);
+
+      const result = await executeQuery(query, {}, adminToken);
+
+      expect(result.body.singleResult.data.adminNotificationsUnread.items[0].templateCustomization.id).toBe(templateCustomizationId);
+      expect(TemplateCustomization.findByIdWithTemplateName).toHaveBeenCalledWith(
+        'Chained AdminNotificationResults.templateCustomization',
+        expect.any(Object),
+        templateCustomizationId
+      );
+    });
+
+    it('should return null for templateCustomization when metadata has no templateCustomizationId', async () => {
+      const mockNotification = buildMockNotification({ metadata: {} });
+      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+        buildPaginatedResult([mockNotification])
+      );
+
+      const result = await executeQuery(query, {}, adminToken);
+
+      expect(result.body.singleResult.data.adminNotificationsUnread.items[0].templateCustomization).toBeNull();
+      expect(TemplateCustomization.findByIdWithTemplateName).not.toHaveBeenCalled();
+    });
+
+    it('should resolve feedback when metadata contains planId', async () => {
+      const planId = casual.integer(1, 999);
+      const mockFeedback = { id: casual.integer(1, 999), messageToOrg: 'Please review', completed: null };
+      const mockNotification = buildMockNotification({ metadata: { planId } });
+
+      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+        buildPaginatedResult([mockNotification])
+      );
+      jest.spyOn(Plan, 'findById').mockResolvedValue({ id: planId, title: 'Plan' } as any);
+      jest.spyOn(PlanFeedback, 'findByPlanId').mockResolvedValue([mockFeedback] as any);
+
+      const result = await executeQuery(query, {}, adminToken);
+
+      expect(result.body.singleResult.data.adminNotificationsUnread.items[0].feedback.messageToOrg).toBe('Please review');
+      expect(PlanFeedback.findByPlanId).toHaveBeenCalledWith(
+        'Chained AdminNotificationResults.feedback',
+        expect.any(Object),
+        planId
+      );
+    });
+
+    it('should return null for feedback when all feedback rounds are completed', async () => {
+      const planId = casual.integer(1, 999);
+      const completedFeedback = { id: casual.integer(1, 999), messageToOrg: 'Done', completed: new Date().toISOString() };
+      const mockNotification = buildMockNotification({ metadata: { planId } });
+
+      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+        buildPaginatedResult([mockNotification])
+      );
+      jest.spyOn(Plan, 'findById').mockResolvedValue({ id: planId, title: 'Plan' } as any);
+      jest.spyOn(PlanFeedback, 'findByPlanId').mockResolvedValue([completedFeedback] as any);
+
+      const result = await executeQuery(query, {}, adminToken);
+
+      expect(result.body.singleResult.data.adminNotificationsUnread.items[0].feedback).toBeNull();
+    });
+
+    it('should resolve createdBy when createdById is set', async () => {
+      const createdById = casual.integer(1, 999);
+      const mockUser = { id: createdById, givenName: 'Jane', surName: 'Doe' };
+      const mockNotification = buildMockNotification({ createdById });
+
+      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+        buildPaginatedResult([mockNotification])
+      );
+      jest.spyOn(User, 'findById').mockResolvedValue(mockUser as any);
+
+      const result = await executeQuery(query, {}, adminToken);
+
+      expect(result.body.singleResult.data.adminNotificationsUnread.items[0].createdBy.givenName).toBe('Jane');
+      expect(User.findById).toHaveBeenCalledWith(
+        'Chained AdminNotificationResults.createdBy',
+        expect.any(Object),
+        createdById
+      );
+    });
+
+    it('should return null for createdBy when createdById is not set', async () => {
+      const mockNotification = buildMockNotification({ createdById: null });
+      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+        buildPaginatedResult([mockNotification])
+      );
+
+      const result = await executeQuery(query, {}, adminToken);
+
+      expect(result.body.singleResult.data.adminNotificationsUnread.items[0].createdBy).toBeNull();
+      expect(User.findById).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/resolvers/__tests__/adminNotifications.spec.ts
+++ b/src/resolvers/__tests__/adminNotifications.spec.ts
@@ -28,9 +28,9 @@ jest.mock('../../datasources/cache');
 
 jest.mock('../../models/AdminNotifications', () => ({
   AdminNotificationResults: {
-    findReadByAffiliationId: jest.fn(),
-    findUnreadByAffiliationId: jest.fn(),
-    findByAffiliationId: jest.fn(),
+    findReadByUserId: jest.fn(),
+    findUnreadByUserId: jest.fn(),
+    findByUserId: jest.fn(),
   },
   AdminNotification: Object.assign(
     jest.fn().mockImplementation(() => ({
@@ -145,7 +145,7 @@ describe('adminNotification resolver', () => {
 
     it('should return unread notifications for an admin', async () => {
       const mockNotification = buildMockNotification({ isRead: false });
-      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+      (AdminNotificationResults.findUnreadByUserId as jest.Mock).mockResolvedValue(
         buildPaginatedResult([mockNotification])
       );
 
@@ -153,33 +153,16 @@ describe('adminNotification resolver', () => {
 
       expect(result.body.singleResult.data.adminNotificationsUnread.totalCount).toBe(1);
       expect(result.body.singleResult.data.adminNotificationsUnread.items[0].isRead).toBe(false);
-      expect(AdminNotificationResults.findUnreadByAffiliationId).toHaveBeenCalledWith(
+      expect(AdminNotificationResults.findUnreadByUserId).toHaveBeenCalledWith(
         'unreadAdminNotifications resolver',
         expect.any(Object),
-        affiliationId,
-        undefined
-      );
-    });
-
-    it('should pass null affiliationId for superAdmin', async () => {
-      (isSuperAdmin as jest.Mock).mockReturnValue(true);
-      (isAdmin as jest.Mock).mockReturnValue(false);
-      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
-        buildPaginatedResult([])
-      );
-
-      await executeQuery(query, {}, superAdminToken);
-
-      expect(AdminNotificationResults.findUnreadByAffiliationId).toHaveBeenCalledWith(
-        'unreadAdminNotifications resolver',
-        expect.any(Object),
-        null,
+        adminToken.id,
         undefined
       );
     });
 
     it('should return an InternalServerError when the query throws', async () => {
-      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockRejectedValue(
+      (AdminNotificationResults.findUnreadByUserId as jest.Mock).mockRejectedValue(
         new Error('DB failure')
       );
 
@@ -207,7 +190,7 @@ describe('adminNotification resolver', () => {
 
     it('should return read notifications for an admin', async () => {
       const mockNotification = buildMockNotification({ isRead: true });
-      (AdminNotificationResults.findReadByAffiliationId as jest.Mock).mockResolvedValue(
+      (AdminNotificationResults.findReadByUserId as jest.Mock).mockResolvedValue(
         buildPaginatedResult([mockNotification])
       );
 
@@ -215,33 +198,16 @@ describe('adminNotification resolver', () => {
 
       expect(result.body.singleResult.data.adminNotificationsRead.totalCount).toBe(1);
       expect(result.body.singleResult.data.adminNotificationsRead.items[0].isRead).toBe(true);
-      expect(AdminNotificationResults.findReadByAffiliationId).toHaveBeenCalledWith(
+      expect(AdminNotificationResults.findReadByUserId).toHaveBeenCalledWith(
         'adminNotifications resolver',
         expect.any(Object),
-        affiliationId,
-        undefined
-      );
-    });
-
-    it('should pass null affiliationId for superAdmin', async () => {
-      (isSuperAdmin as jest.Mock).mockReturnValue(true);
-      (isAdmin as jest.Mock).mockReturnValue(false);
-      (AdminNotificationResults.findReadByAffiliationId as jest.Mock).mockResolvedValue(
-        buildPaginatedResult([])
-      );
-
-      await executeQuery(query, {}, superAdminToken);
-
-      expect(AdminNotificationResults.findReadByAffiliationId).toHaveBeenCalledWith(
-        'adminNotifications resolver',
-        expect.any(Object),
-        null,
+        adminToken.id,
         undefined
       );
     });
 
     it('should return an InternalServerError when the query throws', async () => {
-      (AdminNotificationResults.findReadByAffiliationId as jest.Mock).mockRejectedValue(
+      (AdminNotificationResults.findReadByUserId as jest.Mock).mockRejectedValue(
         new Error('DB failure')
       );
 
@@ -272,7 +238,7 @@ describe('adminNotification resolver', () => {
         buildMockNotification({ isRead: false }),
         buildMockNotification({ isRead: true }),
       ];
-      (AdminNotificationResults.findByAffiliationId as jest.Mock).mockResolvedValue(
+      (AdminNotificationResults.findByUserId as jest.Mock).mockResolvedValue(
         buildPaginatedResult(items, 2)
       );
 
@@ -282,7 +248,7 @@ describe('adminNotification resolver', () => {
     });
 
     it('should return an InternalServerError when the query throws', async () => {
-      (AdminNotificationResults.findByAffiliationId as jest.Mock).mockRejectedValue(
+      (AdminNotificationResults.findByUserId as jest.Mock).mockRejectedValue(
         new Error('DB failure')
       );
 
@@ -290,74 +256,6 @@ describe('adminNotification resolver', () => {
 
       expect(result.body.singleResult.errors).toBeDefined();
       expect(result.body.singleResult.errors[0].message).toBe('DB failure');
-    });
-  });
-
-  // ─── Mutations ─────────────────────────────────────────────────────────────
-
-  describe('Mutation.addAdminNotification', () => {
-    let input: any;
-    beforeEach(() => {
-      input = {
-        notificationType: 'FEEDBACK_REQUESTED',
-        affiliationId,
-        metadata: { planId: 1 },
-      };
-    });
-    const query = `
-      mutation addAdminNotification($input: AdminNotificationOptions!) {
-        addAdminNotification(input: $input) {
-          id
-          notificationType
-          errors {
-            general
-          }
-        }
-      }
-    `;
-
-    it('should create and return a new notification', async () => {
-      const mockCreated = buildMockNotification({ id: 99 });
-      (AdminNotification as unknown as jest.Mock).mockImplementation(() => ({
-        create: jest.fn().mockResolvedValue(mockCreated),
-        errors: {},
-        addError: jest.fn(),
-      }));
-
-      const result = await executeQuery(query, { input }, adminToken);
-
-      expect(result.body.singleResult.data.addAdminNotification.id).toBe(99);
-    });
-
-    it('should add a general error when create returns no id', async () => {
-      const notificationInstance = {
-        create: jest.fn().mockResolvedValue({ id: null, errors: {} }),
-        errors: {},
-        addError: jest.fn(),
-      };
-      (AdminNotification as unknown as jest.Mock).mockImplementation(() => notificationInstance);
-
-      const result = await executeQuery(query, { input }, adminToken);
-
-      expect(result.body.singleResult.errors).toBeUndefined();
-      expect(notificationInstance.addError).toHaveBeenCalledWith('general', 'Unable to create AdminNotification');
-    });
-
-    it('should return Forbidden when the caller is not authorized', async () => {
-      const result = await executeQuery(query, { input }, researcherToken);
-      expect(result.body.singleResult.errors).toBeDefined();
-    });
-
-    it('should return InternalServerError when create throws', async () => {
-      (AdminNotification as unknown as jest.Mock).mockImplementation(() => ({
-        create: jest.fn().mockRejectedValue(new Error('DB error')),
-        errors: {},
-        addError: jest.fn(),
-      }));
-
-      const result = await executeQuery(query, { input }, adminToken);
-
-      expect(result.body.singleResult.errors[0].message).toBe('DB error');
     });
   });
 
@@ -372,27 +270,13 @@ describe('adminNotification resolver', () => {
       (isSuperAdmin as jest.Mock).mockReturnValue(false);
       (isAdmin as jest.Mock).mockReturnValue(true);
 
-      const mockNotification = buildMockNotification({ affiliationId });
+      const mockNotification = buildMockNotification({ userId: adminToken.id });
       (AdminNotification.findById as jest.Mock).mockResolvedValue({
         ...mockNotification,
         markAsRead: jest.fn().mockResolvedValue(mockNotification),
       });
 
       const result = await executeQuery(query, { id: mockNotification.id }, adminToken);
-
-      expect(result.body.singleResult.data.markNotificationAsRead).toBe(true);
-    });
-
-    it('should return true when superAdmin marks any notification as read', async () => {
-      (isSuperAdmin as jest.Mock).mockReturnValue(true);
-      (isAdmin as jest.Mock).mockReturnValue(false);
-      const mockNotification = buildMockNotification({ affiliationId: casual.url });
-      (AdminNotification.findById as jest.Mock).mockResolvedValue({
-        ...mockNotification,
-        markAsRead: jest.fn().mockResolvedValue(mockNotification),
-      });
-
-      const result = await executeQuery(query, { id: mockNotification.id }, superAdminToken);
 
       expect(result.body.singleResult.data.markNotificationAsRead).toBe(true);
     });
@@ -407,7 +291,7 @@ describe('adminNotification resolver', () => {
     });
 
     it('should return Forbidden when an admin tries to mark another affiliations notification', async () => {
-      const mockNotification = buildMockNotification({ affiliationId: 'https://ror.org/different' });
+      const mockNotification = buildMockNotification({ userId: 999 });
       (AdminNotification.findById as jest.Mock).mockResolvedValue({
         ...mockNotification,
         markAsRead: jest.fn(),
@@ -422,7 +306,7 @@ describe('adminNotification resolver', () => {
     it('should return false when markAsRead returns null', async () => {
       (isSuperAdmin as jest.Mock).mockReturnValue(false);
       (isAdmin as jest.Mock).mockReturnValue(true);
-      const mockNotification = buildMockNotification({ affiliationId });
+      const mockNotification = buildMockNotification({ userId: adminToken.id });
       (AdminNotification.findById as jest.Mock).mockResolvedValue({
         ...mockNotification,
         markAsRead: jest.fn().mockResolvedValue(null),
@@ -452,7 +336,7 @@ describe('adminNotification resolver', () => {
     it('should mark a notification as unread and return true', async () => {
       (isSuperAdmin as jest.Mock).mockReturnValue(false);
       (isAdmin as jest.Mock).mockReturnValue(true);
-      const mockNotification = buildMockNotification({ affiliationId });
+      const mockNotification = buildMockNotification({ userId: adminToken.id });
       (AdminNotification.findById as jest.Mock).mockResolvedValue({
         ...mockNotification,
         markAsUnRead: jest.fn().mockResolvedValue(mockNotification),
@@ -473,7 +357,7 @@ describe('adminNotification resolver', () => {
     });
 
     it('should return Forbidden when an admin tries to unread another affiliations notification', async () => {
-      const mockNotification = buildMockNotification({ affiliationId: 'https://ror.org/different' });
+      const mockNotification = buildMockNotification({ userId: 999 });
       (AdminNotification.findById as jest.Mock).mockResolvedValue({
         ...mockNotification,
         markAsUnRead: jest.fn(),
@@ -488,7 +372,7 @@ describe('adminNotification resolver', () => {
     it('should return false when markAsUnRead returns null', async () => {
       (isSuperAdmin as jest.Mock).mockReturnValue(false);
       (isAdmin as jest.Mock).mockReturnValue(true);
-      const mockNotification = buildMockNotification({ affiliationId });
+      const mockNotification = buildMockNotification({ userId: adminToken.id });
       (AdminNotification.findById as jest.Mock).mockResolvedValue({
         ...mockNotification,
         markAsUnRead: jest.fn().mockResolvedValue(null),
@@ -531,7 +415,7 @@ describe('adminNotification resolver', () => {
       const mockPlan = { id: planId, title: 'My Plan' };
       const mockNotification = buildMockNotification({ metadata: { planId } });
 
-      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+      (AdminNotificationResults.findUnreadByUserId as jest.Mock).mockResolvedValue(
         buildPaginatedResult([mockNotification])
       );
       jest.spyOn(Plan, 'findById').mockResolvedValue(mockPlan as any);
@@ -548,7 +432,7 @@ describe('adminNotification resolver', () => {
 
     it('should return null for plan when metadata has no planId', async () => {
       const mockNotification = buildMockNotification({ metadata: {} });
-      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+      (AdminNotificationResults.findUnreadByUserId as jest.Mock).mockResolvedValue(
         buildPaginatedResult([mockNotification])
       );
 
@@ -563,7 +447,7 @@ describe('adminNotification resolver', () => {
       const mockTemplate = { id: templateId, name: 'My Template' };
       const mockNotification = buildMockNotification({ metadata: { templateId } });
 
-      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+      (AdminNotificationResults.findUnreadByUserId as jest.Mock).mockResolvedValue(
         buildPaginatedResult([mockNotification])
       );
       jest.spyOn(Template, 'findById').mockResolvedValue(mockTemplate as any);
@@ -580,7 +464,7 @@ describe('adminNotification resolver', () => {
 
     it('should return null for template when metadata has no templateId', async () => {
       const mockNotification = buildMockNotification({ metadata: {} });
-      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+      (AdminNotificationResults.findUnreadByUserId as jest.Mock).mockResolvedValue(
         buildPaginatedResult([mockNotification])
       );
 
@@ -595,7 +479,7 @@ describe('adminNotification resolver', () => {
       const mockCustomization = { id: templateCustomizationId, templateName: 'My Template' };
       const mockNotification = buildMockNotification({ metadata: { templateCustomizationId } });
 
-      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+      (AdminNotificationResults.findUnreadByUserId as jest.Mock).mockResolvedValue(
         buildPaginatedResult([mockNotification])
       );
       jest.spyOn(TemplateCustomization, 'findByIdWithTemplateName').mockResolvedValue(mockCustomization as any);
@@ -612,7 +496,7 @@ describe('adminNotification resolver', () => {
 
     it('should return null for templateCustomization when metadata has no templateCustomizationId', async () => {
       const mockNotification = buildMockNotification({ metadata: {} });
-      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+      (AdminNotificationResults.findUnreadByUserId as jest.Mock).mockResolvedValue(
         buildPaginatedResult([mockNotification])
       );
 
@@ -627,7 +511,7 @@ describe('adminNotification resolver', () => {
       const mockFeedback = { id: casual.integer(1, 999), messageToOrg: 'Please review', completed: null };
       const mockNotification = buildMockNotification({ metadata: { planId } });
 
-      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+      (AdminNotificationResults.findUnreadByUserId as jest.Mock).mockResolvedValue(
         buildPaginatedResult([mockNotification])
       );
       jest.spyOn(Plan, 'findById').mockResolvedValue({ id: planId, title: 'Plan' } as any);
@@ -648,7 +532,7 @@ describe('adminNotification resolver', () => {
       const completedFeedback = { id: casual.integer(1, 999), messageToOrg: 'Done', completed: new Date().toISOString() };
       const mockNotification = buildMockNotification({ metadata: { planId } });
 
-      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+      (AdminNotificationResults.findUnreadByUserId as jest.Mock).mockResolvedValue(
         buildPaginatedResult([mockNotification])
       );
       jest.spyOn(Plan, 'findById').mockResolvedValue({ id: planId, title: 'Plan' } as any);
@@ -664,7 +548,7 @@ describe('adminNotification resolver', () => {
       const mockUser = { id: createdById, givenName: 'Jane', surName: 'Doe' };
       const mockNotification = buildMockNotification({ createdById });
 
-      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+      (AdminNotificationResults.findUnreadByUserId as jest.Mock).mockResolvedValue(
         buildPaginatedResult([mockNotification])
       );
       jest.spyOn(User, 'findById').mockResolvedValue(mockUser as any);
@@ -681,7 +565,7 @@ describe('adminNotification resolver', () => {
 
     it('should return null for createdBy when createdById is not set', async () => {
       const mockNotification = buildMockNotification({ createdById: null });
-      (AdminNotificationResults.findUnreadByAffiliationId as jest.Mock).mockResolvedValue(
+      (AdminNotificationResults.findUnreadByUserId as jest.Mock).mockResolvedValue(
         buildPaginatedResult([mockNotification])
       );
 

--- a/src/resolvers/__tests__/templateCustomization.spec.ts
+++ b/src/resolvers/__tests__/templateCustomization.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import casual from "casual";
 import { ApolloServer } from "@apollo/server";
 import { typeDefs } from "../../schema";
@@ -8,6 +9,8 @@ import { VersionedTemplate } from '../../models/VersionedTemplate';
 import { logger } from "../../logger";
 import { JWTAccessToken } from "../../services/tokenService";
 import { UserRole } from "../../models/User";
+import { Affiliation } from '../../models/Affiliation';
+import { AdminNotification } from '../../models/AdminNotifications';
 import {
   TemplateCustomization,
   TemplateCustomizationMigrationStatus,
@@ -42,12 +45,10 @@ let adminToken: JWTAccessToken;
 let query: string;
 
 // Proxy call to the Apollo server test server
-async function executeQuery (
+async function executeQuery(
   query: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   variables: any,
   token: JWTAccessToken
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> {
   const context = buildContext(logger, token, null);
 
@@ -407,18 +408,23 @@ describe('templateCustomization resolvers', () => {
     it('should publish template customization successfully when status is DRAFT', async () => {
       const draftCustomization = {
         ...mockCustomization,
-        status: TemplateCustomizationStatus.DRAFT
+        status: TemplateCustomizationStatus.DRAFT,
+        publish: jest.fn().mockResolvedValue(mockCustomization),
       } as unknown as TemplateCustomization;
-      (getValidatedCustomization as jest.Mock) = jest.fn().mockResolvedValue(draftCustomization);
-      (mockCustomization.publish as jest.Mock).mockResolvedValue(mockCustomization);
+
+      (getValidatedCustomization as jest.Mock).mockResolvedValue(draftCustomization);
       (TemplateCustomizationOverview.generateOverview as jest.Mock).mockResolvedValue(mockCustomizationOverview);
+
+      jest.spyOn(Affiliation, 'findByURI').mockResolvedValue({ uri: affiliationId } as any);
+
+      const mockCreate = jest.fn().mockResolvedValue({ id: 1 });
+      jest.spyOn(AdminNotification.prototype, 'create').mockImplementation(mockCreate);
 
       const input = { templateCustomizationId: 1 };
       const result = await executeQuery(query, input, adminToken);
 
       expect(result.body.kind).toEqual('single');
       expect(result.body.singleResult.errors).toBeUndefined();
-      expect(result.body.singleResult.data.publishTemplateCustomization).toBeTruthy();
       expect(result.body.singleResult.data.publishTemplateCustomization.customizationId).toEqual(mockCustomizationOverview.customizationId);
       expect(draftCustomization.publish).toHaveBeenCalledWith(expect.any(Object));
     });

--- a/src/resolvers/adminNotifications.ts
+++ b/src/resolvers/adminNotifications.ts
@@ -1,0 +1,219 @@
+import { Resolvers } from "../types";
+import { MyContext } from '../context';
+import {
+  AdminNotificationResults,
+  AdminNotification,
+  AdminNotificationOptions,
+} from '../models/AdminNotifications';
+import { Plan } from '../models/Plan';
+import { Template } from '../models/Template';
+import { PlanFeedback } from '../models/PlanFeedback';
+import { User } from '../models/User';
+import {
+  authenticatedResolver,
+  isAdmin,
+  isSuperAdmin,
+} from "../services/authService";
+import {
+  ForbiddenError,
+  InternalServerError,
+  NotFoundError
+} from "../utils/graphQLErrors";
+import { prepareObjectForLogs } from "../logger";
+import { GraphQLError } from "graphql";
+import { UserRole } from "../models/User";
+import { PaginatedQueryResults, PaginationOptions } from "../types/general";
+import { TemplateCustomization } from "../models/TemplateCustomization";
+
+export const resolvers: Resolvers = {
+  Query: {
+    adminNotificationsRead: authenticatedResolver(
+      'adminNotifications resolver',
+      UserRole.ADMIN,
+      async (
+        _: Record<PropertyKey, never>,
+        { paginationOptions }: { paginationOptions: PaginationOptions },
+        context: MyContext
+      ): Promise<PaginatedQueryResults<AdminNotificationResults>> => {
+        const reference = 'adminNotifications resolver';
+        // SuperAdmins get all notifications in the response, and Admins get notifications filtered by their affiliation
+        const affiliationId = isSuperAdmin(context.token) ? null : context.token.affiliationId;
+        return await AdminNotificationResults.findReadByAffiliationId(
+          reference,
+          context,
+          affiliationId,
+          paginationOptions
+        );
+      }
+    ),
+
+    adminNotificationsUnread: authenticatedResolver(
+      'unreadAdminNotifications resolver',
+      UserRole.ADMIN,
+      async (
+        _: Record<PropertyKey, never>,
+        { paginationOptions }: { paginationOptions: PaginationOptions },
+        context: MyContext
+      ): Promise<PaginatedQueryResults<AdminNotificationResults>> => {
+        const reference = 'unreadAdminNotifications resolver';
+        // SuperAdmins get all notifications in the response, and Admins get notifications filtered by their affiliation
+        const affiliationId = isSuperAdmin(context.token) ? null : context.token.affiliationId;
+
+        return await AdminNotificationResults.findUnreadByAffiliationId(
+          reference,
+          context,
+          affiliationId,
+          paginationOptions
+        );
+      }
+    ),
+    adminNotifications: authenticatedResolver(
+      'unreadAdminNotifications resolver',
+      UserRole.ADMIN,
+      async (
+        _: Record<PropertyKey, never>,
+        { paginationOptions }: { paginationOptions: PaginationOptions },
+        context: MyContext
+      ): Promise<PaginatedQueryResults<AdminNotificationResults>> => {
+        const reference = 'unreadAdminNotifications resolver';
+        // SuperAdmins get all notifications in the response, and Admins get notifications filtered by their affiliation
+        const affiliationId = isSuperAdmin(context.token) ? null : context.token.affiliationId;
+
+        return await AdminNotificationResults.findByAffiliationId(
+          reference,
+          context,
+          affiliationId,
+          paginationOptions
+        );
+      }
+    ),
+  },
+
+  Mutation: {
+    addAdminNotification: authenticatedResolver(
+      'addAdminNotification resolver',
+      UserRole.ADMIN,
+      async (
+        _: Record<PropertyKey, never>,
+        { input }: { input: AdminNotificationOptions },
+        context: MyContext
+      ): Promise<AdminNotification> => {
+        if (!isSuperAdmin(context.token) && context.token.affiliationId !== input.affiliationId) {
+          throw ForbiddenError();
+        }
+
+        const notification = new AdminNotification(input);
+        const created = await notification.create(context);
+
+        if (created?.id) {
+          return created;
+        }
+
+        if (!notification.errors['general']) {
+          notification.addError('general', 'Unable to create AdminNotification');
+        }
+        return notification;
+      }
+    ),
+    markNotificationAsRead: authenticatedResolver(
+      'markNotificationAsRead resolver',
+      UserRole.ADMIN,
+      async (
+        _: Record<PropertyKey, never>,
+        { id }: { id: number },
+        context: MyContext
+      ): Promise<boolean> => {
+        const reference = 'markNotificationAsRead resolver';
+        try {
+          const notification = await AdminNotification.findById(reference, context, id);
+
+          if (!notification) {
+            throw NotFoundError(`AdminNotification with ID ${id} not found`);
+          }
+
+          if (isSuperAdmin(context.token) || (isAdmin(context.token) && context.token.affiliationId === notification.affiliationId)) {
+            const updated = await notification.markAsRead(context);
+            return updated !== null;
+          }
+          throw ForbiddenError();
+        } catch (err) {
+          if (err instanceof GraphQLError) throw err;
+          context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
+          throw InternalServerError();
+        }
+      }
+    ),
+
+    markNotificationAsUnRead: authenticatedResolver(
+      'markNotificationAsUnRead resolver',
+      UserRole.ADMIN,
+      async (
+        _: Record<PropertyKey, never>,
+        { id }: { id: number },
+        context: MyContext
+      ): Promise<boolean> => {
+        const reference = 'markNotificationAsUnRead resolver';
+        try {
+          const notification = await AdminNotification.findById(reference, context, id);
+
+          if (!notification) {
+            throw NotFoundError(`AdminNotification with ID ${id} not found`);
+          }
+
+          if (isSuperAdmin(context.token) || (isAdmin(context.token) && context.token.affiliationId === notification.affiliationId)) {
+            const updated = await notification.markAsUnRead(context);
+            return updated !== null;
+          }
+          throw ForbiddenError();
+        } catch (err) {
+          if (err instanceof GraphQLError) throw err;
+          context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
+          throw InternalServerError();
+        }
+      }
+    ),
+  },
+  AdminNotificationResults: {
+    // Fetch the plan associated with the notification if metadata contains a planId
+    plan: async (parent: AdminNotificationResults, _, context: MyContext): Promise<Plan | null> => {
+      if (parent.metadata?.planId) {
+        return await Plan.findById('Chained AdminNotificationResults.plan', context, parent.metadata.planId);
+      }
+      return null;
+    },
+
+    // Fetch the template associated with the notification if metadata contains a templateId
+    template: async (parent: AdminNotificationResults, _, context: MyContext): Promise<Template | null> => {
+      if (parent.metadata?.templateId) {
+        return await Template.findById('Chained AdminNotificationResults.template', context, parent.metadata.templateId);
+      }
+      return null;
+    },
+
+    // Fetch the templateCustomization associated with the notification if metadata contains a templateCustomizationId
+    templateCustomization: async (parent: AdminNotificationResults, _, context: MyContext): Promise<TemplateCustomization | null> => {
+      if (parent.metadata?.templateCustomizationId) {
+        return await TemplateCustomization.findByIdWithTemplateName('Chained AdminNotificationResults.templateCustomization', context, parent.metadata.templateCustomizationId);
+      }
+      return null;
+    },
+
+    // Fetch the feedback associated with the plan if metadata contains a planId
+    feedback: async (parent: AdminNotificationResults, _, context: MyContext): Promise<PlanFeedback | null> => {
+      if (parent.metadata?.planId) {
+        const feedbackList = await PlanFeedback.findByPlanId('Chained AdminNotificationResults.feedback', context, parent.metadata.planId);
+        // Return the most recent open feedback round
+        return feedbackList.find(fb => fb.completed === null) ?? null;
+      }
+      return null;
+    },
+
+    // Fetch the user who created the notification
+    createdBy: async (parent: AdminNotificationResults, _, context: MyContext): Promise<User | null> => {
+      if (parent.createdById) {
+        return await User.findById('Chained AdminNotificationResults.createdBy', context, parent.createdById);
+      }
+      return null;
+    },
+  },
+};

--- a/src/resolvers/adminNotifications.ts
+++ b/src/resolvers/adminNotifications.ts
@@ -3,7 +3,6 @@ import { MyContext } from '../context';
 import {
   AdminNotificationResults,
   AdminNotification,
-  AdminNotificationOptions,
 } from '../models/AdminNotifications';
 import { Plan } from '../models/Plan';
 import { Template } from '../models/Template';
@@ -11,8 +10,6 @@ import { PlanFeedback } from '../models/PlanFeedback';
 import { User } from '../models/User';
 import {
   authenticatedResolver,
-  isAdmin,
-  isSuperAdmin,
 } from "../services/authService";
 import {
   ForbiddenError,
@@ -36,14 +33,8 @@ export const resolvers: Resolvers = {
         context: MyContext
       ): Promise<PaginatedQueryResults<AdminNotificationResults>> => {
         const reference = 'adminNotifications resolver';
-        // SuperAdmins get all notifications in the response, and Admins get notifications filtered by their affiliation
-        const affiliationId = isSuperAdmin(context.token) ? null : context.token.affiliationId;
-        return await AdminNotificationResults.findReadByAffiliationId(
-          reference,
-          context,
-          affiliationId,
-          paginationOptions
-        );
+        const userId = context.token.id;
+        return await AdminNotificationResults.findReadByUserId(reference, context, userId, paginationOptions)
       }
     ),
 
@@ -56,19 +47,18 @@ export const resolvers: Resolvers = {
         context: MyContext
       ): Promise<PaginatedQueryResults<AdminNotificationResults>> => {
         const reference = 'unreadAdminNotifications resolver';
-        // SuperAdmins get all notifications in the response, and Admins get notifications filtered by their affiliation
-        const affiliationId = isSuperAdmin(context.token) ? null : context.token.affiliationId;
+        const userId = context.token.id;
 
-        return await AdminNotificationResults.findUnreadByAffiliationId(
+        return await AdminNotificationResults.findUnreadByUserId(
           reference,
           context,
-          affiliationId,
+          userId,
           paginationOptions
         );
       }
     ),
     adminNotifications: authenticatedResolver(
-      'unreadAdminNotifications resolver',
+      'adminNotifications resolver',
       UserRole.ADMIN,
       async (
         _: Record<PropertyKey, never>,
@@ -76,13 +66,12 @@ export const resolvers: Resolvers = {
         context: MyContext
       ): Promise<PaginatedQueryResults<AdminNotificationResults>> => {
         const reference = 'unreadAdminNotifications resolver';
-        // SuperAdmins get all notifications in the response, and Admins get notifications filtered by their affiliation
-        const affiliationId = isSuperAdmin(context.token) ? null : context.token.affiliationId;
+        const userId = context.token.id;
 
-        return await AdminNotificationResults.findByAffiliationId(
+        return await AdminNotificationResults.findByUserId(
           reference,
           context,
-          affiliationId,
+          userId,
           paginationOptions
         );
       }
@@ -90,31 +79,6 @@ export const resolvers: Resolvers = {
   },
 
   Mutation: {
-    addAdminNotification: authenticatedResolver(
-      'addAdminNotification resolver',
-      UserRole.ADMIN,
-      async (
-        _: Record<PropertyKey, never>,
-        { input }: { input: AdminNotificationOptions },
-        context: MyContext
-      ): Promise<AdminNotification> => {
-        if (!isSuperAdmin(context.token) && context.token.affiliationId !== input.affiliationId) {
-          throw ForbiddenError();
-        }
-
-        const notification = new AdminNotification(input);
-        const created = await notification.create(context);
-
-        if (created?.id) {
-          return created;
-        }
-
-        if (!notification.errors['general']) {
-          notification.addError('general', 'Unable to create AdminNotification');
-        }
-        return notification;
-      }
-    ),
     markNotificationAsRead: authenticatedResolver(
       'markNotificationAsRead resolver',
       UserRole.ADMIN,
@@ -131,7 +95,7 @@ export const resolvers: Resolvers = {
             throw NotFoundError(`AdminNotification with ID ${id} not found`);
           }
 
-          if (isSuperAdmin(context.token) || (isAdmin(context.token) && context.token.affiliationId === notification.affiliationId)) {
+          if (context.token.id === notification.userId) {
             const updated = await notification.markAsRead(context);
             return updated !== null;
           }
@@ -160,7 +124,7 @@ export const resolvers: Resolvers = {
             throw NotFoundError(`AdminNotification with ID ${id} not found`);
           }
 
-          if (isSuperAdmin(context.token) || (isAdmin(context.token) && context.token.affiliationId === notification.affiliationId)) {
+          if (context.token.id === notification.userId) {
             const updated = await notification.markAsUnRead(context);
             return updated !== null;
           }

--- a/src/resolvers/feedback.ts
+++ b/src/resolvers/feedback.ts
@@ -25,6 +25,7 @@ import { ProjectCollaborator, ProjectCollaboratorAccessLevel } from "../models/C
 import { PlanFeedbackComment } from "../models/PlanFeedbackComment";
 import { VersionedTemplate } from "../models/VersionedTemplate";
 import { Affiliation } from "../models/Affiliation";
+import { AdminNotification } from "../models/AdminNotifications";
 import { ResolversParentTypes } from "../types";
 import { Resolvers, PlanFeedbackStatus } from "../types";
 import { getCurrentDate } from "../utils/helpers";
@@ -204,7 +205,19 @@ export const resolvers: Resolvers = {
             // Send emails to the feedback recipients
             await sendFeedbackRequestEmail(context, planOwnerName, planURL, planTitle, affiliation.feedbackEmails, messageToOrg ?? '');
 
-            return await feedbackComment.create(context);
+            const createdFeedback = await feedbackComment.create(context);
+
+            // Notify all org admins of the feedback request
+            if (createdFeedback?.id) {
+              const notification = new AdminNotification({
+                notificationType: 'FEEDBACK_REQUESTED',
+                affiliationId: affiliation.uri,
+                metadata: { planId },
+              });
+              await notification.create(context);
+            }
+
+            return createdFeedback;
           }
         }
         throw context?.token ? ForbiddenError() : AuthenticationError();

--- a/src/resolvers/feedback.ts
+++ b/src/resolvers/feedback.ts
@@ -209,12 +209,13 @@ export const resolvers: Resolvers = {
 
             // Notify all org admins of the feedback request
             if (createdFeedback?.id) {
-              const notification = new AdminNotification({
-                notificationType: 'FEEDBACK_REQUESTED',
-                affiliationId: affiliation.uri,
-                metadata: { planId },
-              });
-              await notification.create(context);
+              await AdminNotification.addNotificationForAffiliation(
+                reference,
+                context,
+                affiliation.uri,
+                'FEEDBACK_REQUESTED',
+                { planId },
+              );
             }
 
             return createdFeedback;

--- a/src/resolvers/template.ts
+++ b/src/resolvers/template.ts
@@ -27,6 +27,7 @@ import { isNullOrUndefined, normaliseDateTime } from "../utils/helpers";
 import {
   handleFunderTemplateArchive
 } from "../services/templateCustomizationService";
+import { AdminNotification } from "../models/AdminNotifications";
 
 export const resolvers: Resolvers = {
   Query: {
@@ -36,8 +37,8 @@ export const resolvers: Resolvers = {
       try {
         if (isAdmin(context.token)) {
           const opts = !isNullOrUndefined(paginationOptions) && paginationOptions.type === PaginationType.OFFSET
-                      ? paginationOptions as PaginationOptionsForOffsets
-                      : { ...paginationOptions, type: PaginationType.CURSOR } as PaginationOptionsForCursors;
+            ? paginationOptions as PaginationOptionsForOffsets
+            : { ...paginationOptions, type: PaginationType.CURSOR } as PaginationOptionsForCursors;
 
           return await TemplateSearchResult.findByAffiliationIdAndTerm(
             reference,
@@ -149,6 +150,18 @@ export const resolvers: Resolvers = {
 
           // Create new template
           const newTemplate = await template.create(context);
+
+          // Notify all org admins of the new template
+          if (newTemplate?.id) {
+            const notification = new AdminNotification({
+              notificationType: 'TEMPLATE_CREATED',
+              affiliationId: context.token.affiliationId,
+              metadata: { templateId: newTemplate.id },
+            });
+            await notification.create(context);
+          }
+
+
           const templateId = newTemplate.id;
 
           // Add generic error

--- a/src/resolvers/template.ts
+++ b/src/resolvers/template.ts
@@ -153,12 +153,13 @@ export const resolvers: Resolvers = {
 
           // Notify all org admins of the new template
           if (newTemplate?.id) {
-            const notification = new AdminNotification({
-              notificationType: 'TEMPLATE_CREATED',
-              affiliationId: context.token.affiliationId,
-              metadata: { templateId: newTemplate.id },
-            });
-            await notification.create(context);
+            await AdminNotification.addNotificationForAffiliation(
+              reference,
+              context,
+              context.token.affiliationId,
+              'TEMPLATE_CREATED',
+              { templateId: newTemplate.id },
+            );
           }
 
 

--- a/src/resolvers/templateCustomization.ts
+++ b/src/resolvers/templateCustomization.ts
@@ -245,12 +245,14 @@ export const resolvers: Resolvers = {
 
           // Notify all org admins when customization changes are published
           if (published?.id) {
-            const notification = new AdminNotification({
-              notificationType: 'TEMPLATE_CUSTOMIZATION_CHANGED',
-              affiliationId: affiliation.uri,
-              metadata: { templateCustomizationId: published.id }
-            });
-            await notification.create(context);
+            await AdminNotification.addNotificationForAffiliation(
+              reference,
+              context,
+              affiliation.uri,
+              'TEMPLATE_CUSTOMIZATION_CHANGED',
+              { templateCustomizationId: published.id }
+            );
+
           }
           // Transfer any errors
           overview.errors = published.errors;

--- a/src/resolvers/templateCustomization.ts
+++ b/src/resolvers/templateCustomization.ts
@@ -6,6 +6,7 @@ import {
 import { authenticatedResolver } from "../services/authService";
 import { MyContext } from "../context";
 import { VersionedTemplate } from "../models/VersionedTemplate";
+import { AdminNotification } from "../models/AdminNotifications";
 import { isNullOrUndefined, normaliseDateTime } from "../utils/helpers";
 import {
   TemplateCustomization, TemplateCustomizationOverview,
@@ -14,6 +15,7 @@ import {
 import { getValidatedCustomization } from "../services/templateCustomizationService";
 import { NotFoundError } from "../utils/graphQLErrors";
 import { UserRole } from "../models/User";
+import { Affiliation } from "../models/Affiliation";
 
 export const resolvers: Resolvers = {
   Query: {
@@ -38,25 +40,25 @@ export const resolvers: Resolvers = {
         { templateCustomizationId }: { templateCustomizationId: number },
         context: MyContext
       ): Promise<TemplateCustomizationOverview | null> => {
-      const reference = 'templateCustomization resolver';
+        const reference = 'templateCustomization resolver';
 
-      const customization: TemplateCustomizationOverview = await TemplateCustomizationOverview.generateOverview(
-        reference,
-        context,
-        templateCustomizationId
-      );
-      if (!customization) throw NotFoundError();
+        const customization: TemplateCustomizationOverview = await TemplateCustomizationOverview.generateOverview(
+          reference,
+          context,
+          templateCustomizationId
+        );
+        if (!customization) throw NotFoundError();
 
-      // Find the parent template customization and verify the user has access.
-      // This will throw a forbidden error if they do not.
-      await getValidatedCustomization(
-        reference,
-        context,
-        templateCustomizationId
-      );
+        // Find the parent template customization and verify the user has access.
+        // This will throw a forbidden error if they do not.
+        await getValidatedCustomization(
+          reference,
+          context,
+          templateCustomizationId
+        );
 
-      return customization;
-    }),
+        return customization;
+      }),
   },
 
   Mutation: {
@@ -80,41 +82,41 @@ export const resolvers: Resolvers = {
         { input }: { input: AddTemplateCustomizationInput },
         context: MyContext
       ): Promise<TemplateCustomizationOverview | null> => {
-      const reference = 'addTemplateCustomization resolver';
-      const { versionedTemplateId, status } = input;
+        const reference = 'addTemplateCustomization resolver';
+        const { versionedTemplateId, status } = input;
 
-      // Fetch the versioned funder template
-      const versionedTemplate: VersionedTemplate = await VersionedTemplate.findById(
-        reference,
-        context,
-        versionedTemplateId
-      );
-      if (!versionedTemplate) throw NotFoundError();
-
-      const customization = new TemplateCustomization({
-        affiliationId: context.token.affiliationId,
-        templateId: versionedTemplate.templateId,
-        currentVersionedTemplateId: versionedTemplate.id,
-        status
-      });
-
-      // Save the new template customization
-      const created: TemplateCustomization = await customization.create(context);
-
-      // If there were no problems, then generate the overview and return it
-      if (!isNullOrUndefined(created)) {
-        const overview: TemplateCustomizationOverview = await TemplateCustomizationOverview.generateOverview(
+        // Fetch the versioned funder template
+        const versionedTemplate: VersionedTemplate = await VersionedTemplate.findById(
           reference,
           context,
-          created.id
+          versionedTemplateId
         );
+        if (!versionedTemplate) throw NotFoundError();
 
-        // Transfer any errors encountered during the creation to the Overview
-        overview.errors = created.errors;
-        return overview;
-      }
-      return undefined;
-    }),
+        const customization = new TemplateCustomization({
+          affiliationId: context.token.affiliationId,
+          templateId: versionedTemplate.templateId,
+          currentVersionedTemplateId: versionedTemplate.id,
+          status
+        });
+
+        // Save the new template customization
+        const created: TemplateCustomization = await customization.create(context);
+
+        // If there were no problems, then generate the overview and return it
+        if (!isNullOrUndefined(created)) {
+          const overview: TemplateCustomizationOverview = await TemplateCustomizationOverview.generateOverview(
+            reference,
+            context,
+            created.id
+          );
+
+          // Transfer any errors encountered during the creation to the Overview
+          overview.errors = created.errors;
+          return overview;
+        }
+        return undefined;
+      }),
 
     /**
      * ADMIN ONLY: Update the specified TemplateCustomization
@@ -136,33 +138,33 @@ export const resolvers: Resolvers = {
         { input }: { input: UpdateTemplateCustomizationInput },
         context: MyContext
       ): Promise<TemplateCustomizationOverview | null> => {
-      const reference = 'updateTemplateCustomization resolver';
-      const { templateCustomizationId, status } = input;
+        const reference = 'updateTemplateCustomization resolver';
+        const { templateCustomizationId, status } = input;
 
-      const customization: TemplateCustomization = await getValidatedCustomization(
-        reference,
-        context,
-        templateCustomizationId
-      );
-      if (!customization) throw NotFoundError();
-
-      // Update the customization
-      customization.status = TemplateCustomizationStatus[status];
-      const updated: TemplateCustomization = await customization.update(context);
-
-      if (!isNullOrUndefined(updated)) {
-        const overview: TemplateCustomizationOverview = await TemplateCustomizationOverview.generateOverview(
+        const customization: TemplateCustomization = await getValidatedCustomization(
           reference,
           context,
-          updated.id
+          templateCustomizationId
         );
+        if (!customization) throw NotFoundError();
 
-        // Transfer any errors encountered during the update to the Overview
-        overview.errors = updated.errors;
-        return overview;
-      }
-      return undefined;
-    }),
+        // Update the customization
+        customization.status = TemplateCustomizationStatus[status];
+        const updated: TemplateCustomization = await customization.update(context);
+
+        if (!isNullOrUndefined(updated)) {
+          const overview: TemplateCustomizationOverview = await TemplateCustomizationOverview.generateOverview(
+            reference,
+            context,
+            updated.id
+          );
+
+          // Transfer any errors encountered during the update to the Overview
+          overview.errors = updated.errors;
+          return overview;
+        }
+        return undefined;
+      }),
 
     /**
      * ADMIN ONLY: Delete the specified TemplateCustomization
@@ -176,7 +178,7 @@ export const resolvers: Resolvers = {
      * @throws UnauthorizedError when the JWT token is not present
      * @throws InternalServerError when a fatal error has occurred
      */
-        removeTemplateCustomization: authenticatedResolver(
+    removeTemplateCustomization: authenticatedResolver(
       'removeTemplateCustomization resolver',
       UserRole.ADMIN,
       async (
@@ -184,17 +186,17 @@ export const resolvers: Resolvers = {
         { templateCustomizationId }: { templateCustomizationId: number },
         context: MyContext
       ): Promise<TemplateCustomization> => {
-      const reference = 'removeTemplateCustomization resolver';
+        const reference = 'removeTemplateCustomization resolver';
 
-      const customization: TemplateCustomization = await getValidatedCustomization(
-        reference,
-        context,
-        templateCustomizationId
-      );
-      if (!customization) throw NotFoundError();
+        const customization: TemplateCustomization = await getValidatedCustomization(
+          reference,
+          context,
+          templateCustomizationId
+        );
+        if (!customization) throw NotFoundError();
 
-      return await customization.delete(context);
-    }),
+        return await customization.delete(context);
+      }),
 
     /**
      * ADMIN ONLY: Publish the specified TemplateCustomization
@@ -216,29 +218,46 @@ export const resolvers: Resolvers = {
         { templateCustomizationId }: { templateCustomizationId: number },
         context: MyContext
       ): Promise<TemplateCustomizationOverview | null> => {
-      const reference = 'publishTemplateCustomization resolver';
+        const reference = 'publishTemplateCustomization resolver';
 
-      const customization: TemplateCustomization = await getValidatedCustomization(
-        reference,
-        context,
-        templateCustomizationId
-      );
-      if (!customization) throw NotFoundError();
-
-      const published: TemplateCustomization = await customization.publish(context);
-
-      if (!isNullOrUndefined(published)) {
-        const overview: TemplateCustomizationOverview = await TemplateCustomizationOverview.generateOverview(
+        const customization: TemplateCustomization = await getValidatedCustomization(
           reference,
           context,
-          published.id
+          templateCustomizationId
         );
-        // Transfer any errors
-        overview.errors = published.errors;
-        return overview;
-      }
-      return undefined;
-    }),
+        if (!customization) throw NotFoundError();
+
+        const published: TemplateCustomization = await customization.publish(context);
+
+        if (!isNullOrUndefined(published)) {
+          const overview: TemplateCustomizationOverview = await TemplateCustomizationOverview.generateOverview(
+            reference,
+            context,
+            published.id
+          );
+
+          const affiliationId = context.token.affiliationId;
+          if (!affiliationId) {
+            throw NotFoundError(`Affiliation for user not found`);
+          }
+
+          const affiliation = await Affiliation.findByURI(reference, context, affiliationId);
+
+          // Notify all org admins when customization changes are published
+          if (published?.id) {
+            const notification = new AdminNotification({
+              notificationType: 'TEMPLATE_CUSTOMIZATION_CHANGED',
+              affiliationId: affiliation.uri,
+              metadata: { templateCustomizationId: published.id }
+            });
+            await notification.create(context);
+          }
+          // Transfer any errors
+          overview.errors = published.errors;
+          return overview;
+        }
+        return undefined;
+      }),
 
     /**
      * ADMIN ONLY: Unpublish the specified TemplateCustomization
@@ -260,28 +279,28 @@ export const resolvers: Resolvers = {
         { templateCustomizationId }: { templateCustomizationId: number },
         context: MyContext
       ): Promise<TemplateCustomizationOverview | null> => {
-      const reference = 'unpublishTemplateCustomization resolver';
-      const customization: TemplateCustomization = await getValidatedCustomization(
-        reference,
-        context,
-        templateCustomizationId
-      );
-      if (!customization) throw NotFoundError();
-
-      const unpublished: TemplateCustomization = await customization.unpublish(context);
-
-      if (!isNullOrUndefined(unpublished)) {
-        const overview: TemplateCustomizationOverview = await TemplateCustomizationOverview.generateOverview(
+        const reference = 'unpublishTemplateCustomization resolver';
+        const customization: TemplateCustomization = await getValidatedCustomization(
           reference,
           context,
-          unpublished.id
+          templateCustomizationId
         );
-        // Transfer any errors
-        overview.errors = unpublished.errors;
-        return overview;
-      }
-      return undefined;
-    }),
+        if (!customization) throw NotFoundError();
+
+        const unpublished: TemplateCustomization = await customization.unpublish(context);
+
+        if (!isNullOrUndefined(unpublished)) {
+          const overview: TemplateCustomizationOverview = await TemplateCustomizationOverview.generateOverview(
+            reference,
+            context,
+            unpublished.id
+          );
+          // Transfer any errors
+          overview.errors = unpublished.errors;
+          return overview;
+        }
+        return undefined;
+      }),
   },
 
   TemplateCustomization: {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,6 +1,7 @@
 import { mergeTypeDefs } from '@graphql-tools/merge';
 
 import { typeDefs as baseTypeDefs } from './schemas/base';
+import { typeDefs as adminNotificationTypeDefs } from './schemas/adminNotifications';
 import { typeDefs as affiliationTypeDefs } from './schemas/affiliation';
 import { typeDefs as answerTypeDefs } from './schemas/answer';
 import { typeDefs as collaboratorTypeDefs } from './schemas/collaborator';
@@ -37,7 +38,7 @@ import { typeDefs as versionedTemplateTypeDefs } from './schemas/versionedTempla
 
 export const typeDefs = mergeTypeDefs([
   baseTypeDefs,
-
+  adminNotificationTypeDefs,
   affiliationTypeDefs,
   answerTypeDefs,
   collaboratorTypeDefs,

--- a/src/schemas/adminNotifications.ts
+++ b/src/schemas/adminNotifications.ts
@@ -1,0 +1,112 @@
+import gql from "graphql-tag";
+
+export const typeDefs = gql`
+  extend type Query {
+    "Retrieve all read notifications for a specific affiliation"
+    adminNotificationsRead(paginationOptions: PaginationOptions): AdminNotificationResultsPage
+    "Retrieve all unread notifications for a specific affiliation"
+    adminNotificationsUnread(paginationOptions: PaginationOptions): AdminNotificationResultsPage
+    "Retrieve all notifications for a specific affiliation"
+    adminNotifications(paginationOptions: PaginationOptions): AdminNotificationResultsPage
+  }
+
+  extend type Mutation {
+    "Create a new admin notification"
+    addAdminNotification(input: AdminNotificationOptions!): AdminNotificationResults!
+    "Mark a notification as read"
+    markNotificationAsRead(id: Int!): Boolean!
+    "Mark a notification as unread"
+    markNotificationAsUnRead(id: Int!): Boolean!
+  }
+
+  input AdminNotificationOptions {
+    "The type of notification"
+    notificationType: AdminNotificationType!
+    "Additional data providing the associated Ids for the notification"
+    metadata: AdminNotificationMetadataInput
+    "The affiliation associated with the notification"
+    affiliationId: String!
+    "Whether the notification has been read"
+    isRead: Boolean
+  }
+
+  type AdminNotificationMetadata {
+    "The associated plan Id for the notification, if applicable"
+    planId: Int
+    "The associated template Id for the notification, if applicable"
+    templateId: Int
+    "The associated template customization Id for the notification, if applicable"
+    templateCustomizationId: Int
+  }
+
+  input AdminNotificationMetadataInput {
+    "The associated plan Id for the notification, if applicable"
+    planId: Int
+    "The associated template Id for the notification, if applicable"
+    templateId: Int
+    "The associated template customization Id for the notification, if applicable"
+    templateCustomizationId: Int
+  }
+
+    type AdminNotificationResultsPage {
+      items: [AdminNotificationResults!]!
+      totalCount: Int
+      hasNextPage: Boolean!
+      hasPreviousPage: Boolean
+      currentOffset: Int
+      nextCursor: String
+    }
+
+
+  type AdminNotificationResults {
+    "The unique identifer for the Object"
+    id: Int
+    "The user who created the Object"
+    createdById: Int
+    "The timestamp when the Object was created"
+    created: String
+    "The user who last modified the Object"
+    modifiedById: Int
+    "The timestamp when the Object was last modifed"
+    modified: String
+    "Errors associated with the Object"
+    errors: AdminNotificationErrors
+
+    "The notification type"
+    notificationType: AdminNotificationType
+    "Additional data providing the associated Ids for the notification"
+    metadata: AdminNotificationMetadata
+    "The affiliation associated with the notification"
+    affiliationId: String
+    "Whether the notification has been read"
+    isRead: Boolean
+
+    "The plan associated with the notification if metadata contains a planId"
+    plan: Plan
+    "The template associated with the notification if metadata contains a templateId"
+    template: Template
+    "The template customization associated with the notification if metadata contains a templateCustomizationId"
+    templateCustomization: TemplateCustomization
+    "The feedback associated with the plan if metadata contains a planId"
+    feedback: PlanFeedback
+    "The user who created the notification"
+    createdBy: User
+    }
+
+  "A collection of errors related to the Section"
+  type AdminNotificationErrors {
+    "General error messages such as the object already exists"
+    general: String
+  }
+
+
+  "The types of notifications for Admin Notification"
+  enum AdminNotificationType {
+    "When feedback is requested on a plan"
+    FEEDBACK_REQUESTED
+    "When a template is created"
+    TEMPLATE_CREATED
+    "When customization to a template has changed"
+    TEMPLATE_CUSTOMIZATION_CHANGED
+  }
+`;

--- a/src/schemas/adminNotifications.ts
+++ b/src/schemas/adminNotifications.ts
@@ -11,23 +11,10 @@ export const typeDefs = gql`
   }
 
   extend type Mutation {
-    "Create a new admin notification"
-    addAdminNotification(input: AdminNotificationOptions!): AdminNotificationResults!
     "Mark a notification as read"
     markNotificationAsRead(id: Int!): Boolean!
     "Mark a notification as unread"
     markNotificationAsUnRead(id: Int!): Boolean!
-  }
-
-  input AdminNotificationOptions {
-    "The type of notification"
-    notificationType: AdminNotificationType!
-    "Additional data providing the associated Ids for the notification"
-    metadata: AdminNotificationMetadataInput
-    "The affiliation associated with the notification"
-    affiliationId: String!
-    "Whether the notification has been read"
-    isRead: Boolean
   }
 
   type AdminNotificationMetadata {
@@ -48,14 +35,14 @@ export const typeDefs = gql`
     templateCustomizationId: Int
   }
 
-    type AdminNotificationResultsPage {
-      items: [AdminNotificationResults!]!
-      totalCount: Int
-      hasNextPage: Boolean!
-      hasPreviousPage: Boolean
-      currentOffset: Int
-      nextCursor: String
-    }
+  type AdminNotificationResultsPage {
+    items: [AdminNotificationResults!]!
+    totalCount: Int
+    hasNextPage: Boolean!
+    hasPreviousPage: Boolean
+    currentOffset: Int
+    nextCursor: String
+  }
 
 
   type AdminNotificationResults {
@@ -80,6 +67,8 @@ export const typeDefs = gql`
     affiliationId: String
     "Whether the notification has been read"
     isRead: Boolean
+    "The userId of the user associated with the notification"
+    userId: Int
 
     "The plan associated with the notification if metadata contains a planId"
     plan: Plan

--- a/src/schemas/templateCustomization.ts
+++ b/src/schemas/templateCustomization.ts
@@ -74,6 +74,8 @@ export const typeDefs = gql`
     latestPublishedDate: String
     "Whether the customization has been modified since it was last published"
     isDirty: Boolean!
+    "The name of the parent template, included for convenience when fetching a customization with its template name"
+    templateName: String
   }
 
   "A collection of errors related to the Template Customization"

--- a/src/types.ts
+++ b/src/types.ts
@@ -284,6 +284,96 @@ export type AddTemplateCustomizationInput = {
   versionedTemplateId: Scalars['Int']['input'];
 };
 
+/** A collection of errors related to the Section */
+export type AdminNotificationErrors = {
+  __typename?: 'AdminNotificationErrors';
+  /** General error messages such as the object already exists */
+  general?: Maybe<Scalars['String']['output']>;
+};
+
+export type AdminNotificationMetadata = {
+  __typename?: 'AdminNotificationMetadata';
+  /** The associated plan Id for the notification, if applicable */
+  planId?: Maybe<Scalars['Int']['output']>;
+  /** The associated template customization Id for the notification, if applicable */
+  templateCustomizationId?: Maybe<Scalars['Int']['output']>;
+  /** The associated template Id for the notification, if applicable */
+  templateId?: Maybe<Scalars['Int']['output']>;
+};
+
+export type AdminNotificationMetadataInput = {
+  /** The associated plan Id for the notification, if applicable */
+  planId?: InputMaybe<Scalars['Int']['input']>;
+  /** The associated template customization Id for the notification, if applicable */
+  templateCustomizationId?: InputMaybe<Scalars['Int']['input']>;
+  /** The associated template Id for the notification, if applicable */
+  templateId?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type AdminNotificationOptions = {
+  /** The affiliation associated with the notification */
+  affiliationId: Scalars['String']['input'];
+  /** Whether the notification has been read */
+  isRead?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Additional data providing the associated Ids for the notification */
+  metadata?: InputMaybe<AdminNotificationMetadataInput>;
+  /** The type of notification */
+  notificationType: AdminNotificationType;
+};
+
+export type AdminNotificationResults = {
+  __typename?: 'AdminNotificationResults';
+  /** The affiliation associated with the notification */
+  affiliationId?: Maybe<Scalars['String']['output']>;
+  /** The timestamp when the Object was created */
+  created?: Maybe<Scalars['String']['output']>;
+  /** The user who created the notification */
+  createdBy?: Maybe<User>;
+  /** The user who created the Object */
+  createdById?: Maybe<Scalars['Int']['output']>;
+  /** Errors associated with the Object */
+  errors?: Maybe<AdminNotificationErrors>;
+  /** The feedback associated with the plan if metadata contains a planId */
+  feedback?: Maybe<PlanFeedback>;
+  /** The unique identifer for the Object */
+  id?: Maybe<Scalars['Int']['output']>;
+  /** Whether the notification has been read */
+  isRead?: Maybe<Scalars['Boolean']['output']>;
+  /** Additional data providing the associated Ids for the notification */
+  metadata?: Maybe<AdminNotificationMetadata>;
+  /** The timestamp when the Object was last modifed */
+  modified?: Maybe<Scalars['String']['output']>;
+  /** The user who last modified the Object */
+  modifiedById?: Maybe<Scalars['Int']['output']>;
+  /** The notification type */
+  notificationType?: Maybe<AdminNotificationType>;
+  /** The plan associated with the notification if metadata contains a planId */
+  plan?: Maybe<Plan>;
+  /** The template associated with the notification if metadata contains a templateId */
+  template?: Maybe<Template>;
+  /** The template customization associated with the notification if metadata contains a templateCustomizationId */
+  templateCustomization?: Maybe<TemplateCustomization>;
+};
+
+export type AdminNotificationResultsPage = {
+  __typename?: 'AdminNotificationResultsPage';
+  currentOffset?: Maybe<Scalars['Int']['output']>;
+  hasNextPage: Scalars['Boolean']['output'];
+  hasPreviousPage?: Maybe<Scalars['Boolean']['output']>;
+  items: Array<AdminNotificationResults>;
+  nextCursor?: Maybe<Scalars['String']['output']>;
+  totalCount?: Maybe<Scalars['Int']['output']>;
+};
+
+/** The types of notifications for Admin Notification */
+export type AdminNotificationType =
+  /** When feedback is requested on a plan */
+  | 'FEEDBACK_REQUESTED'
+  /** When a template is created */
+  | 'TEMPLATE_CREATED'
+  /** When customization to a template has changed */
+  | 'TEMPLATE_CUSTOMIZATION_CHANGED';
+
 /** A respresentation of an institution, organization or company */
 export type Affiliation = {
   __typename?: 'Affiliation';
@@ -1390,6 +1480,8 @@ export type Mutation = {
   _empty?: Maybe<Scalars['String']['output']>;
   /** Reactivate the specified user Account (Admin only) */
   activateUser?: Maybe<User>;
+  /** Create a new admin notification */
+  addAdminNotification: AdminNotificationResults;
   /** Create a new Affiliation */
   addAffiliation?: Maybe<Affiliation>;
   /** Assign an alternate identifier to the plan */
@@ -1478,6 +1570,10 @@ export type Mutation = {
   introduction?: Maybe<Scalars['String']['output']>;
   /** Designates the specified Template as the default (SuperAdmin only) */
   markAsDefaultTemplate?: Maybe<Template>;
+  /** Mark a notification as read */
+  markNotificationAsRead: Scalars['Boolean']['output'];
+  /** Mark a notification as unread */
+  markNotificationAsUnRead: Scalars['Boolean']['output'];
   /** Merge two licenses */
   mergeLicenses?: Maybe<License>;
   /** Merge two metadata standards */
@@ -1653,6 +1749,11 @@ export type Mutation = {
 
 export type MutationActivateUserArgs = {
   userId: Scalars['Int']['input'];
+};
+
+
+export type MutationAddAdminNotificationArgs = {
+  input: AdminNotificationOptions;
 };
 
 
@@ -1902,6 +2003,16 @@ export type MutationGenerateLogoUploadUrlArgs = {
 
 export type MutationMarkAsDefaultTemplateArgs = {
   templateId: Scalars['Int']['input'];
+};
+
+
+export type MutationMarkNotificationAsReadArgs = {
+  id: Scalars['Int']['input'];
+};
+
+
+export type MutationMarkNotificationAsUnReadArgs = {
+  id: Scalars['Int']['input'];
 };
 
 
@@ -3184,6 +3295,12 @@ export type PublishedTemplateSearchResults = PaginatedQueryResults & {
 export type Query = {
   __typename?: 'Query';
   _empty?: Maybe<Scalars['String']['output']>;
+  /** Retrieve all notifications for a specific affiliation */
+  adminNotifications?: Maybe<AdminNotificationResultsPage>;
+  /** Retrieve all read notifications for a specific affiliation */
+  adminNotificationsRead?: Maybe<AdminNotificationResultsPage>;
+  /** Retrieve all unread notifications for a specific affiliation */
+  adminNotificationsUnread?: Maybe<AdminNotificationResultsPage>;
   /** Retrieve a specific Affiliation by its ID */
   affiliationById?: Maybe<Affiliation>;
   /** Retrieve a specific Affiliation by its URI */
@@ -3379,6 +3496,21 @@ export type Query = {
   users?: Maybe<UserSearchResults>;
   /** Get all VersionedGuidance for a given affiliation and Tag IDs */
   versionedGuidance: Array<VersionedGuidance>;
+};
+
+
+export type QueryAdminNotificationsArgs = {
+  paginationOptions?: InputMaybe<PaginationOptions>;
+};
+
+
+export type QueryAdminNotificationsReadArgs = {
+  paginationOptions?: InputMaybe<PaginationOptions>;
+};
+
+
+export type QueryAdminNotificationsUnreadArgs = {
+  paginationOptions?: InputMaybe<PaginationOptions>;
 };
 
 
@@ -4689,6 +4821,8 @@ export type TemplateCustomization = {
   modifiedById?: Maybe<Scalars['Int']['output']>;
   /** The status of the customization */
   status: TemplateCustomizationStatus;
+  /** The name of the parent template, included for convenience when fetching a customization with its template name */
+  templateName?: Maybe<Scalars['String']['output']>;
 };
 
 /** A collection of errors related to the Template Customization */
@@ -5949,6 +6083,13 @@ export type ResolversTypes = {
   AddSectionCustomizationInput: AddSectionCustomizationInput;
   AddSectionInput: AddSectionInput;
   AddTemplateCustomizationInput: AddTemplateCustomizationInput;
+  AdminNotificationErrors: ResolverTypeWrapper<AdminNotificationErrors>;
+  AdminNotificationMetadata: ResolverTypeWrapper<AdminNotificationMetadata>;
+  AdminNotificationMetadataInput: AdminNotificationMetadataInput;
+  AdminNotificationOptions: AdminNotificationOptions;
+  AdminNotificationResults: ResolverTypeWrapper<AdminNotificationResults>;
+  AdminNotificationResultsPage: ResolverTypeWrapper<AdminNotificationResultsPage>;
+  AdminNotificationType: AdminNotificationType;
   Affiliation: ResolverTypeWrapper<Affiliation>;
   AffiliationEmailDomain: ResolverTypeWrapper<AffiliationEmailDomain>;
   AffiliationEmailDomainInput: AffiliationEmailDomainInput;
@@ -6199,6 +6340,12 @@ export type ResolversParentTypes = {
   AddSectionCustomizationInput: AddSectionCustomizationInput;
   AddSectionInput: AddSectionInput;
   AddTemplateCustomizationInput: AddTemplateCustomizationInput;
+  AdminNotificationErrors: AdminNotificationErrors;
+  AdminNotificationMetadata: AdminNotificationMetadata;
+  AdminNotificationMetadataInput: AdminNotificationMetadataInput;
+  AdminNotificationOptions: AdminNotificationOptions;
+  AdminNotificationResults: AdminNotificationResults;
+  AdminNotificationResultsPage: AdminNotificationResultsPage;
   Affiliation: Affiliation;
   AffiliationEmailDomain: AffiliationEmailDomain;
   AffiliationEmailDomainInput: AffiliationEmailDomainInput;
@@ -6401,6 +6548,43 @@ export type ResolversParentTypes = {
   VersionedTemplateSearchResult: VersionedTemplateSearchResult;
   Work: Work;
   WorkVersion: WorkVersion;
+};
+
+export type AdminNotificationErrorsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['AdminNotificationErrors'] = ResolversParentTypes['AdminNotificationErrors']> = {
+  general?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+};
+
+export type AdminNotificationMetadataResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['AdminNotificationMetadata'] = ResolversParentTypes['AdminNotificationMetadata']> = {
+  planId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  templateCustomizationId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  templateId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+};
+
+export type AdminNotificationResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['AdminNotificationResults'] = ResolversParentTypes['AdminNotificationResults']> = {
+  affiliationId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  createdBy?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+  createdById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  errors?: Resolver<Maybe<ResolversTypes['AdminNotificationErrors']>, ParentType, ContextType>;
+  feedback?: Resolver<Maybe<ResolversTypes['PlanFeedback']>, ParentType, ContextType>;
+  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  isRead?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  metadata?: Resolver<Maybe<ResolversTypes['AdminNotificationMetadata']>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  notificationType?: Resolver<Maybe<ResolversTypes['AdminNotificationType']>, ParentType, ContextType>;
+  plan?: Resolver<Maybe<ResolversTypes['Plan']>, ParentType, ContextType>;
+  template?: Resolver<Maybe<ResolversTypes['Template']>, ParentType, ContextType>;
+  templateCustomization?: Resolver<Maybe<ResolversTypes['TemplateCustomization']>, ParentType, ContextType>;
+};
+
+export type AdminNotificationResultsPageResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['AdminNotificationResultsPage'] = ResolversParentTypes['AdminNotificationResultsPage']> = {
+  currentOffset?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  hasNextPage?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  hasPreviousPage?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  items?: Resolver<Array<ResolversTypes['AdminNotificationResults']>, ParentType, ContextType>;
+  nextCursor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
 };
 
 export type AffiliationResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Affiliation'] = ResolversParentTypes['Affiliation']> = {
@@ -6946,6 +7130,7 @@ export type MetadataStandardSearchResultsResolvers<ContextType = MyContext, Pare
 export type MutationResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
   _empty?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   activateUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationActivateUserArgs, 'userId'>>;
+  addAdminNotification?: Resolver<ResolversTypes['AdminNotificationResults'], ParentType, ContextType, RequireFields<MutationAddAdminNotificationArgs, 'input'>>;
   addAffiliation?: Resolver<Maybe<ResolversTypes['Affiliation']>, ParentType, ContextType, RequireFields<MutationAddAffiliationArgs, 'input'>>;
   addAlternateIdentifierToPlan?: Resolver<Maybe<ResolversTypes['AlternateIdentifier']>, ParentType, ContextType, RequireFields<MutationAddAlternateIdentifierToPlanArgs, 'alternateIdentifier' | 'planId'>>;
   addAnswer?: Resolver<Maybe<ResolversTypes['Answer']>, ParentType, ContextType, RequireFields<MutationAddAnswerArgs, 'planId'>>;
@@ -6990,6 +7175,8 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   guidance?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   introduction?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   markAsDefaultTemplate?: Resolver<Maybe<ResolversTypes['Template']>, ParentType, ContextType, RequireFields<MutationMarkAsDefaultTemplateArgs, 'templateId'>>;
+  markNotificationAsRead?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationMarkNotificationAsReadArgs, 'id'>>;
+  markNotificationAsUnRead?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationMarkNotificationAsUnReadArgs, 'id'>>;
   mergeLicenses?: Resolver<Maybe<ResolversTypes['License']>, ParentType, ContextType, RequireFields<MutationMergeLicensesArgs, 'licenseToKeepId' | 'licenseToRemoveId'>>;
   mergeMetadataStandards?: Resolver<Maybe<ResolversTypes['MetadataStandard']>, ParentType, ContextType, RequireFields<MutationMergeMetadataStandardsArgs, 'metadataStandardToKeepId' | 'metadataStandardToRemoveId'>>;
   mergeRepositories?: Resolver<Maybe<ResolversTypes['CustomRepository']>, ParentType, ContextType, RequireFields<MutationMergeRepositoriesArgs, 'repositoryToKeepId' | 'repositoryToRemoveId'>>;
@@ -7495,6 +7682,9 @@ export type PublishedTemplateSearchResultsResolvers<ContextType = MyContext, Par
 
 export type QueryResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
   _empty?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  adminNotifications?: Resolver<Maybe<ResolversTypes['AdminNotificationResultsPage']>, ParentType, ContextType, Partial<QueryAdminNotificationsArgs>>;
+  adminNotificationsRead?: Resolver<Maybe<ResolversTypes['AdminNotificationResultsPage']>, ParentType, ContextType, Partial<QueryAdminNotificationsReadArgs>>;
+  adminNotificationsUnread?: Resolver<Maybe<ResolversTypes['AdminNotificationResultsPage']>, ParentType, ContextType, Partial<QueryAdminNotificationsUnreadArgs>>;
   affiliationById?: Resolver<Maybe<ResolversTypes['Affiliation']>, ParentType, ContextType, RequireFields<QueryAffiliationByIdArgs, 'affiliationId'>>;
   affiliationByURI?: Resolver<Maybe<ResolversTypes['Affiliation']>, ParentType, ContextType, RequireFields<QueryAffiliationByUriArgs, 'uri'>>;
   affiliationTypes?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
@@ -8019,6 +8209,7 @@ export type TemplateCustomizationResolvers<ContextType = MyContext, ParentType e
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   status?: Resolver<ResolversTypes['TemplateCustomizationStatus'], ParentType, ContextType>;
+  templateName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 };
 
 export type TemplateCustomizationErrorsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['TemplateCustomizationErrors'] = ResolversParentTypes['TemplateCustomizationErrors']> = {
@@ -8492,6 +8683,10 @@ export type WorkVersionResolvers<ContextType = MyContext, ParentType extends Res
 };
 
 export type Resolvers<ContextType = MyContext> = {
+  AdminNotificationErrors?: AdminNotificationErrorsResolvers<ContextType>;
+  AdminNotificationMetadata?: AdminNotificationMetadataResolvers<ContextType>;
+  AdminNotificationResults?: AdminNotificationResultsResolvers<ContextType>;
+  AdminNotificationResultsPage?: AdminNotificationResultsPageResolvers<ContextType>;
   Affiliation?: AffiliationResolvers<ContextType>;
   AffiliationEmailDomain?: AffiliationEmailDomainResolvers<ContextType>;
   AffiliationErrors?: AffiliationErrorsResolvers<ContextType>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -310,17 +310,6 @@ export type AdminNotificationMetadataInput = {
   templateId?: InputMaybe<Scalars['Int']['input']>;
 };
 
-export type AdminNotificationOptions = {
-  /** The affiliation associated with the notification */
-  affiliationId: Scalars['String']['input'];
-  /** Whether the notification has been read */
-  isRead?: InputMaybe<Scalars['Boolean']['input']>;
-  /** Additional data providing the associated Ids for the notification */
-  metadata?: InputMaybe<AdminNotificationMetadataInput>;
-  /** The type of notification */
-  notificationType: AdminNotificationType;
-};
-
 export type AdminNotificationResults = {
   __typename?: 'AdminNotificationResults';
   /** The affiliation associated with the notification */
@@ -353,6 +342,8 @@ export type AdminNotificationResults = {
   template?: Maybe<Template>;
   /** The template customization associated with the notification if metadata contains a templateCustomizationId */
   templateCustomization?: Maybe<TemplateCustomization>;
+  /** The userId of the user associated with the notification */
+  userId?: Maybe<Scalars['Int']['output']>;
 };
 
 export type AdminNotificationResultsPage = {
@@ -1480,8 +1471,6 @@ export type Mutation = {
   _empty?: Maybe<Scalars['String']['output']>;
   /** Reactivate the specified user Account (Admin only) */
   activateUser?: Maybe<User>;
-  /** Create a new admin notification */
-  addAdminNotification: AdminNotificationResults;
   /** Create a new Affiliation */
   addAffiliation?: Maybe<Affiliation>;
   /** Assign an alternate identifier to the plan */
@@ -1749,11 +1738,6 @@ export type Mutation = {
 
 export type MutationActivateUserArgs = {
   userId: Scalars['Int']['input'];
-};
-
-
-export type MutationAddAdminNotificationArgs = {
-  input: AdminNotificationOptions;
 };
 
 
@@ -6086,7 +6070,6 @@ export type ResolversTypes = {
   AdminNotificationErrors: ResolverTypeWrapper<AdminNotificationErrors>;
   AdminNotificationMetadata: ResolverTypeWrapper<AdminNotificationMetadata>;
   AdminNotificationMetadataInput: AdminNotificationMetadataInput;
-  AdminNotificationOptions: AdminNotificationOptions;
   AdminNotificationResults: ResolverTypeWrapper<AdminNotificationResults>;
   AdminNotificationResultsPage: ResolverTypeWrapper<AdminNotificationResultsPage>;
   AdminNotificationType: AdminNotificationType;
@@ -6343,7 +6326,6 @@ export type ResolversParentTypes = {
   AdminNotificationErrors: AdminNotificationErrors;
   AdminNotificationMetadata: AdminNotificationMetadata;
   AdminNotificationMetadataInput: AdminNotificationMetadataInput;
-  AdminNotificationOptions: AdminNotificationOptions;
   AdminNotificationResults: AdminNotificationResults;
   AdminNotificationResultsPage: AdminNotificationResultsPage;
   Affiliation: Affiliation;
@@ -6576,6 +6558,7 @@ export type AdminNotificationResultsResolvers<ContextType = MyContext, ParentTyp
   plan?: Resolver<Maybe<ResolversTypes['Plan']>, ParentType, ContextType>;
   template?: Resolver<Maybe<ResolversTypes['Template']>, ParentType, ContextType>;
   templateCustomization?: Resolver<Maybe<ResolversTypes['TemplateCustomization']>, ParentType, ContextType>;
+  userId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
 };
 
 export type AdminNotificationResultsPageResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['AdminNotificationResultsPage'] = ResolversParentTypes['AdminNotificationResultsPage']> = {
@@ -7130,7 +7113,6 @@ export type MetadataStandardSearchResultsResolvers<ContextType = MyContext, Pare
 export type MutationResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
   _empty?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   activateUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationActivateUserArgs, 'userId'>>;
-  addAdminNotification?: Resolver<ResolversTypes['AdminNotificationResults'], ParentType, ContextType, RequireFields<MutationAddAdminNotificationArgs, 'input'>>;
   addAffiliation?: Resolver<Maybe<ResolversTypes['Affiliation']>, ParentType, ContextType, RequireFields<MutationAddAffiliationArgs, 'input'>>;
   addAlternateIdentifierToPlan?: Resolver<Maybe<ResolversTypes['AlternateIdentifier']>, ParentType, ContextType, RequireFields<MutationAddAlternateIdentifierToPlanArgs, 'alternateIdentifier' | 'planId'>>;
   addAnswer?: Resolver<Maybe<ResolversTypes['Answer']>, ParentType, ContextType, RequireFields<MutationAddAnswerArgs, 'planId'>>;


### PR DESCRIPTION

## Description

- Added `adminNotifications` model, resolver and db table. 
- Added `findByIdWithTemplateName` method to `TemplateCustomization` model so that we can return the template name 
- Updated `requestFeedback`, `addTemplate` and `publishTemplateCustomization` resolvers to add a record to the `adminNotifications` table

Fixes # ([570](https://github.com/CDLUC3/dmptool-ui/issues/570))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested and with updated and new unit tests


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules
* Frontend changes will be in PR review shortly