### PR TITLE
Updates for the Admin User Profile page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## v1.1.0
 
 ### Added
+- Added `isArchived` field to the `users` table to help us filter those users out when returned in `users` response [#281]
+- Added `findByProjectIdWithPagination` method to the `PlanSearchResult` model for the `plans` resolver [#281]
+- Added `userProjects` query to return all projects for a specified user, with search term and pagination [#281]
+- Added `updateUserRole` mutation for admins to change a user's role, `updateUserInfo` mutation for super admins to update a specified user's profile, and an `archiveUser` mutation to archive a user[#281]
 - Added a default researc h output table question to the default template
 - Added data migration to add `displayAbbreviation` and `displayDomain` to the `affiliations` table
 - Added data migration to backfill those new DB fields
@@ -102,6 +106,8 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated `plans` resolver to have pagination for a specified `userId` with optional `search term`, and added a chained resolver for `PlanSearchResult` for `templateOwnerAffiliationName` [#281]
+- Updated `PlanSearchResult` model to include `createdById` and `templateOwnerAffiliationName` for the Admin Users page [#281]
 - Updated `users` resolver to include `role` and `affiliationId` [#240]
 - Added `findByAffiliationId` and `search` to pass in `role` as optional [#240]
 - Added `findByUserId` to `Plan` model to find all plans for a given user [#240]

--- a/data-migrations/2026-06-25-0919-add-isArchived-field-to-users.sql
+++ b/data-migrations/2026-06-25-0919-add-isArchived-field-to-users.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `users`
+ADD COLUMN `isArchived` tinyint(1) NOT NULL DEFAULT '0' AFTER `active`;

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -139,12 +139,14 @@ export class PlanSearchResult {
   }
 
   /**
-   * Find high-level details about the plans for a project. This information is
-   * meant to supply an overview of the plans.
+   * Find projects for a specified userId, with pagination and optional search term filtering. 
+   * This method returns a paginated list of PlanSearchResult objects that match the search criteria.
    *
    * @param reference The caller's reference string for logging purposes'
    * @param context The Apollo context object
-   * @param projectId The ID of the project to return plans for
+   * @param userId The ID of the user to return projects for
+   * @param options Pagination options for the query
+   * @param term Optional search term to filter the results
    * @returns An array of PlanSearchResult objects
    */
   static async findByProjectIdWithPagination(

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -139,7 +139,7 @@ export class PlanSearchResult {
   }
 
   /**
-   * Find projects for a specified userId, with pagination and optional search term filtering. 
+   * Find projects/plans for a specified userId, with pagination and optional search term filtering. 
    * This method returns a paginated list of PlanSearchResult objects that match the search criteria.
    *
    * @param reference The caller's reference string for logging purposes'
@@ -149,7 +149,7 @@ export class PlanSearchResult {
    * @param term Optional search term to filter the results
    * @returns An array of PlanSearchResult objects
    */
-  static async findByProjectIdWithPagination(
+  static async findByUserIdWithPagination(
     reference: string,
     context: MyContext,
     userId: number,

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -13,6 +13,14 @@ import { PlanGuidance } from "./Guidance";
 import { VersionedTemplate } from "./VersionedTemplate";
 import { Project } from "./Project";
 import { Tag } from "./Tag";
+import {
+  PaginatedQueryResults,
+  PaginationOptions,
+  PaginationOptionsForCursors,
+  PaginationOptionsForOffsets,
+  PaginationType
+} from '../types/general';
+import { prepareObjectForLogs } from '../logger';
 
 export const DEFAULT_TEMPORARY_DMP_ID_PREFIX = 'temp-dmpId-';
 
@@ -52,6 +60,7 @@ export class PlanSearchResult {
   public id: number;
   public createdBy: string;
   public created: string;
+  public createdById: number;
   public modifiedBy: string;
   public modified: string;
   public title: string;
@@ -62,6 +71,7 @@ export class PlanSearchResult {
   public members: string;
   public templateTitle: string;
   public versionedTemplateId: number;
+  public templateOwnerAffiliationName: string;
 
   // The following fields will only be set when the plan is published!
   public dmpId: string;
@@ -72,6 +82,7 @@ export class PlanSearchResult {
     this.id = options.id;
     this.createdBy = options.createdBy;
     this.created = options.created;
+    this.createdById = options.createdById;
     this.modifiedBy = options.modifiedBy;
     this.modified = options.modified;
     this.title = options.title;
@@ -82,6 +93,7 @@ export class PlanSearchResult {
     this.members = options.members;
     this.templateTitle = options.title;
     this.versionedTemplateId = options.versionedTemplateId;
+    this.templateOwnerAffiliationName = options.templateOwnerAffiliationName;
 
     this.dmpId = options.dmpId;
     this.registeredBy = options.registeredBy;
@@ -89,14 +101,14 @@ export class PlanSearchResult {
   }
 
   /**
-   * Find high-level details about the plans for a project. This information is
-   * meant to supply an overview of the plans.
-   *
-   * @param reference The caller's reference string for logging purposes'
-   * @param context The Apollo context object
-   * @param projectId The ID of the project to return plans for
-   * @returns An array of PlanSearchResult objects
-   */
+ * Find high-level details about the plans for a project. This information is
+ * meant to supply an overview of the plans.
+ *
+ * @param reference The caller's reference string for logging purposes'
+ * @param context The Apollo context object
+ * @param projectId The ID of the project to return plans for
+ * @returns An array of PlanSearchResult objects
+ */
   static async findByProjectId(reference: string, context: MyContext, projectId: number): Promise<PlanSearchResult[]> {
     const sql = 'SELECT p.id, ' +
       'CONCAT(cu.givenName, CONCAT(\' \', cu.surName)) createdBy, p.created, ' +
@@ -124,6 +136,94 @@ export class PlanSearchResult {
       'ORDER BY p.created DESC;';
     const results = await Plan.query(context, sql, [projectId?.toString()], reference);
     return Array.isArray(results) ? results.map((entry) => new PlanSearchResult(entry)) : [];
+  }
+
+  /**
+   * Find high-level details about the plans for a project. This information is
+   * meant to supply an overview of the plans.
+   *
+   * @param reference The caller's reference string for logging purposes'
+   * @param context The Apollo context object
+   * @param projectId The ID of the project to return plans for
+   * @returns An array of PlanSearchResult objects
+   */
+  static async findByProjectIdWithPagination(
+    reference: string,
+    context: MyContext,
+    projectId: number,
+    options: PaginationOptions = Plan.getDefaultPaginationOptions(),
+    term?: string,
+  ): Promise<PaginatedQueryResults<PlanSearchResult>> {
+    const whereFilters = ['p.projectId = ?'];
+    const values = [projectId.toString()];
+
+    // Handle the incoming search term
+    const searchTerm = (term ?? '').toLowerCase().trim();
+    if (searchTerm) {
+      whereFilters.push(`(
+      LOWER(p.title) LIKE ? OR
+      LOWER(vt.name) LIKE ?
+    )`);
+      values.push(`%${searchTerm}%`, `%${searchTerm}%`);
+    }
+
+    const sqlStatement = `
+    SELECT p.id, p.createdById,
+      CONCAT(cu.givenName, ' ', cu.surName) createdBy, p.created,
+      CONCAT(cm.givenName, ' ', cm.surName) modifiedBy, p.modified,
+      p.versionedTemplateId, p.title, p.status, p.visibility, p.dmpId,
+      CONCAT(cr.givenName, ' ', cr.surName) registeredBy, p.registered, p.featured,
+      GROUP_CONCAT(DISTINCT CONCAT(prc.givenName, ' ', prc.surName, ' (', r.label, ')')) members,
+      GROUP_CONCAT(DISTINCT fundings.name) funding
+    FROM plans p
+    LEFT JOIN users cu ON cu.id = p.createdById
+    LEFT JOIN users cm ON cm.id = p.modifiedById
+    LEFT JOIN users cr ON cr.id = p.registeredById
+    LEFT JOIN versionedTemplates vt ON vt.id = p.versionedTemplateId
+    LEFT JOIN planMembers plc ON plc.planId = p.id
+    LEFT JOIN projectMembers prc ON prc.id = plc.projectMemberId
+    LEFT JOIN planMemberRoles plcr ON plc.id = plcr.planMemberId
+    LEFT JOIN memberRoles r ON plcr.memberRoleId = r.id
+    LEFT JOIN planFundings ON planFundings.planId = p.id
+    LEFT JOIN projectFundings ON projectFundings.id = planFundings.projectFundingId
+    LEFT JOIN affiliations fundings ON projectFundings.affiliationId = fundings.uri
+  `;
+
+    const groupBy = `
+    GROUP BY p.id, p.createdById,cu.givenName, cu.surName, cm.givenName, cm.surName,
+    p.title, p.status, p.visibility,
+    p.dmpId, cr.givenName, cr.surName, p.registered, p.featured
+  `;
+
+    let opts;
+    if (options.type === PaginationType.OFFSET) {
+      opts = {
+        ...options,
+        availableSortFields: ['p.title', 'p.status', 'p.created', 'p.modified', 'p.registered', 'p.visibility'],
+      } as PaginationOptionsForOffsets;
+    } else {
+      opts = {
+        ...options,
+        cursorField: 'CONCAT(p.title, p.id)',
+      } as PaginationOptionsForCursors;
+    }
+
+    if (isNullOrUndefined(opts.sortField)) opts.sortField = 'p.created';
+    if (isNullOrUndefined(opts.sortDir)) opts.sortDir = 'DESC';
+    opts.countField = 'p.id';
+
+    const response: PaginatedQueryResults<PlanSearchResult> = await Plan.queryWithPagination(
+      context,
+      sqlStatement,
+      whereFilters,
+      groupBy,
+      values,
+      opts,
+      reference,
+    );
+
+    context.logger.debug(prepareObjectForLogs({ options, response }), reference);
+    return response;
   }
 }
 
@@ -308,6 +408,7 @@ export class PlanSectionProgress {
       vs.id AS versionedSectionId,
       vs.displayOrder,
       vs.name AS title,
+      p.createdById,
       COUNT(DISTINCT vq.id) AS totalQuestions,
       COUNT(DISTINCT CASE
           WHEN a.id IS NOT NULL AND ${FILLED_ANSWER_CHECK}

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -91,7 +91,7 @@ export class PlanSearchResult {
     this.featured = options.featured ?? false;
     this.funding = options.funding;
     this.members = options.members;
-    this.templateTitle = options.title;
+    this.templateTitle = options.templateTitle;
     this.versionedTemplateId = options.versionedTemplateId;
     this.templateOwnerAffiliationName = options.templateOwnerAffiliationName;
 
@@ -172,6 +172,7 @@ export class PlanSearchResult {
       CONCAT(cu.givenName, ' ', cu.surName) createdBy, p.created,
       CONCAT(cm.givenName, ' ', cm.surName) modifiedBy, p.modified,
       p.versionedTemplateId, p.title, p.status, p.visibility, p.dmpId,
+      vt.name AS templateTitle,
       CONCAT(cr.givenName, ' ', cr.surName) registeredBy, p.registered, p.featured,
       GROUP_CONCAT(DISTINCT CONCAT(prc.givenName, ' ', prc.surName, ' (', r.label, ')')) members,
       GROUP_CONCAT(DISTINCT fundings.name) funding
@@ -192,7 +193,7 @@ export class PlanSearchResult {
     const groupBy = `
     GROUP BY p.id, p.createdById,cu.givenName, cu.surName, cm.givenName, cm.surName,
     p.title, p.status, p.visibility,
-    p.dmpId, cr.givenName, cr.surName, p.registered, p.featured
+    p.dmpId, cr.givenName, cr.surName, p.registered, p.featured, vt.name
   `;
 
     let opts;

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -223,7 +223,6 @@ export class PlanSearchResult {
       reference,
     );
 
-    console.log("***Response from findByProjectIdWithPagination", response);
     context.logger.debug(prepareObjectForLogs({ options, response }), reference);
     return response;
   }

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -150,12 +150,12 @@ export class PlanSearchResult {
   static async findByProjectIdWithPagination(
     reference: string,
     context: MyContext,
-    projectId: number,
+    userId: number,
     options: PaginationOptions = Plan.getDefaultPaginationOptions(),
     term?: string,
   ): Promise<PaginatedQueryResults<PlanSearchResult>> {
-    const whereFilters = ['p.projectId = ?'];
-    const values = [projectId.toString()];
+    const whereFilters = ['p.createdById = ?'];
+    const values = [userId.toString()];
 
     // Handle the incoming search term
     const searchTerm = (term ?? '').toLowerCase().trim();
@@ -223,6 +223,7 @@ export class PlanSearchResult {
       reference,
     );
 
+    console.log("***Response from findByProjectIdWithPagination", response);
     context.logger.debug(prepareObjectForLogs({ options, response }), reference);
     return response;
   }
@@ -409,7 +410,6 @@ export class PlanSectionProgress {
       vs.id AS versionedSectionId,
       vs.displayOrder,
       vs.name AS title,
-      p.createdById,
       COUNT(DISTINCT vq.id) AS totalQuestions,
       COUNT(DISTINCT CASE
           WHEN a.id IS NOT NULL AND ${FILLED_ANSWER_CHECK}

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -56,6 +56,7 @@ export class User extends MySqlModel {
 
   public locked?: boolean;
   public active?: boolean;
+  public isArchived?: boolean;
 
   public tableName = 'users';
 
@@ -81,6 +82,7 @@ export class User extends MySqlModel {
     this.notify_on_feedback_complete = options.notify_on_feedback_complete ?? true;
     this.notify_on_plan_shared = options.notify_on_plan_shared ?? true;
     this.notify_on_plan_visibility_change = options.notify_on_plan_visibility_change ?? true;
+    this.isArchived = options.isArchived ?? false;
 
     this.prepForSave();
   }
@@ -218,6 +220,8 @@ export class User extends MySqlModel {
     const whereFilters = ['u.affiliationId = ?'];
     const values = [affiliationId];
 
+    whereFilters.push('u.isArchived = 0');
+
     if (!isNullOrUndefined(role)) {
       whereFilters.push('u.role = ?');
       values.push(role);
@@ -287,6 +291,8 @@ export class User extends MySqlModel {
   ): Promise<PaginatedQueryResults<User>> {
     const whereFilters: string[] = [];
     const values: string[] = [];
+
+    whereFilters.push('u.isArchived = 0');
 
     // Handle the incoming search term
     const searchTerm = (term ?? '').toLowerCase().trim();

--- a/src/models/__mocks__/Plan.ts
+++ b/src/models/__mocks__/Plan.ts
@@ -54,6 +54,7 @@ const planToPlanSearchResult = (plan: Plan): PlanSearchResult => {
   return {
     id: plan.id,
     createdBy: casual.full_name,
+    createdById: plan.createdById,
     created: plan.created,
     modifiedBy: casual.full_name,
     modified: plan.modified,
@@ -68,6 +69,7 @@ const planToPlanSearchResult = (plan: Plan): PlanSearchResult => {
     members: casual.full_name,
     templateTitle: casual.title,
     versionedTemplateId: plan.versionedTemplateId,
+    templateOwnerAffiliationName: casual.company_name,
   }
 }
 

--- a/src/models/__tests__/Plan.spec.ts
+++ b/src/models/__tests__/Plan.spec.ts
@@ -17,6 +17,8 @@ import { getCurrentDate } from "../../utils/helpers";
 import { PlanGuidance } from "../Guidance";
 import { Project } from "../Project";
 import { VersionedTemplate } from "../VersionedTemplate";
+import { PaginationType } from "../../types/general";
+
 
 jest.mock('../../context.ts');
 
@@ -48,9 +50,11 @@ describe('PlanSearchResult', () => {
     funding: casual.company_name,
     members: [casual.full_name, casual.full_name],
     createdBy: casual.full_name,
+    createdById: casual.integer(1, 99),
     created: casual.date('YYYY-MM-DD'),
     modifiedBy: casual.full_name,
     modified: casual.date('YYYY-MM-DD'),
+    templateOwnerAffiliationId: casual.company_name
   }
   beforeEach(() => {
     searchResult = new PlanSearchResult(searchResultData);
@@ -145,6 +149,140 @@ describe('PlanSearchResult.findByProjectId', () => {
     const projectId = casual.integer(1, 999);
     const result = await PlanSearchResult.findByProjectId('testing', context, projectId);
     expect(result).toEqual([]);
+  });
+});
+
+describe('PlanSearchResult.findByProjectIdWithPagination', () => {
+  const originalQuery = Plan.query;
+  const originalQueryWithPagination = Plan.queryWithPagination;
+
+  let localQuery: jest.Mock;
+  let localQueryWithPagination: jest.Mock;
+
+  beforeEach(() => {
+    localQuery = jest.fn();
+    localQueryWithPagination = jest.fn();
+    (Plan.query as jest.Mock) = localQuery;
+    (Plan.queryWithPagination as jest.Mock) = localQueryWithPagination;
+  });
+
+  afterEach(() => {
+    Plan.query = originalQuery;
+    Plan.queryWithPagination = originalQueryWithPagination;
+  });
+
+  const makeOptions = (overrides = {}) => ({
+    type: PaginationType.OFFSET,
+    offset: 0,
+    limit: 10,
+    sortDir: 'DESC',
+    sortField: undefined,
+    ...overrides,
+  });
+
+  const makePaginatedResult = (items: PlanSearchResult[]) => ({
+    items,
+    totalCount: items.length,
+    hasNextPage: false,
+    hasPreviousPage: false,
+    currentOffset: 0,
+  });
+
+  it.only('should call queryWithPagination with correct base variables', async () => {
+    const userId = casual.integer(1, 99);
+    const options = makeOptions();
+    const expected = makePaginatedResult([]);
+    localQueryWithPagination.mockResolvedValueOnce(expected);
+
+    await PlanSearchResult.findByProjectIdWithPagination('testing', context, userId, options);
+
+    expect(localQueryWithPagination).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [ctx, sql, whereFilters, _groupBy, values, _opts, ref] = localQueryWithPagination.mock.calls[0];
+
+
+    expect(ctx).toBe(context);
+    expect(ref).toBe('testing');
+    expect(whereFilters).toContain('p.createdById = ?');
+    expect(values).toContain(userId.toString());
+    expect(normalizeSQL(sql)).toContain('FROM plans p');
+    expect(normalizeSQL(sql)).toContain('LEFT JOIN versionedTemplates vt ON vt.id = p.versionedTemplateId');
+  });
+
+  it('should include search term filter when term is provided', async () => {
+    const userId = casual.integer(1, 99);
+    const options = makeOptions();
+    const term = 'reef';
+    localQueryWithPagination.mockResolvedValueOnce(makePaginatedResult([]));
+
+    await PlanSearchResult.findByProjectIdWithPagination('testing', context, userId, options, term);
+
+    const [, , whereFilters, , values] = localQueryWithPagination.mock.calls[0];
+
+    expect(whereFilters.some((f: string) => f.includes('LOWER(p.title) LIKE ?'))).toBe(true);
+    expect(values).toContain(`%${term}%`);
+  });
+
+  it('should not include search term filter when term is empty', async () => {
+    const userId = casual.integer(1, 99);
+    const options = makeOptions();
+    localQueryWithPagination.mockResolvedValueOnce(makePaginatedResult([]));
+
+    await PlanSearchResult.findByProjectIdWithPagination('testing', context, userId, options, '');
+
+    const [, , whereFilters] = localQueryWithPagination.mock.calls[0];
+    expect(whereFilters).toHaveLength(1); // only createdById filter
+  });
+
+  it('should use default sort field and direction when not provided', async () => {
+    const userId = casual.integer(1, 99);
+    const options = makeOptions({ sortField: undefined, sortDir: undefined });
+    localQueryWithPagination.mockResolvedValueOnce(makePaginatedResult([]));
+
+    await PlanSearchResult.findByProjectIdWithPagination('testing', context, userId, options);
+
+    const [, , , , , opts] = localQueryWithPagination.mock.calls[0];
+    expect(opts.sortField).toBe('p.created');
+    expect(opts.sortDir).toBe('DESC');
+  });
+
+  it('should return paginated results', async () => {
+    const userId = casual.integer(1, 99);
+    const item = new PlanSearchResult({
+      id: casual.integer(1, 99),
+      createdById: userId,
+      createdBy: casual.full_name,
+      created: casual.date('YYYY-MM-DD'),
+      modifiedBy: casual.full_name,
+      modified: casual.date('YYYY-MM-DD'),
+      title: casual.sentence,
+      status: PlanStatus.DRAFT,
+      visibility: PlanVisibility.PRIVATE,
+      dmpId: casual.uuid,
+      templateTitle: casual.sentence,
+      templateOwnerAffiliationName: casual.company_name,
+    });
+
+    const expected = makePaginatedResult([item]);
+    localQueryWithPagination.mockResolvedValueOnce(expected);
+
+    const result = await PlanSearchResult.findByProjectIdWithPagination(
+      'testing', context, userId, makeOptions()
+    );
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should return empty results when no plans found', async () => {
+    const userId = casual.integer(1, 99);
+    localQueryWithPagination.mockResolvedValueOnce(makePaginatedResult([]));
+
+    const result = await PlanSearchResult.findByProjectIdWithPagination(
+      'testing', context, userId, makeOptions()
+    );
+
+    expect(result.items).toHaveLength(0);
+    expect(result.totalCount).toBe(0);
   });
 });
 

--- a/src/models/__tests__/Plan.spec.ts
+++ b/src/models/__tests__/Plan.spec.ts
@@ -194,7 +194,7 @@ describe('PlanSearchResult.findByProjectIdWithPagination', () => {
     const expected = makePaginatedResult([]);
     localQueryWithPagination.mockResolvedValueOnce(expected);
 
-    await PlanSearchResult.findByProjectIdWithPagination('testing', context, userId, options);
+    await PlanSearchResult.findByUserIdWithPagination('testing', context, userId, options);
 
     expect(localQueryWithPagination).toHaveBeenCalledTimes(1);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -215,7 +215,7 @@ describe('PlanSearchResult.findByProjectIdWithPagination', () => {
     const term = 'reef';
     localQueryWithPagination.mockResolvedValueOnce(makePaginatedResult([]));
 
-    await PlanSearchResult.findByProjectIdWithPagination('testing', context, userId, options, term);
+    await PlanSearchResult.findByUserIdWithPagination('testing', context, userId, options, term);
 
     const [, , whereFilters, , values] = localQueryWithPagination.mock.calls[0];
 
@@ -228,7 +228,7 @@ describe('PlanSearchResult.findByProjectIdWithPagination', () => {
     const options = makeOptions();
     localQueryWithPagination.mockResolvedValueOnce(makePaginatedResult([]));
 
-    await PlanSearchResult.findByProjectIdWithPagination('testing', context, userId, options, '');
+    await PlanSearchResult.findByUserIdWithPagination('testing', context, userId, options, '');
 
     const [, , whereFilters] = localQueryWithPagination.mock.calls[0];
     expect(whereFilters).toHaveLength(1); // only createdById filter
@@ -239,7 +239,7 @@ describe('PlanSearchResult.findByProjectIdWithPagination', () => {
     const options = makeOptions({ sortField: undefined, sortDir: undefined });
     localQueryWithPagination.mockResolvedValueOnce(makePaginatedResult([]));
 
-    await PlanSearchResult.findByProjectIdWithPagination('testing', context, userId, options);
+    await PlanSearchResult.findByUserIdWithPagination('testing', context, userId, options);
 
     const [, , , , , opts] = localQueryWithPagination.mock.calls[0];
     expect(opts.sortField).toBe('p.created');
@@ -266,7 +266,7 @@ describe('PlanSearchResult.findByProjectIdWithPagination', () => {
     const expected = makePaginatedResult([item]);
     localQueryWithPagination.mockResolvedValueOnce(expected);
 
-    const result = await PlanSearchResult.findByProjectIdWithPagination(
+    const result = await PlanSearchResult.findByUserIdWithPagination(
       'testing', context, userId, makeOptions()
     );
 
@@ -277,7 +277,7 @@ describe('PlanSearchResult.findByProjectIdWithPagination', () => {
     const userId = casual.integer(1, 99);
     localQueryWithPagination.mockResolvedValueOnce(makePaginatedResult([]));
 
-    const result = await PlanSearchResult.findByProjectIdWithPagination(
+    const result = await PlanSearchResult.findByUserIdWithPagination(
       'testing', context, userId, makeOptions()
     );
 

--- a/src/resolvers/plan.ts
+++ b/src/resolvers/plan.ts
@@ -560,9 +560,9 @@ export const resolvers: Resolvers = {
       );
       return affiliation?.displayName || null;
     },
-    user: async (parent: PlanSearchResult, _, context: MyContext): Promise<User> => {
+    planCreator: async (parent: PlanSearchResult, _, context: MyContext): Promise<User> => {
       if (parent?.createdById) {
-        return await User.findById('planSearchResult.user resolver', context, parent.createdById);
+        return await User.findById('planSearchResult.planCreator resolver', context, parent.createdById);
       }
       return null;
     }

--- a/src/resolvers/plan.ts
+++ b/src/resolvers/plan.ts
@@ -59,7 +59,7 @@ export const resolvers: Resolvers = {
             ? paginationOptions as PaginationOptionsForOffsets
             : { ...paginationOptions, type: PaginationType.CURSOR } as PaginationOptionsForCursors;
 
-          return await PlanSearchResult.findByProjectIdWithPagination(reference, context, userId, opts, term);
+          return await PlanSearchResult.findByUserIdWithPagination(reference, context, userId, opts, term);
         } catch (err) {
           if (err instanceof GraphQLError) throw err;
           context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
@@ -561,7 +561,6 @@ export const resolvers: Resolvers = {
       return affiliation?.displayName || null;
     },
     user: async (parent: PlanSearchResult, _, context: MyContext): Promise<User> => {
-      console.log('****parent', parent);
       if (parent?.createdById) {
         return await User.findById('planSearchResult.user resolver', context, parent.createdById);
       }

--- a/src/resolvers/plan.ts
+++ b/src/resolvers/plan.ts
@@ -14,7 +14,7 @@ import { AlternateIdentifier } from "../models/AlternateIdentifier";
 import { isNullOrUndefined, normaliseDateTime } from "../utils/helpers";
 import { AuthenticationError, ForbiddenError, InternalServerError, NotFoundError } from "../utils/graphQLErrors";
 import { PaginationOptionsForCursors, PaginationOptionsForOffsets, PaginationOptions, PaginationType } from "../types/general";
-import { PaginatedPlanResults, PaginatedQueryResults, PlanFeedbackStatus, Resolvers } from "../types";
+import { PaginatedPlanResults, PlanFeedbackStatus, Resolvers } from "../types";
 import { prepareObjectForLogs } from "../logger";
 
 // Services
@@ -31,6 +31,7 @@ import { authenticatedResolver, isAuthorized, isAdmin, isSuperAdmin } from "../s
 
 export const resolvers: Resolvers = {
   Query: {
+    // Find all of the plans for a specified userId, with pagination and optional search term filtering
     plans: authenticatedResolver(
       'plansWithPagination resolver',
       UserRole.ADMIN,

--- a/src/resolvers/plan.ts
+++ b/src/resolvers/plan.ts
@@ -2,7 +2,7 @@ import { GraphQLError } from "graphql";
 import { MyContext } from "../context";
 import { Plan, PlanSearchResult, PlanSectionProgress, PlanProgress, PlanStatus, PlanVisibility } from "../models/Plan";
 import { Project } from "../models/Project";
-import { User } from "../models/User";
+import { User, UserRole } from "../models/User";
 import { PlanMember } from "../models/Member";
 import { PlanFunding } from "../models/Funding";
 import { PlanFeedback } from "../models/PlanFeedback";
@@ -13,7 +13,7 @@ import { ProjectCollaboratorAccessLevel } from "../models/Collaborator";
 import { AlternateIdentifier } from "../models/AlternateIdentifier";
 import { isNullOrUndefined, normaliseDateTime } from "../utils/helpers";
 import { AuthenticationError, ForbiddenError, InternalServerError, NotFoundError } from "../utils/graphQLErrors";
-import { PaginationOptionsForCursors, PaginationOptionsForOffsets, PaginationType } from "../types/general";
+import { PaginationOptionsForCursors, PaginationOptionsForOffsets, PaginationOptions, PaginationType } from "../types/general";
 import { PaginatedPlanResults, PaginatedQueryResults, PlanFeedbackStatus, Resolvers } from "../types";
 import { prepareObjectForLogs } from "../logger";
 
@@ -26,33 +26,46 @@ import {
   hasPermissionOnProject,
   isProjectReadOnlyForCurrentUser
 } from "../services/projectService";
-import { isAuthorized } from "../services/authService";
-
+import { authenticatedResolver, isAuthorized, isAdmin, isSuperAdmin } from "../services/authService";
 
 
 export const resolvers: Resolvers = {
   Query: {
-    plans: async (_, { projectId, term, paginationOptions }, context: MyContext): Promise<PaginatedPlanResults> => {
-      const reference = 'plansWithPagination resolver';
-      try {
-        if (isAuthorized(context.token)) {
-          const project = await Project.findById(reference, context, projectId);
-          if (!project) throw NotFoundError(`Project with ID ${projectId} not found`);
-          if (await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.COMMENT)) {
-            const opts = !isNullOrUndefined(paginationOptions) && paginationOptions.type === PaginationType.OFFSET
-              ? paginationOptions as PaginationOptionsForOffsets
-              : { ...paginationOptions, type: PaginationType.CURSOR } as PaginationOptionsForCursors;
+    plans: authenticatedResolver(
+      'plansWithPagination resolver',
+      UserRole.ADMIN,
+      async (
+        _: Record<PropertyKey, never>,
+        { userId, term, paginationOptions }: { userId: number; term?: string; paginationOptions?: PaginationOptions },
+        context: MyContext
+      ): Promise<PaginatedPlanResults> => {
+        const reference = 'plansWithPagination resolver';
+        try {
 
-            return await PlanSearchResult.findByProjectIdWithPagination(reference, context, projectId, opts, term);
+          const superAdmin: boolean = isSuperAdmin(context.token);
+
+          if (!superAdmin) {
+            // Admin must belong to the same affiliation as the target user
+            const targetUser = await User.findById(reference, context, userId);
+            if (!targetUser) throw NotFoundError(`User with ID ${userId} not found`);
+
+            if (!(isAdmin(context.token) && context.token.affiliationId === targetUser.affiliationId)) {
+              throw ForbiddenError();
+            }
           }
+
+          const opts = !isNullOrUndefined(paginationOptions) && paginationOptions.type === PaginationType.OFFSET
+            ? paginationOptions as PaginationOptionsForOffsets
+            : { ...paginationOptions, type: PaginationType.CURSOR } as PaginationOptionsForCursors;
+
+          return await PlanSearchResult.findByProjectIdWithPagination(reference, context, userId, opts, term);
+        } catch (err) {
+          if (err instanceof GraphQLError) throw err;
+          context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
+          throw InternalServerError();
         }
-        throw context?.token ? ForbiddenError() : AuthenticationError();
-      } catch (err) {
-        if (err instanceof GraphQLError) throw err;
-        context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
-        throw InternalServerError();
-      }
-    },
+      },
+    ),
     // Find the plan by its id
     plan: async (_, { planId }, context: MyContext): Promise<Plan> => {
       const reference = 'plan resolver';

--- a/src/resolvers/plan.ts
+++ b/src/resolvers/plan.ts
@@ -1,55 +1,58 @@
 import { GraphQLError } from "graphql";
 import { MyContext } from "../context";
 import { Plan, PlanSearchResult, PlanSectionProgress, PlanProgress, PlanStatus, PlanVisibility } from "../models/Plan";
-import { prepareObjectForLogs } from "../logger";
-import { AuthenticationError, ForbiddenError, InternalServerError, NotFoundError } from "../utils/graphQLErrors";
 import { Project } from "../models/Project";
 import { User } from "../models/User";
-import { isAuthorized } from "../services/authService";
-import {
-  hasPermissionOnProject,
-  isProjectReadOnlyForCurrentUser
-} from "../services/projectService";
 import { PlanMember } from "../models/Member";
 import { PlanFunding } from "../models/Funding";
 import { PlanFeedback } from "../models/PlanFeedback";
-import { PlanFeedbackStatus, Resolvers } from "../types";
+import { Affiliation } from "../models/Affiliation";
 import { VersionedTemplate } from "../models/VersionedTemplate";
 import { Answer } from "../models/Answer";
 import { ProjectCollaboratorAccessLevel } from "../models/Collaborator";
+import { AlternateIdentifier } from "../models/AlternateIdentifier";
 import { isNullOrUndefined, normaliseDateTime } from "../utils/helpers";
+import { AuthenticationError, ForbiddenError, InternalServerError, NotFoundError } from "../utils/graphQLErrors";
+import { PaginationOptionsForCursors, PaginationOptionsForOffsets, PaginationType } from "../types/general";
+import { PaginatedPlanResults, PaginatedQueryResults, PlanFeedbackStatus, Resolvers } from "../types";
+import { prepareObjectForLogs } from "../logger";
+
+// Services
 import {
   ensureDefaultPlanContact,
   saveMaDMPVersion
 } from "../services/planService";
-import { AlternateIdentifier } from "../models/AlternateIdentifier";
+import {
+  hasPermissionOnProject,
+  isProjectReadOnlyForCurrentUser
+} from "../services/projectService";
+import { isAuthorized } from "../services/authService";
+
 
 
 export const resolvers: Resolvers = {
   Query: {
-    // return all of the projects that the current user owns or is a collaborator on
-    plans: async (_, { projectId }, context: MyContext): Promise<PlanSearchResult[]> => {
-      const reference = 'plans resolver';
+    plans: async (_, { projectId, term, paginationOptions }, context: MyContext): Promise<PaginatedPlanResults> => {
+      const reference = 'plansWithPagination resolver';
       try {
         if (isAuthorized(context.token)) {
           const project = await Project.findById(reference, context, projectId);
-
-          if (!project) {
-            throw NotFoundError(`Project with ID ${projectId} not found`);
-          }
+          if (!project) throw NotFoundError(`Project with ID ${projectId} not found`);
           if (await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.COMMENT)) {
-            return await PlanSearchResult.findByProjectId(reference, context, projectId);
+            const opts = !isNullOrUndefined(paginationOptions) && paginationOptions.type === PaginationType.OFFSET
+              ? paginationOptions as PaginationOptionsForOffsets
+              : { ...paginationOptions, type: PaginationType.CURSOR } as PaginationOptionsForCursors;
+
+            return await PlanSearchResult.findByProjectIdWithPagination(reference, context, projectId, opts, term);
           }
         }
         throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {
         if (err instanceof GraphQLError) throw err;
-
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
         throw InternalServerError();
       }
     },
-
     // Find the plan by its id
     plan: async (_, { planId }, context: MyContext): Promise<Plan> => {
       const reference = 'plan resolver';
@@ -525,6 +528,30 @@ export const resolvers: Resolvers = {
         );
       }
       return [];
+    },
+    templateOwnerAffiliationName: async (parent: PlanSearchResult, _, context: MyContext): Promise<string | null> => {
+      if (!parent?.versionedTemplateId) return null;
+
+      const versionedTemplate = await VersionedTemplate.findById(
+        'planSearchResult.templateOwnerAffiliationName resolver',
+        context,
+        parent.versionedTemplateId
+      );
+      if (!versionedTemplate?.ownerId) return null;
+
+      const affiliation = await Affiliation.findByURI(
+        'planSearchResult.templateOwnerAffiliationName resolver',
+        context,
+        versionedTemplate.ownerId
+      );
+      return affiliation?.displayName || null;
+    },
+    user: async (parent: PlanSearchResult, _, context: MyContext): Promise<User> => {
+      console.log('****parent', parent);
+      if (parent?.createdById) {
+        return await User.findById('planSearchResult.user resolver', context, parent.createdById);
+      }
+      return null;
     }
   }
 

--- a/src/resolvers/project.ts
+++ b/src/resolvers/project.ts
@@ -6,7 +6,7 @@ import {
   ProjectCollaboratorAccessLevel
 } from '../models/Collaborator';
 import { MyContext } from '../context';
-import { isAdmin, isAuthorized, isSuperAdmin } from '../services/authService';
+import { authenticatedResolver, isAdmin, isAuthorized, isSuperAdmin } from '../services/authService';
 import {
   AuthenticationError,
   ForbiddenError,
@@ -15,6 +15,7 @@ import {
 } from '../utils/graphQLErrors';
 import { ProjectFunding } from '../models/Funding';
 import { ProjectMember } from '../models/Member';
+import { User, UserRole } from "../models/User";
 import {
   ensureDefaultProjectContact,
   hasPermissionOnProject,
@@ -37,7 +38,7 @@ import { validateEmail } from '../utils/helpers';
 import {
   PaginationOptionsForCursors,
   PaginationOptionsForOffsets,
-  PaginationType
+  PaginationType,
 } from '../types/general';
 import { saveMaDMPVersion } from "../services/planService";
 
@@ -109,6 +110,48 @@ export const resolvers: Resolvers = {
         throw InternalServerError();
       }
     },
+    // Return all projects for a specified user (Admin only!)
+    userProjects: authenticatedResolver(
+      'userProjects resolver',
+      UserRole.ADMIN,
+      async (
+        _: Record<PropertyKey, never>,
+        { userId, term, paginationOptions, filterOptions },
+        context: MyContext
+      ): Promise<ProjectSearchResults> => {
+        const reference = 'userProjects resolver';
+        try {
+          const superAdmin = isSuperAdmin(context.token);
+
+          if (!superAdmin) {
+            const targetUser = await User.findById(reference, context, userId);
+            if (!targetUser) throw NotFoundError(`User with ID ${userId} not found`);
+
+            if (!(isAdmin(context.token) && context.token.affiliationId === targetUser.affiliationId)) {
+              throw ForbiddenError();
+            }
+          }
+
+          const pagOpts = !isNullOrUndefined(paginationOptions) && paginationOptions.type === PaginationType.OFFSET
+            ? paginationOptions as PaginationOptionsForOffsets
+            : { ...paginationOptions, type: PaginationType.CURSOR } as PaginationOptionsForCursors;
+
+          return await ProjectSearchResult.search(
+            reference,
+            context,
+            term,
+            userId,
+            context.token?.affiliationId,
+            filterOptions,
+            pagOpts
+          );
+        } catch (err) {
+          if (err instanceof GraphQLError) throw err;
+          context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
+          throw InternalServerError();
+        }
+      },
+    ),
 
     // Fetch a single project
     project: async (_, { projectId }, context: MyContext): Promise<Project> => {

--- a/src/resolvers/project.ts
+++ b/src/resolvers/project.ts
@@ -110,7 +110,7 @@ export const resolvers: Resolvers = {
         throw InternalServerError();
       }
     },
-    // Return all projects for a specified user (Admin only!)
+    // Return all projects for a specified user (Admin only!) with pagination and optional search term filtering
     userProjects: authenticatedResolver(
       'userProjects resolver',
       UserRole.ADMIN,

--- a/src/resolvers/user.ts
+++ b/src/resolvers/user.ts
@@ -13,6 +13,9 @@ import { prepareObjectForLogs } from "../logger";
 import { GraphQLError } from "graphql";
 import { PaginationOptionsForCursors, PaginationOptionsForOffsets, PaginationType } from "../types/general";
 import { isNullOrUndefined, normaliseDateTime } from "../utils/helpers";
+import {
+  authenticatedResolver,
+} from "../services/authService";
 
 export const resolvers: Resolvers = {
   Query: {
@@ -132,6 +135,82 @@ export const resolvers: Resolvers = {
         throw InternalServerError();
       }
     },
+
+    // Update the specifeied user's information (SuperAdmin only)
+    updateUserInfo: authenticatedResolver(
+      'updateUserInfo resolver',
+      UserRole.SUPERADMIN,
+      async (
+        _: Record<PropertyKey, never>,
+        { input: { userId, email, givenName, surName, affiliationId, otherAffiliationName, languageId } }: {
+          input: {
+            userId: number;
+            email: string;
+            givenName: string;
+            surName: string;
+            affiliationId: string;
+            otherAffiliationName?: string;
+            languageId: string;
+          }
+        },
+        context: MyContext
+      ): Promise<User> => {
+        console.log('****UpdateUserInfo', userId, email, givenName, surName, affiliationId, otherAffiliationName, languageId);
+        const reference = 'updateUserInfo resolver';
+        try {
+          const user = await User.findById(reference, context, userId);
+          if (!user || !user.active || user.locked) {
+            throw ForbiddenError();
+          }
+
+          if (otherAffiliationName) {
+            const affiliation = await processOtherAffiliationName(context, otherAffiliationName);
+            if (affiliation.hasErrors()) {
+              const err = affiliation.errors?.general ?? 'Unable to save the affiliation at this time';
+              user.addError('otherAffiliationName', err);
+              return user;
+            }
+            user.affiliationId = affiliation.uri;
+          } else {
+            user.affiliationId = affiliationId;
+          }
+
+          // Update the email
+          const existingPrimaryEmail = await UserEmail.findPrimaryByUserId(reference, context, user.id);
+          if (existingPrimaryEmail) {
+            // Directly update the email field and mark as confirmed since a SuperAdmin is setting it
+            existingPrimaryEmail.email = email;
+            existingPrimaryEmail.isConfirmed = true;
+            await new UserEmail(existingPrimaryEmail).update(context);
+          } else {
+            // No primary exists yet — create one, marked as confirmed
+            const newEmail = new UserEmail({
+              userId: user.id,
+              email,
+              isPrimary: true,
+              isConfirmed: true   // SuperAdmin-set emails skip confirmation
+            });
+            await newEmail.create(context);
+          }
+
+
+          // Update the user fields
+          user.givenName = givenName;
+          user.surName = surName;
+          user.languageId = languageId || defaultLanguageId;
+          const updated = await new User(user).update(context);
+
+          if (!updated || updated.hasErrors()) {
+            user.addError('general', 'Unable to save the profile changes at this time');
+          }
+          return user.hasErrors() ? user : await User.findById(reference, context, user.id);
+
+        } catch (err) {
+          if (err instanceof GraphQLError) throw err;
+          context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
+          throw InternalServerError();
+        }
+      }),
 
     // Update the current user's email notifications
     updateUserNotifications: async (_, { input: {

--- a/src/resolvers/user.ts
+++ b/src/resolvers/user.ts
@@ -496,6 +496,30 @@ export const resolvers: Resolvers = {
       }
     },
 
+    // Anonymize the specified user's account (essentially deletes their account without orphaning things)
+    archiveUser: async (_, { userId }, context: MyContext): Promise<User> => {
+      const reference = 'archiveUser resolver';
+      try {
+        if (isAdmin(context.token)) {
+          const user = await User.findById(reference, context, userId);
+          if (!user) throw NotFoundError();
+
+          if (context.token.affiliationId === user.affiliationId || isSuperAdmin(context.token)) {
+            const updated = await anonymizeUser(context, user);
+            if (!updated || updated.hasErrors()) {
+              user.addError('general', 'Unable to archive the user at this time');
+            }
+            return user.hasErrors() ? user : updated;
+          }
+        }
+        throw context?.token ? ForbiddenError() : AuthenticationError();
+      } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+        context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
+        throw InternalServerError();
+      }
+    },
+
     // Merge the 2 user accounts (SuperAdmin and Admin only)
     mergeUsers: async (_, { userIdToBeMerged, userIdToKeep }, context: MyContext): Promise<User> => {
       const reference = 'mergeUsers resolver';

--- a/src/resolvers/user.ts
+++ b/src/resolvers/user.ts
@@ -297,30 +297,6 @@ export const resolvers: Resolvers = {
       }
     },
 
-    // Anonymize the current user's account (essentially deletes their account without orphaning things)
-    removeUser: async (_, __, context: MyContext): Promise<User> => {
-      const reference = 'removeUser resolver';
-      try {
-        if (isAuthorized(context?.token)) {
-          const user = await User.findById(reference, context, context.token.id);
-          // Only continue if the user is active and not locked
-          if (!user || !user.active || user.locked) {
-            throw ForbiddenError();
-          }
-          const updated = await anonymizeUser(context, user);
-          if (!updated || updated.hasErrors()) {
-            user.addError('general', 'Unable to remove your account at this time');
-          }
-          return user.hasErrors() ? user : updated;
-        }
-        // Unauthenticated
-        throw AuthenticationError();
-      } catch (err) {
-        context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
-        throw InternalServerError();
-      }
-    },
-
     // Set the user's ORCID
     setUserOrcid: async (_, { orcid }, context: MyContext): Promise<User> => {
       const reference = 'setUserOrcid resolver';

--- a/src/resolvers/user.ts
+++ b/src/resolvers/user.ts
@@ -136,7 +136,7 @@ export const resolvers: Resolvers = {
       }
     },
 
-    // Update the specifeied user's information (SuperAdmin only)
+    // Update the specified user's information (SuperAdmin only)
     updateUserInfo: authenticatedResolver(
       'updateUserInfo resolver',
       UserRole.SUPERADMIN,
@@ -155,7 +155,6 @@ export const resolvers: Resolvers = {
         },
         context: MyContext
       ): Promise<User> => {
-        console.log('****UpdateUserInfo', userId, email, givenName, surName, affiliationId, otherAffiliationName, languageId);
         const reference = 'updateUserInfo resolver';
         try {
           const user = await User.findById(reference, context, userId);
@@ -204,6 +203,56 @@ export const resolvers: Resolvers = {
             user.addError('general', 'Unable to save the profile changes at this time');
           }
           return user.hasErrors() ? user : await User.findById(reference, context, user.id);
+
+        } catch (err) {
+          if (err instanceof GraphQLError) throw err;
+          context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
+          throw InternalServerError();
+        }
+      }),
+
+    // Update the specified user's role only (SuperAdmin and Admin only)
+    updateUserRole: authenticatedResolver(
+      'updateUserRole resolver',
+      UserRole.ADMIN, // Org Admins can access, but with constraints enforced below
+      async (
+        _: Record<PropertyKey, never>,
+        { input: { userId, role } }: {
+          input: {
+            userId: number;
+            role: UserRole;
+          }
+        },
+        context: MyContext
+      ): Promise<User> => {
+        const reference = 'updateUserRole resolver';
+        try {
+          const currentUser = await User.findById(reference, context, context.token.id);
+          const targetUser = await User.findById(reference, context, userId);
+
+          if (!targetUser || !targetUser.active || targetUser.locked) {
+            throw ForbiddenError();
+          }
+
+          // Org Admins cannot assign SUPERADMIN role
+          if (currentUser.role === UserRole.ADMIN && role === UserRole.SUPERADMIN) {
+            throw ForbiddenError();
+          }
+
+          // Org Admins cannot change the role of a SUPERADMIN
+          if (currentUser.role === UserRole.ADMIN && targetUser.role === UserRole.SUPERADMIN) {
+            throw ForbiddenError();
+          }
+
+          targetUser.role = role;
+          const updated = await new User(targetUser).update(context);
+
+          if (!updated || updated.hasErrors()) {
+            targetUser.addError('general', 'Unable to update the user role at this time');
+            return targetUser;
+          }
+
+          return await User.findById(reference, context, userId);
 
         } catch (err) {
           if (err instanceof GraphQLError) throw err;

--- a/src/schemas/plan.ts
+++ b/src/schemas/plan.ts
@@ -2,8 +2,8 @@ import gql from "graphql-tag";
 
 export const typeDefs = gql`
   extend type Query {
-    "Get all plans for the research project"
-    plans(projectId: Int!): [PlanSearchResult!]
+    "Get all plans for the research project with pagination support"
+    plans(projectId: Int!,term: String, paginationOptions: PaginationOptions): PaginatedPlanResults
 
     "Get a specific plan"
     plan(planId: Int!): Plan
@@ -34,7 +34,7 @@ export const typeDefs = gql`
     removeAlternateIdentifierFromPlan(planId: Int!, alternateIdentifier: String!): AlternateIdentifier
   }
 
-  type PlanSearchResult {
+  type PlanSearchResult{
     "The unique identifer for the Object"
     id: Int
     "The user who created the Object"
@@ -68,7 +68,31 @@ export const typeDefs = gql`
     versionedSections: [PlanSectionProgress!]
     "The versioned template id the plan is based on"
     versionedTemplateId: Int
+    "The name of the affiliation that owns the template the plan is based on"
+    templateOwnerAffiliationName: String
+    "The user who created the plan"
+    user: User
   }
+
+  type PaginatedPlanResults implements PaginatedQueryResults {
+  "The plans that match the search criteria"
+  items: [PlanSearchResult]
+  "The total number of possible items"
+  totalCount: Int
+  "The number of items returned"
+  limit: Int
+  "The cursor to use for the next page of results (for infinite scroll/load more)"
+  nextCursor: String
+  "The current offset of the results (for standard offset pagination)"
+  currentOffset: Int
+  "Whether or not there is a next page"
+  hasNextPage: Boolean
+  "Whether or not there is a previous page"
+  hasPreviousPage: Boolean
+  "The sortFields that are available for this query (for standard offset pagination only!)"
+  availableSortFields: [String]
+}
+
 
   "The progress the user has made within a section of the plan"
   type PlanSectionProgress {

--- a/src/schemas/plan.ts
+++ b/src/schemas/plan.ts
@@ -3,7 +3,7 @@ import gql from "graphql-tag";
 export const typeDefs = gql`
   extend type Query {
     "Get all plans for the research project with pagination support"
-    plans(projectId: Int!,term: String, paginationOptions: PaginationOptions): PaginatedPlanResults
+    plans(userId: Int!,term: String, paginationOptions: PaginationOptions): PaginatedPlanResults
 
     "Get a specific plan"
     plan(planId: Int!): Plan

--- a/src/schemas/plan.ts
+++ b/src/schemas/plan.ts
@@ -71,7 +71,7 @@ export const typeDefs = gql`
     "The name of the affiliation that owns the template the plan is based on"
     templateOwnerAffiliationName: String
     "The user who created the plan"
-    user: User
+    planCreator: User
   }
 
   type PaginatedPlanResults implements PaginatedQueryResults {

--- a/src/schemas/project.ts
+++ b/src/schemas/project.ts
@@ -19,6 +19,14 @@ export const projectTypeDefs = gql`
       filterOptions: ProjectFilterOptions
     ): ProjectSearchResults
 
+    "Get all projects for a specified user (Admin only!)"
+    userProjects(
+      userId: Int!,
+      term: String,
+      paginationOptions: PaginationOptions,
+      filterOptions: ProjectFilterOptions
+    ): ProjectSearchResults
+    
     "Get a specific project"
     project(projectId: Int!): Project
 

--- a/src/schemas/user.ts
+++ b/src/schemas/user.ts
@@ -13,6 +13,8 @@ export const typeDefs = gql`
   extend type Mutation {
     "Update the current user's information"
     updateUserProfile(input: UpdateUserProfileInput!): User
+    "Update the specified user's information (SuperAdmin only)"
+    updateUserInfo(input: UpdateUserInfoInput!): User
     "Update the current user's email notifications"
     updateUserNotifications(input: UpdateUserNotificationsInput!): User
     "Set the user's ORCID"
@@ -198,6 +200,24 @@ export const typeDefs = gql`
     "The user's preferred language"
     languageId: String
   }
+
+  input UpdateUserInfoInput {
+    "The user's id"
+    userId: Int!
+    "The user's email address"
+    email: String!
+    "The user's given name"
+    givenName: String!
+    "The user's surname"
+    surName: String!
+    "The id of the affiliation if the user selected one from the typeahead list"
+    affiliationId: String
+    "The name of the affiliation if the user did not select one from the typeahead list"
+    otherAffiliationName: String
+    "The user's preferred language"
+    languageId: String
+  }
+
 
   input UpdateUserNotificationsInput {
     "Whether or not email notifications are on for when a Plan has a new comment"

--- a/src/schemas/user.ts
+++ b/src/schemas/user.ts
@@ -36,6 +36,8 @@ export const typeDefs = gql`
     deactivateUser(userId: Int!): User
     "Reactivate the specified user Account (Admin only)"
     activateUser(userId: Int!): User
+    "Archive the specified user and anonymize their data (Admin only)"
+    archiveUser(userId: Int!): User
     "Merge the 2 user accounts (Admin only)"
     mergeUsers(userIdToBeMerged: Int!, userIdToKeep: Int!): User
   }

--- a/src/schemas/user.ts
+++ b/src/schemas/user.ts
@@ -15,6 +15,8 @@ export const typeDefs = gql`
     updateUserProfile(input: UpdateUserProfileInput!): User
     "Update the specified user's information (SuperAdmin only)"
     updateUserInfo(input: UpdateUserInfoInput!): User
+    " Update the specified user's role (SuperAdmin and Admin only)"
+    updateUserRole(input: UpdateUserRoleInput!): User
     "Update the current user's email notifications"
     updateUserNotifications(input: UpdateUserNotificationsInput!): User
     "Set the user's ORCID"
@@ -222,6 +224,12 @@ export const typeDefs = gql`
     languageId: String
   }
 
+  input UpdateUserRoleInput {
+    "The user's id"
+    userId: Int!
+    "The new role for the user"
+    role: UserRole!
+  }
 
   input UpdateUserNotificationsInput {
     "Whether or not email notifications are on for when a Plan has a new comment"

--- a/src/schemas/user.ts
+++ b/src/schemas/user.ts
@@ -104,6 +104,8 @@ export const typeDefs = gql`
     locked: Boolean
     "Whether or not account is active"
     active: Boolean
+    "Whether or not account is archived"
+    isArchived: Boolean
 
     "The timestamp of the last login"
     last_sign_in: String

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -63,6 +63,7 @@ export const anonymizeUser = async (context: MyContext, user: User): Promise<Use
   user.affiliationId = null;
   user.orcid = null;
   user.ssoId = null;
+  user.isArchived = true;
   user.role = UserRole.RESEARCHER;
   user.languageId = defaultLanguageId;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1745,6 +1745,8 @@ export type Mutation = {
   updateUserNotifications?: Maybe<User>;
   /** Update the current user's information */
   updateUserProfile?: Maybe<User>;
+  /**  Update the specified user's role (SuperAdmin and Admin only) */
+  updateUserRole?: Maybe<User>;
   /** Upload a plan */
   uploadPlan?: Maybe<Plan>;
   /** Insert or update a related work, the work is looked up in OpenSearch and details added */
@@ -2463,6 +2465,11 @@ export type MutationUpdateUserNotificationsArgs = {
 
 export type MutationUpdateUserProfileArgs = {
   input: UpdateUserProfileInput;
+};
+
+
+export type MutationUpdateUserRoleArgs = {
+  input: UpdateUserRoleInput;
 };
 
 
@@ -5290,6 +5297,13 @@ export type UpdateUserProfileInput = {
   surName: Scalars['String']['input'];
 };
 
+export type UpdateUserRoleInput = {
+  /** The new role for the user */
+  role: UserRole;
+  /** The user's id */
+  userId: Scalars['Int']['input'];
+};
+
 export type UpsertRelatedWorkInput = {
   /** The Digital Object Identifier (DOI) of the work */
   doi: Scalars['String']['input'];
@@ -6361,6 +6375,7 @@ export type ResolversTypes = {
   UpdateUserInfoInput: UpdateUserInfoInput;
   UpdateUserNotificationsInput: UpdateUserNotificationsInput;
   UpdateUserProfileInput: UpdateUserProfileInput;
+  UpdateUserRoleInput: UpdateUserRoleInput;
   UpsertRelatedWorkInput: UpsertRelatedWorkInput;
   User: ResolverTypeWrapper<User>;
   UserEmail: ResolverTypeWrapper<UserEmail>;
@@ -6593,6 +6608,7 @@ export type ResolversParentTypes = {
   UpdateUserInfoInput: UpdateUserInfoInput;
   UpdateUserNotificationsInput: UpdateUserNotificationsInput;
   UpdateUserProfileInput: UpdateUserProfileInput;
+  UpdateUserRoleInput: UpdateUserRoleInput;
   UpsertRelatedWorkInput: UpsertRelatedWorkInput;
   User: User;
   UserEmail: UserEmail;
@@ -7345,6 +7361,7 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   updateUserInfo?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationUpdateUserInfoArgs, 'input'>>;
   updateUserNotifications?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationUpdateUserNotificationsArgs, 'input'>>;
   updateUserProfile?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationUpdateUserProfileArgs, 'input'>>;
+  updateUserRole?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationUpdateUserRoleArgs, 'input'>>;
   uploadPlan?: Resolver<Maybe<ResolversTypes['Plan']>, ParentType, ContextType, RequireFields<MutationUploadPlanArgs, 'projectId'>>;
   upsertRelatedWork?: Resolver<Maybe<ResolversTypes['RelatedWorkSearchResult']>, ParentType, ContextType, RequireFields<MutationUpsertRelatedWorkArgs, 'input'>>;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -5326,6 +5326,8 @@ export type User = {
   givenName?: Maybe<Scalars['String']['output']>;
   /** The unique identifier for the Object */
   id?: Maybe<Scalars['Int']['output']>;
+  /** Whether or not account is archived */
+  isArchived?: Maybe<Scalars['Boolean']['output']>;
   /** The user's preferred language */
   languageId: Scalars['String']['output'];
   /** The timestamp of the last login */
@@ -8404,6 +8406,7 @@ export type UserResolvers<ContextType = MyContext, ParentType extends ResolversP
   failed_sign_in_attempts?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   givenName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  isArchived?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   languageId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   last_sign_in?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   last_sign_in_via?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2899,6 +2899,8 @@ export type PlanSearchResult = {
   modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
   modifiedBy?: Maybe<Scalars['String']['output']>;
+  /** The user who created the plan */
+  planCreator?: Maybe<User>;
   /** The timestamp for when the Plan was registered/published */
   registered?: Maybe<Scalars['String']['output']>;
   /** The person who published/registered the plan */
@@ -2911,8 +2913,6 @@ export type PlanSearchResult = {
   templateTitle?: Maybe<Scalars['String']['output']>;
   /** The title of the plan */
   title?: Maybe<Scalars['String']['output']>;
-  /** The user who created the plan */
-  user?: Maybe<User>;
   /** The section search results */
   versionedSections?: Maybe<Array<PlanSectionProgress>>;
   /** The versioned template id the plan is based on */
@@ -7577,13 +7577,13 @@ export type PlanSearchResultResolvers<ContextType = MyContext, ParentType extend
   members?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedBy?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  planCreator?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
   registered?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   registeredBy?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   status?: Resolver<Maybe<ResolversTypes['PlanStatus']>, ParentType, ContextType>;
   templateOwnerAffiliationName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   templateTitle?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
   versionedSections?: Resolver<Maybe<Array<ResolversTypes['PlanSectionProgress']>>, ParentType, ContextType>;
   versionedTemplateId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   visibility?: Resolver<Maybe<ResolversTypes['PlanVisibility']>, ParentType, ContextType>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1737,6 +1737,8 @@ export type Mutation = {
   updateTemplate?: Maybe<Template>;
   /** Update a customization (user must be an Admin) */
   updateTemplateCustomization: TemplateCustomizationOverview;
+  /** Update the specified user's information (SuperAdmin only) */
+  updateUserInfo?: Maybe<User>;
   /** Update the current user's email notifications */
   updateUserNotifications?: Maybe<User>;
   /** Update the current user's information */
@@ -2442,6 +2444,11 @@ export type MutationUpdateTemplateCustomizationArgs = {
 };
 
 
+export type MutationUpdateUserInfoArgs = {
+  input: UpdateUserInfoInput;
+};
+
+
 export type MutationUpdateUserNotificationsArgs = {
   input: UpdateUserNotificationsInput;
 };
@@ -2500,6 +2507,26 @@ export type OpenSearchWorkSource = {
   name: Scalars['String']['output'];
   /** The URL for the source of the work */
   url?: Maybe<Scalars['String']['output']>;
+};
+
+export type PaginatedPlanResults = PaginatedQueryResults & {
+  __typename?: 'PaginatedPlanResults';
+  /** The sortFields that are available for this query (for standard offset pagination only!) */
+  availableSortFields?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  /** The current offset of the results (for standard offset pagination) */
+  currentOffset?: Maybe<Scalars['Int']['output']>;
+  /** Whether or not there is a next page */
+  hasNextPage?: Maybe<Scalars['Boolean']['output']>;
+  /** Whether or not there is a previous page */
+  hasPreviousPage?: Maybe<Scalars['Boolean']['output']>;
+  /** The plans that match the search criteria */
+  items?: Maybe<Array<Maybe<PlanSearchResult>>>;
+  /** The number of items returned */
+  limit?: Maybe<Scalars['Int']['output']>;
+  /** The cursor to use for the next page of results (for infinite scroll/load more) */
+  nextCursor?: Maybe<Scalars['String']['output']>;
+  /** The total number of possible items */
+  totalCount?: Maybe<Scalars['Int']['output']>;
 };
 
 export type PaginatedQueryResults = {
@@ -2864,10 +2891,14 @@ export type PlanSearchResult = {
   registeredBy?: Maybe<Scalars['String']['output']>;
   /** The current status of the plan */
   status?: Maybe<PlanStatus>;
+  /** The name of the affiliation that owns the template the plan is based on */
+  templateOwnerAffiliationName?: Maybe<Scalars['String']['output']>;
   /** The name of the template the plan is based on */
   templateTitle?: Maybe<Scalars['String']['output']>;
   /** The title of the plan */
   title?: Maybe<Scalars['String']['output']>;
+  /** The user who created the plan */
+  user?: Maybe<User>;
   /** The section search results */
   versionedSections?: Maybe<Array<PlanSectionProgress>>;
   /** The versioned template id the plan is based on */
@@ -3387,8 +3418,8 @@ export type Query = {
   planFundings?: Maybe<Array<Maybe<PlanFunding>>>;
   /** Get all of the Users that are Members for the specific Plan */
   planMembers?: Maybe<Array<Maybe<PlanMember>>>;
-  /** Get all plans for the research project */
-  plans?: Maybe<Array<PlanSearchResult>>;
+  /** Get all plans for the research project with pagination support */
+  plans?: Maybe<PaginatedPlanResults>;
   /** Returns a list of the top 20 funders ranked by popularity (nbr of plans) for the past year */
   popularFunders?: Maybe<Array<Maybe<FunderPopularityResult>>>;
   /** Get a specific project */
@@ -3719,7 +3750,9 @@ export type QueryPlanMembersArgs = {
 
 
 export type QueryPlansArgs = {
+  paginationOptions?: InputMaybe<PaginationOptions>;
   projectId: Scalars['Int']['input'];
+  term?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -5197,6 +5230,23 @@ export type UpdateTemplateCustomizationInput = {
   templateCustomizationId: Scalars['Int']['input'];
 };
 
+export type UpdateUserInfoInput = {
+  /** The id of the affiliation if the user selected one from the typeahead list */
+  affiliationId?: InputMaybe<Scalars['String']['input']>;
+  /** The user's email address */
+  email: Scalars['String']['input'];
+  /** The user's given name */
+  givenName: Scalars['String']['input'];
+  /** The user's preferred language */
+  languageId?: InputMaybe<Scalars['String']['input']>;
+  /** The name of the affiliation if the user did not select one from the typeahead list */
+  otherAffiliationName?: InputMaybe<Scalars['String']['input']>;
+  /** The user's surname */
+  surName: Scalars['String']['input'];
+  /** The user's id */
+  userId: Scalars['Int']['input'];
+};
+
 export type UpdateUserNotificationsInput = {
   /** Whether or not email notifications are on for when a Plan has a new comment */
   notify_on_comment_added: Scalars['Boolean']['input'];
@@ -6055,6 +6105,7 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = 
     | ( CollaboratorSearchResults )
     | ( CustomizableTemplateSearchResults )
     | ( MetadataStandardSearchResults )
+    | ( PaginatedPlanResults )
     | ( ProjectSearchResults )
     | ( PublishedTemplateSearchResults )
     | ( RelatedWorkSearchResults )
@@ -6163,6 +6214,7 @@ export type ResolversTypes = {
   OpenSearchWork: ResolverTypeWrapper<OpenSearchWork>;
   OpenSearchWorkSource: ResolverTypeWrapper<OpenSearchWorkSource>;
   Orcid: ResolverTypeWrapper<Scalars['Orcid']['output']>;
+  PaginatedPlanResults: ResolverTypeWrapper<PaginatedPlanResults>;
   PaginatedQueryResults: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['PaginatedQueryResults']>;
   PaginationOptions: PaginationOptions;
   PaginationType: PaginationType;
@@ -6287,6 +6339,7 @@ export type ResolversTypes = {
   UpdateSectionCustomizationInput: UpdateSectionCustomizationInput;
   UpdateSectionInput: UpdateSectionInput;
   UpdateTemplateCustomizationInput: UpdateTemplateCustomizationInput;
+  UpdateUserInfoInput: UpdateUserInfoInput;
   UpdateUserNotificationsInput: UpdateUserNotificationsInput;
   UpdateUserProfileInput: UpdateUserProfileInput;
   UpsertRelatedWorkInput: UpsertRelatedWorkInput;
@@ -6412,6 +6465,7 @@ export type ResolversParentTypes = {
   OpenSearchWork: OpenSearchWork;
   OpenSearchWorkSource: OpenSearchWorkSource;
   Orcid: Scalars['Orcid']['output'];
+  PaginatedPlanResults: PaginatedPlanResults;
   PaginatedQueryResults: ResolversInterfaceTypes<ResolversParentTypes>['PaginatedQueryResults'];
   PaginationOptions: PaginationOptions;
   Plan: Plan;
@@ -6517,6 +6571,7 @@ export type ResolversParentTypes = {
   UpdateSectionCustomizationInput: UpdateSectionCustomizationInput;
   UpdateSectionInput: UpdateSectionInput;
   UpdateTemplateCustomizationInput: UpdateTemplateCustomizationInput;
+  UpdateUserInfoInput: UpdateUserInfoInput;
   UpdateUserNotificationsInput: UpdateUserNotificationsInput;
   UpdateUserProfileInput: UpdateUserProfileInput;
   UpsertRelatedWorkInput: UpsertRelatedWorkInput;
@@ -7267,6 +7322,7 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   updateTag?: Resolver<Maybe<ResolversTypes['Tag']>, ParentType, ContextType, RequireFields<MutationUpdateTagArgs, 'name' | 'tagId'>>;
   updateTemplate?: Resolver<Maybe<ResolversTypes['Template']>, ParentType, ContextType, RequireFields<MutationUpdateTemplateArgs, 'name' | 'templateId'>>;
   updateTemplateCustomization?: Resolver<ResolversTypes['TemplateCustomizationOverview'], ParentType, ContextType, RequireFields<MutationUpdateTemplateCustomizationArgs, 'input'>>;
+  updateUserInfo?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationUpdateUserInfoArgs, 'input'>>;
   updateUserNotifications?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationUpdateUserNotificationsArgs, 'input'>>;
   updateUserProfile?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationUpdateUserProfileArgs, 'input'>>;
   uploadPlan?: Resolver<Maybe<ResolversTypes['Plan']>, ParentType, ContextType, RequireFields<MutationUploadPlanArgs, 'projectId'>>;
@@ -7298,8 +7354,20 @@ export interface OrcidScalarConfig extends GraphQLScalarTypeConfig<ResolversType
   name: 'Orcid';
 }
 
+export type PaginatedPlanResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PaginatedPlanResults'] = ResolversParentTypes['PaginatedPlanResults']> = {
+  availableSortFields?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
+  currentOffset?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  hasNextPage?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  hasPreviousPage?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  items?: Resolver<Maybe<Array<Maybe<ResolversTypes['PlanSearchResult']>>>, ParentType, ContextType>;
+  limit?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  nextCursor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  totalCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type PaginatedQueryResultsResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PaginatedQueryResults'] = ResolversParentTypes['PaginatedQueryResults']> = {
-  __resolveType: TypeResolveFn<'AffiliationSearchResults' | 'CollaboratorSearchResults' | 'CustomizableTemplateSearchResults' | 'MetadataStandardSearchResults' | 'ProjectSearchResults' | 'PublishedTemplateSearchResults' | 'RelatedWorkSearchResults' | 'RepositorySearchResults' | 'ResearchDomainSearchResults' | 'TemplateSearchResults' | 'UserSearchResults' | 'VersionedSectionSearchResults', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'AffiliationSearchResults' | 'CollaboratorSearchResults' | 'CustomizableTemplateSearchResults' | 'MetadataStandardSearchResults' | 'PaginatedPlanResults' | 'ProjectSearchResults' | 'PublishedTemplateSearchResults' | 'RelatedWorkSearchResults' | 'RepositorySearchResults' | 'ResearchDomainSearchResults' | 'TemplateSearchResults' | 'UserSearchResults' | 'VersionedSectionSearchResults', ParentType, ContextType>;
 };
 
 export type PlanResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Plan'] = ResolversParentTypes['Plan']> = {
@@ -7475,8 +7543,10 @@ export type PlanSearchResultResolvers<ContextType = MyContext, ParentType extend
   registered?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   registeredBy?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   status?: Resolver<Maybe<ResolversTypes['PlanStatus']>, ParentType, ContextType>;
+  templateOwnerAffiliationName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   templateTitle?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
   versionedSections?: Resolver<Maybe<Array<ResolversTypes['PlanSectionProgress']>>, ParentType, ContextType>;
   versionedTemplateId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   visibility?: Resolver<Maybe<ResolversTypes['PlanVisibility']>, ParentType, ContextType>;
@@ -7739,7 +7809,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   planFeedbackStatus?: Resolver<Maybe<ResolversTypes['PlanFeedbackStatus']>, ParentType, ContextType, RequireFields<QueryPlanFeedbackStatusArgs, 'planId'>>;
   planFundings?: Resolver<Maybe<Array<Maybe<ResolversTypes['PlanFunding']>>>, ParentType, ContextType, RequireFields<QueryPlanFundingsArgs, 'planId'>>;
   planMembers?: Resolver<Maybe<Array<Maybe<ResolversTypes['PlanMember']>>>, ParentType, ContextType, RequireFields<QueryPlanMembersArgs, 'planId'>>;
-  plans?: Resolver<Maybe<Array<ResolversTypes['PlanSearchResult']>>, ParentType, ContextType, RequireFields<QueryPlansArgs, 'projectId'>>;
+  plans?: Resolver<Maybe<ResolversTypes['PaginatedPlanResults']>, ParentType, ContextType, RequireFields<QueryPlansArgs, 'projectId'>>;
   popularFunders?: Resolver<Maybe<Array<Maybe<ResolversTypes['FunderPopularityResult']>>>, ParentType, ContextType>;
   project?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType, RequireFields<QueryProjectArgs, 'projectId'>>;
   projectCollaborators?: Resolver<Maybe<Array<Maybe<ResolversTypes['ProjectCollaborator']>>>, ParentType, ContextType, RequireFields<QueryProjectCollaboratorsArgs, 'projectId'>>;
@@ -8753,6 +8823,7 @@ export type Resolvers<ContextType = MyContext> = {
   OpenSearchWork?: OpenSearchWorkResolvers<ContextType>;
   OpenSearchWorkSource?: OpenSearchWorkSourceResolvers<ContextType>;
   Orcid?: GraphQLScalarType;
+  PaginatedPlanResults?: PaginatedPlanResultsResolvers<ContextType>;
   PaginatedQueryResults?: PaginatedQueryResultsResolvers<ContextType>;
   Plan?: PlanResolvers<ContextType>;
   PlanErrors?: PlanErrorsResolvers<ContextType>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1555,6 +1555,8 @@ export type Mutation = {
   archiveProject?: Maybe<Project>;
   /** Archive a Template (unpublishes any associated PublishedTemplate */
   archiveTemplate?: Maybe<Template>;
+  /** Archive the specified user and anonymize their data (Admin only) */
+  archiveUser?: Maybe<User>;
   /** Mark the feedback round as complete */
   completeFeedback?: Maybe<PlanFeedback>;
   /** Publish the template or save as a draft */
@@ -1962,6 +1964,11 @@ export type MutationArchiveProjectArgs = {
 
 export type MutationArchiveTemplateArgs = {
   templateId: Scalars['Int']['input'];
+};
+
+
+export type MutationArchiveUserArgs = {
+  userId: Scalars['Int']['input'];
 };
 
 
@@ -3519,6 +3526,8 @@ export type Query = {
   topLevelResearchDomains?: Maybe<Array<Maybe<ResearchDomain>>>;
   /** Returns the specified user (Admin only) */
   user?: Maybe<User>;
+  /** Get all projects for a specified user (Admin only!) */
+  userProjects?: Maybe<ProjectSearchResults>;
   /** Returns all of the users associated with the current admin's affiliation (Super admins get everything) */
   users?: Maybe<UserSearchResults>;
   /** Get all VersionedGuidance for a given affiliation and Tag IDs */
@@ -3751,8 +3760,8 @@ export type QueryPlanMembersArgs = {
 
 export type QueryPlansArgs = {
   paginationOptions?: InputMaybe<PaginationOptions>;
-  projectId: Scalars['Int']['input'];
   term?: InputMaybe<Scalars['String']['input']>;
+  userId: Scalars['Int']['input'];
 };
 
 
@@ -3993,6 +4002,14 @@ export type QueryTemplateVersionsArgs = {
 
 
 export type QueryUserArgs = {
+  userId: Scalars['Int']['input'];
+};
+
+
+export type QueryUserProjectsArgs = {
+  filterOptions?: InputMaybe<ProjectFilterOptions>;
+  paginationOptions?: InputMaybe<PaginationOptions>;
+  term?: InputMaybe<Scalars['String']['input']>;
   userId: Scalars['Int']['input'];
 };
 
@@ -7231,6 +7248,7 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   archivePlan?: Resolver<Maybe<ResolversTypes['Plan']>, ParentType, ContextType, RequireFields<MutationArchivePlanArgs, 'planId'>>;
   archiveProject?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType, RequireFields<MutationArchiveProjectArgs, 'projectId'>>;
   archiveTemplate?: Resolver<Maybe<ResolversTypes['Template']>, ParentType, ContextType, RequireFields<MutationArchiveTemplateArgs, 'templateId'>>;
+  archiveUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationArchiveUserArgs, 'userId'>>;
   completeFeedback?: Resolver<Maybe<ResolversTypes['PlanFeedback']>, ParentType, ContextType, RequireFields<MutationCompleteFeedbackArgs, 'planFeedbackId' | 'planId'>>;
   createTemplateVersion?: Resolver<Maybe<ResolversTypes['Template']>, ParentType, ContextType, RequireFields<MutationCreateTemplateVersionArgs, 'latestPublishVisibility' | 'templateId'>>;
   deactivateUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationDeactivateUserArgs, 'userId'>>;
@@ -7809,7 +7827,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   planFeedbackStatus?: Resolver<Maybe<ResolversTypes['PlanFeedbackStatus']>, ParentType, ContextType, RequireFields<QueryPlanFeedbackStatusArgs, 'planId'>>;
   planFundings?: Resolver<Maybe<Array<Maybe<ResolversTypes['PlanFunding']>>>, ParentType, ContextType, RequireFields<QueryPlanFundingsArgs, 'planId'>>;
   planMembers?: Resolver<Maybe<Array<Maybe<ResolversTypes['PlanMember']>>>, ParentType, ContextType, RequireFields<QueryPlanMembersArgs, 'planId'>>;
-  plans?: Resolver<Maybe<ResolversTypes['PaginatedPlanResults']>, ParentType, ContextType, RequireFields<QueryPlansArgs, 'projectId'>>;
+  plans?: Resolver<Maybe<ResolversTypes['PaginatedPlanResults']>, ParentType, ContextType, RequireFields<QueryPlansArgs, 'userId'>>;
   popularFunders?: Resolver<Maybe<Array<Maybe<ResolversTypes['FunderPopularityResult']>>>, ParentType, ContextType>;
   project?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType, RequireFields<QueryProjectArgs, 'projectId'>>;
   projectCollaborators?: Resolver<Maybe<Array<Maybe<ResolversTypes['ProjectCollaborator']>>>, ParentType, ContextType, RequireFields<QueryProjectCollaboratorsArgs, 'projectId'>>;
@@ -7860,6 +7878,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   templateVersions?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedTemplate']>>>, ParentType, ContextType, RequireFields<QueryTemplateVersionsArgs, 'templateId'>>;
   topLevelResearchDomains?: Resolver<Maybe<Array<Maybe<ResolversTypes['ResearchDomain']>>>, ParentType, ContextType>;
   user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserArgs, 'userId'>>;
+  userProjects?: Resolver<Maybe<ResolversTypes['ProjectSearchResults']>, ParentType, ContextType, RequireFields<QueryUserProjectsArgs, 'userId'>>;
   users?: Resolver<Maybe<ResolversTypes['UserSearchResults']>, ParentType, ContextType, Partial<QueryUsersArgs>>;
   versionedGuidance?: Resolver<Array<ResolversTypes['VersionedGuidance']>, ParentType, ContextType, RequireFields<QueryVersionedGuidanceArgs, 'affiliationId' | 'tagIds'>>;
 };


### PR DESCRIPTION
## Description

- Added `isArchived` field to the `users` table to help us filter those users out when returned in `users` response
- Added `findByProjectIdWithPagination` method to the `PlanSearchResult` model for the `plans` resolver 
- Added `userProjects` query to return all projects for a specified user, with search term and pagination
- Added `updateUserRole` mutation for admins to change a user's role, `updateUserInfo` mutation for super admins to update a specified user's profile, and an `archiveUser` mutation to archive a user
- Updated `plans` resolver to have pagination for a specified `userId` with optional `search term`, and added a chained resolver for `PlanSearchResult` for `templateOwnerAffiliationName`
- Updated `PlanSearchResult` model to include `createdById` and `templateOwnerAffiliationName` for the Admin Users page

Fixes # ([281](https://github.com/CDLUC3/dmptool-doc/issues/281))

## Type of change
- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Manually tested and tested with new unit tests, and frontend changes.

## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [*] Any dependent changes have been merged and published in downstream modules
*Note: There are corresponding frontend changes: https://github.com/CDLUC3/dmptool-ui/pull/1322