### PR TITLE
Addressed bug in updateAffiliation resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,7 @@
 - Removed `ioredis` package
 
 ### Fixed
+- Updated `requestFeedback` with better error messaging for when `feedbackEnabled` is false or there are no `feedbackEmails`. Also, added checks for `input.subHeaderLinks` and `input.ssoEmailDomains` in `updateAffiliations` since it was breaking that mutation when those fields were not included. Also, removed the debugging I had previously added to investigate the `requestFeedback` resolver failing. [#285]
 - Fixed error in `data-migrations/local-only/2026-05-08-1111-seed-project-plan.sql` when inserting data for `templates` and `versionedTemplates` tables which were missing the new `isDefault` value.
 - Fixed an issue with duplicate URIs being returned to `findRe3DataByURIs` by deduping [#33]
 - Fixed bug in `openSearchService` that was throwing an error and not returning repositories [#196]

--- a/src/resolvers/__tests__/feedback.spec.ts
+++ b/src/resolvers/__tests__/feedback.spec.ts
@@ -104,7 +104,11 @@ beforeEach(async () => {
   jest.spyOn(ProjectCollaborator, 'findByProjectId').mockResolvedValue([]);
   jest.spyOn(ProjectCollaborator, 'findPrimaryUserByProjectId').mockResolvedValue(null);
   jest.spyOn(Affiliation, 'findByURI').mockResolvedValue(
-    new Affiliation({ uri: affiliationId, feedbackEmails: [casual.email] })
+    new Affiliation({ 
+      uri: affiliationId, 
+      feedbackEmails: [casual.email],
+      feedbackEnabled: true,
+     })
   );
   jest.spyOn(PlanFeedback.prototype, 'create').mockResolvedValue(feedback);
   jest.spyOn(PlanFeedback.prototype, 'update').mockResolvedValue(feedback);

--- a/src/resolvers/affiliation.ts
+++ b/src/resolvers/affiliation.ts
@@ -303,21 +303,24 @@ export const resolvers: Resolvers = {
 
             const updated: Affiliation = await affiliation.update(context);
             if (updated && !updated.hasErrors()) {
-              // If the update was successful reconcile any AffiliationLinks
-              const links: AffiliationLink[] = input.subHeaderLinks.map((shl: AffiliationLinkInput): AffiliationLink => {
-                return new AffiliationLink(shl);
-              })
-              await reconcileAffiliationLinks(context, reference, updated, links);
-
+              if (input.subHeaderLinks) {
+                // If the update was successful reconcile any AffiliationLinks
+                const links: AffiliationLink[] = input.subHeaderLinks.map((shl: AffiliationLinkInput): AffiliationLink => {
+                  return new AffiliationLink(shl);
+                })
+                await reconcileAffiliationLinks(context, reference, updated, links);
+              }
               // If the user is a superAdmin, also reconcile any AffiliationEmailDomains
               if (superAdmin) {
-                const domains: AffiliationEmailDomain[] = input.ssoEmailDomains.map((ed: string): AffiliationEmailDomain => {
-                  return new AffiliationEmailDomain({
-                    affiliationId: updated.uri,
-                    emailDomain: ed
-                  });
-                })
-                await reconcileAffiliationEmailDomains(context, reference, updated, domains);
+                if (input.ssoEmailDomains) {
+                  const domains: AffiliationEmailDomain[] = input.ssoEmailDomains.map((ed: string): AffiliationEmailDomain => {
+                    return new AffiliationEmailDomain({
+                      affiliationId: updated.uri,
+                      emailDomain: ed
+                    });
+                  })
+                  await reconcileAffiliationEmailDomains(context, reference, updated, domains);
+                }
               }
             }
 

--- a/src/resolvers/feedback.ts
+++ b/src/resolvers/feedback.ts
@@ -180,16 +180,6 @@ export const resolvers: Resolvers = {
 
             const affiliation = await Affiliation.findByURI(reference, context, affiliationId);
 
-            if (!affiliation.feedbackEnabled) {
-              context.logger.warn({ affiliationId }, `${reference}: feedback is not enabled for affiliation`);
-              throw ForbiddenError(`Feedback is not enabled for your organization. Please enable it in your feedback settings.`);
-            }
-
-            if (affiliation.feedbackEmails.length === 0) {
-              context.logger.warn({ affiliationId }, `${reference}: no feedback emails configured`);
-              throw ForbiddenError(`No feedback recipients are configured for your organization. Please add at least one email in your feedback settings.`);
-            }
-
             const planURL = `/projects/${project.id}/dmp/${planId}`;
             const planOwnerName = [context.token.givenName, context.token.surname].filter(Boolean).join(' ');
             const planTitle = plan.title || 'Untitled Plan';

--- a/src/resolvers/feedback.ts
+++ b/src/resolvers/feedback.ts
@@ -153,22 +153,17 @@ export const resolvers: Resolvers = {
 
       try {
         if (isAuthorized(context.token)) {
-          context.logger.info({ planId, userId: context.token.id, affiliationId: context.token.affiliationId }, `${reference}: authorized, starting`);
-
           const plan = await Plan.findById(reference, context, planId);
           if (!plan) {
             throw NotFoundError(`Plan with ID ${planId} not found`);
           }
-          context.logger.info({ planId, projectId: plan.projectId, versionedTemplateId: plan.versionedTemplateId }, `${reference}: plan found`);
 
           const project = await Project.findById(reference, context, plan.projectId);
           if (!project) {
             throw NotFoundError(`Project with ID ${plan.projectId} not found`);
           }
-          context.logger.info({ projectId: project.id }, `${reference}: project found`);
 
           const existingFeedback = await PlanFeedback.findByPlanId(reference, context, planId);
-          context.logger.info({ existingFeedbackCount: existingFeedback.length }, `${reference}: existing feedback fetched`);
 
           const hasOpenFeedback = existingFeedback.some((fb) => fb.completed === null);
           if (hasOpenFeedback) {
@@ -176,29 +171,28 @@ export const resolvers: Resolvers = {
           }
 
           const hasPrimaryPermission = await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.PRIMARY);
-          context.logger.info({ hasPrimaryPermission }, `${reference}: permission check`);
 
           if (hasPrimaryPermission) {
             const affiliationId = context.token.affiliationId;
             if (!affiliationId) {
               throw NotFoundError(`Affiliation for user not found`);
             }
-            context.logger.info({ affiliationId }, `${reference}: looking up affiliation`);
 
             const affiliation = await Affiliation.findByURI(reference, context, affiliationId);
-            context.logger.info(
-              { affiliationUri: affiliation?.uri, feedbackEmailCount: affiliation?.feedbackEmails?.length ?? 0 },
-              `${reference}: affiliation found`
-            );
+
+            if (!affiliation.feedbackEnabled) {
+              context.logger.warn({ affiliationId }, `${reference}: feedback is not enabled for affiliation`);
+              throw ForbiddenError(`Feedback is not enabled for your organization. Please enable it in your feedback settings.`);
+            }
 
             if (affiliation.feedbackEmails.length === 0) {
               context.logger.warn({ affiliationId }, `${reference}: no feedback emails configured`);
+              throw ForbiddenError(`No feedback recipients are configured for your organization. Please add at least one email in your feedback settings.`);
             }
 
             const planURL = `/projects/${project.id}/dmp/${planId}`;
             const planOwnerName = [context.token.givenName, context.token.surname].filter(Boolean).join(' ');
             const planTitle = plan.title || 'Untitled Plan';
-            context.logger.info({ planURL, planOwnerName, planTitle }, `${reference}: sending feedback request email`);
 
             await sendFeedbackRequestEmail(context, planOwnerName, planURL, planTitle, affiliation.feedbackEmails, messageToOrg ?? '');
             context.logger.info(`${reference}: feedback request email sent`);
@@ -211,7 +205,6 @@ export const resolvers: Resolvers = {
             });
 
             const createdFeedback = await feedbackComment.create(context);
-            context.logger.info({ createdFeedbackId: createdFeedback?.id ?? null }, `${reference}: feedback record created`);
 
             if (createdFeedback?.id) {
               await AdminNotification.addNotificationForAffiliation(
@@ -221,16 +214,11 @@ export const resolvers: Resolvers = {
                 'FEEDBACK_REQUESTED',
                 { planId },
               );
-              context.logger.info({ affiliationUri: affiliation.uri }, `${reference}: admin notification sent`);
             }
 
             return createdFeedback;
           }
         }
-        context.logger.warn(
-          { hasToken: !!context?.token, userId: context?.token?.id },
-          `${reference}: reached auth fallthrough — user did not pass permission checks`
-        );
         throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {
         if (err instanceof GraphQLError) throw err;

--- a/src/services/__tests__/emailService.spec.ts
+++ b/src/services/__tests__/emailService.spec.ts
@@ -311,7 +311,7 @@ describe('sendEmail', () => {
     expect(context.logger.error).toHaveBeenCalledTimes(1);
   });
 
-  it.only('should send feedback request emails to all collaborators', async () => {
+  it('should send feedback request emails to all collaborators', async () => {
     jest.spyOn(logger, 'info');
     const emails = Array.from({ length: 3 }, () => casual.email);
     const planOwnerName = `${casual.first_name} ${casual.last_name}`;

--- a/src/services/__tests__/emailService.spec.ts
+++ b/src/services/__tests__/emailService.spec.ts
@@ -311,7 +311,7 @@ describe('sendEmail', () => {
     expect(context.logger.error).toHaveBeenCalledTimes(1);
   });
 
-  it('should send feedback request emails to all collaborators', async () => {
+  it.only('should send feedback request emails to all collaborators', async () => {
     jest.spyOn(logger, 'info');
     const emails = Array.from({ length: 3 }, () => casual.email);
     const planOwnerName = `${casual.first_name} ${casual.last_name}`;
@@ -334,7 +334,7 @@ describe('sendEmail', () => {
       .replace('%{helpUrl}', `${domain}/help`);
 
     expect(sent).toBe(true);
-    expect(logger.info).toHaveBeenCalledTimes(emails.length + 2); // accounting for additional info logs for sending and finishing
+    expect(logger.info).toHaveBeenCalledTimes(emails.length);
     expect(mockSendEmail).toHaveBeenCalledTimes(emails.length);
     for (const email of emails) {
       const expectedHtml = baseHtml.replace('%{adminEmail}', email);

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -298,13 +298,9 @@ export const sendFeedbackRequestEmail = async (
     .replace('%{helpDeskEmail}', emailConfig.helpDeskAddress)
     .replace('%{helpUrl}', `${domain}/help`);
 
-  context.logger.info(`Sending feedback request email to ${collaboratorEmails.length} collaborators for plan "${planTitle}" at URL ${domain}${planURL}`);
-  context.logger.debug(prepareObjectForLogs({ collaboratorEmails, planOwnerName, planURL, planTitle, feedbackRequestMessage }), `Feedback request email details`);
-
   // Send each feedback email recipient their own email
   for (const email of collaboratorEmails) {
     const message = baseMessage.replace('%{adminEmail}', email);
-    context.logger.debug(prepareObjectForLogs({ email, message }), `Sending feedback request email to ${email}`);
     await sendEmail(
       context,
       'FeedbackRequest',
@@ -315,6 +311,5 @@ export const sendFeedbackRequestEmail = async (
       message
     );
   }
-  context.logger.info(`Finished sending feedback request emails for plan "${planTitle}"`);
   return true;
 }


### PR DESCRIPTION
## Description

Previously, on `dev` and `stage` it appeared that `requestFeedback` functionality had failed because the user would get a `Something went wrong` error. But what I found based on the debugging I added, was that this was happening because the affiliation had no`feedbackEmails` in the database table. So, we added better messaging to the client when that happens.

Also, when I then tried to add `feedbackEmails` on the "Feedback Options" page, I was getting the same "Something went wrong" errors. This was because `updateAffiliations` was erroring on there being no `subHeaderLinks` or `ssoEmailDomains` in the `input`. We added checks for this so that it doesn't break.

- Updated `requestFeedback` with better error messaging for when `feedbackEnabled` is false or there are no `feedbackEmails`. 
- Added checks for `input.subHeaderLinks` and `input.ssoEmailDomains` in `updateAffiliations` since it was breaking that mutation when those fields were not included. 
- Removed the debugging I had previously added to investigate the `requestFeedback` resolver failing.

Fixes # ([285](https://github.com/CDLUC3/dmptool-doc/issues/285))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually tested


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules