### PR TITLE
Updated the 'users' resolver methods to return all users for download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated the `users` resolver, and `User.findByAffiliationId` and `User.search` so that when no `paginationOptions` are provided, it returns all results at once for a given affiliationId. This is required for downloading users on the Admin Users page [#238]
 - Updated `plans` resolver to have pagination for a specified `userId` with optional `search term`, and added a chained resolver for `PlanSearchResult` for `templateOwnerAffiliationName` [#281]
 - Updated `PlanSearchResult` model to include `createdById` and `templateOwnerAffiliationName` for the Admin Users page [#281]
 - Update local migration to add RO question to default template

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -209,12 +209,13 @@ export class User extends MySqlModel {
   }
 
   // Return all the Users associated with the specified affiliationId that match the search term
+  // Pagination is optional, but if provided will be used to limit the results
   static async findByAffiliationId(
     reference: string,
     context: MyContext,
     affiliationId: string,
     term: string,
-    options: PaginationOptions = User.getDefaultPaginationOptions(),
+    options: PaginationOptions, // This is optional
     role?: UserRole
   ): Promise<PaginatedQueryResults<User>> {
     const whereFilters = ['u.affiliationId = ?'];
@@ -228,7 +229,7 @@ export class User extends MySqlModel {
     }
     // Handle the incoming search term
     const searchTerm = (term ?? '').toLowerCase().trim();
-    if (!isNullOrUndefined(searchTerm)) {
+    if (searchTerm) {
       whereFilters.push(`(
         (LOWER(u.givenName) LIKE ? OR
         LOWER(u.surName) LIKE ? OR
@@ -243,7 +244,15 @@ export class User extends MySqlModel {
     LEFT JOIN userEmails ue ON u.id = ue.userId AND ue.isPrimary = 1
   `;
 
-    // Determine the type of pagination being used
+    // If no pagination options, then return ALL results
+    if (isNullOrUndefined(options)) {
+      const sql = `${sqlStatement} WHERE ${whereFilters.join(' AND ')} ORDER BY u.created DESC`;
+      const results = await User.query(context, sql, values, reference);
+      const items = Array.isArray(results) ? results.map(r => new User(r)) : [];
+      return { items, totalCount: items.length, hasNextPage: false, hasPreviousPage: false, limit: items.length, currentOffset: 0 };
+    }
+
+    // If there are pagination options, determine the type of pagination being used
     let opts;
     if (options.type === PaginationType.OFFSET) {
       opts = {
@@ -285,7 +294,7 @@ export class User extends MySqlModel {
     reference: string,
     context: MyContext,
     term: string,
-    options: PaginationOptions = User.getDefaultPaginationOptions(),
+    options: PaginationOptions, // This is optional
     role?: UserRole,
     affiliationId?: string,
   ): Promise<PaginatedQueryResults<User>> {
@@ -296,7 +305,7 @@ export class User extends MySqlModel {
 
     // Handle the incoming search term
     const searchTerm = (term ?? '').toLowerCase().trim();
-    if (!isNullOrUndefined(searchTerm)) {
+    if (searchTerm) {
       whereFilters.push(`(
         LOWER(u.givenName) LIKE ? OR
         LOWER(u.surName) LIKE ? OR
@@ -316,6 +325,21 @@ export class User extends MySqlModel {
     if (!isNullOrUndefined(affiliationId)) {
       whereFilters.push('a.uri = ?');
       values.push(affiliationId);
+    }
+
+    // Join users with user_emails
+    const sqlStatement = `
+    SELECT u.*, a.name, a.uri FROM users u
+                      LEFT JOIN affiliations a ON u.affiliationId = a.uri
+                      LEFT JOIN userEmails ue ON u.id = ue.userId AND ue.isPrimary = 1
+  `;
+
+    // If no pagination options, then return ALL results
+    if (isNullOrUndefined(options)) {
+      const sql = `${sqlStatement} WHERE ${whereFilters.join(' AND ')} ORDER BY u.created DESC`;
+      const results = await User.query(context, sql, values, reference);
+      const items = Array.isArray(results) ? results.map(r => new User(r)) : [];
+      return { items, totalCount: items.length, hasNextPage: false, hasPreviousPage: false, limit: items.length, currentOffset: 0 };
     }
 
     // Determine the type of pagination being used
@@ -340,13 +364,6 @@ export class User extends MySqlModel {
 
     // Specify the field we want to use for the count
     opts.countField = 'u.id';
-
-    // Join users with user_emails
-    const sqlStatement = `
-    SELECT u.*, a.name, a.uri FROM users u
-                      LEFT JOIN affiliations a ON u.affiliationId = a.uri
-                      LEFT JOIN userEmails ue ON u.id = ue.userId AND ue.isPrimary = 1
-  `;
 
     const response: PaginatedQueryResults<User> = await User.queryWithPagination(
       context,

--- a/src/models/__tests__/User.spec.ts
+++ b/src/models/__tests__/User.spec.ts
@@ -1298,14 +1298,12 @@ describe('search', () => {
     expect(result.totalCount).toBe(0);
   });
 
-  it('handles an empty search term without adding whereFilters', async () => {
+  it('does not add search filters for an empty search term', async () => {
     await User.search('testRef', context, '', { type: PaginationType.OFFSET });
 
     const callArgs = (User.queryWithPagination as jest.Mock).mock.calls[0];
     const whereFilters = callArgs[2];
 
-    // empty string is still truthy for isNullOrUndefined, so the LIKE block still runs —
-    // but the values will all be '%%' (match everything), not zero filters
-    expect(whereFilters.some((f: string) => f.includes('LOWER(u.givenName) LIKE ?'))).toBe(true);
+    expect(whereFilters.some((f: string) => f.includes('LOWER(u.givenName) LIKE ?'))).toBe(false);
   });
 });

--- a/src/resolvers/user.ts
+++ b/src/resolvers/user.ts
@@ -46,6 +46,10 @@ export const resolvers: Resolvers = {
           : { ...paginationOptions, type: PaginationType.CURSOR } as PaginationOptionsForCursors;
 
         if (isSuperAdmin(context.token)) {
+          // Bulk export (no pagination) without a specified affiliation is not allowed
+          if (isNullOrUndefined(paginationOptions) && isNullOrUndefined(affiliationId)) {
+            throw ForbiddenError('An organization must be specified to export all users.');
+          }
           return await User.search(reference, context, term, opts, role as unknown as UserRole, affiliationId);
 
         } else if (isAdmin(context.token)) {


### PR DESCRIPTION

## Description
- Updated the `users` resolver, and `User.findByAffiliationId` and `User.search` so that when no `paginationOptions` are provided, it returns all results at once for a given affiliationId. This is required for downloading users on the Admin Users page

Fixes # ([238](https://github.com/CDLUC3/dmptool-ui/issues/238))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested and updated unit test.


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules