### PR TITLE
fix bug in data migration to add research output question to default …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Update local migration to add RO question to default template
 - Updated `users` resolver to include `role` and `affiliationId` [#240]
 - Added `findByAffiliationId` and `search` to pass in `role` as optional [#240]
 - Added `findByUserId` to `Plan` model to find all plans for a given user [#240]

--- a/data-migrations/local-only/2026-06-22-0923-add-research-output-to-default-tmplt.sql
+++ b/data-migrations/local-only/2026-06-22-0923-add-research-output-to-default-tmplt.sql
@@ -22,17 +22,40 @@ VALUES (@default_template_id, @section_id, 1, 'Please list all research outputs 
 SET @question_id := LAST_INSERT_ID();
 
 -- Then generate/publish the new version
+SET @prior_versioned_template_id := (SELECT id FROM versionedTemplates WHERE templateId = @default_template_id AND active = 1);
 UPDATE versionedTemplates SET active = 0 WHERE templateId = @default_template_id AND active = 1;
 INSERT INTO versionedTemplates (templateId, active, version, versionType, versionedById, comment, name, description, ownerId, visibility, bestPractice, isDefault, languageId, created, createdById, modified, modifiedById)
   (SELECT id, 1, 'v3', 'PUBLISHED', createdById, 'Added a research output table question', name, description, ownerId, 'PUBLIC', bestPractice, isDefault, languageId, CURDATE(), createdById, CURDATE(), modifiedById
    FROM templates WHERE id = @default_template_id);
 SET @versioned_template_id := LAST_INSERT_ID();
 
+-- Make sure the new version has all the existing sections
+INSERT INTO versionedSections (versionedTemplateId, sectionId, name, introduction, requirements, guidance, displayOrder, bestPractice, created, createdById, modified, modifiedById)
+  (SELECT @versioned_template_id, sectionId, name, introduction, requirements, guidance, displayOrder, bestPractice, CURDATE(), createdById, CURDATE(), modifiedById
+   FROM versionedSections WHERE versionedTemplateId = @prior_versioned_template_id);
+
+-- Then add the new research output section
 INSERT INTO versionedSections (versionedTemplateId, sectionId, name, introduction, requirements, guidance, displayOrder, bestPractice, created, createdById, modified, modifiedById)
   (SELECT @versioned_template_id, id, name, introduction, requirements, guidance, displayOrder, bestPractice, CURDATE(), createdById, CURDATE(), modifiedById
    FROM sections WHERE id = @section_id);
 SET @versioned_section_id := LAST_INSERT_ID();
 
+-- Then make sure all the existing section tags and questions are copied across to the new version
+INSERT INTO versionedSectionTags (versionedSectionId, tagId, created, createdById, modified, modifiedById)
+  (SELECT newVSS.id, st.tagId, CURDATE(), st.createdById, CURDATE(), st.modifiedById
+   FROM versionedSections AS vss
+    INNER JOIN versionedSectionTags AS st ON vss.id = st.versionedSectionId
+    INNER JOIN versionedSections AS newVSS on newVSS.sectionId = vss.sectionId AND newVSS.versionedTemplateId = @versioned_template_id
+   WHERE vss.versionedTemplateId = @prior_versioned_template_id);
+
+INSERT INTO versionedQuestions (versionedTemplateId, versionedSectionId, questionId, questionText, json, requirementText, guidanceText, sampleText, required, displayOrder, created, createdById, modified, modifiedById)
+  (SELECT @versioned_template_id, newVSS.id, vsq.questionId, vsq.questionText, vsq.json, vsq.requirementText, vsq.guidanceText, vsq.sampleText, vsq.required, vsq.displayOrder, CURDATE(), vsq.createdById, CURDATE(), vsq.modifiedById
+   FROM versionedSections AS vss
+     INNER JOIN versionedQuestions vsq ON vss.id = vsq.versionedSectionId
+     INNER JOIN versionedSections AS newVSS on newVSS.sectionId = vss.sectionId AND newVSS.versionedTemplateId = @versioned_template_id
+   WHERE vss.versionedTemplateId = @prior_versioned_template_id);
+
+-- Finally add the new section tags and question to the research output question
 INSERT INTO versionedSectionTags (versionedSectionId, tagId, created, createdById, modified, modifiedById)
   (SELECT @versioned_section_id, tagId, CURDATE(), createdById, CURDATE(), modifiedById
    FROM sectionTags WHERE sectionId = @section_id);


### PR DESCRIPTION
I just realized I forgot to checkin a bug fix for the research output question that was added to the default template for our local DBs.

The new published version of the default template only had the new research output question, not all of the existing questions!