### PR TITLE
Updated VersionedGuidance and Guidance models to make tagId be optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated `Guidance` and `VersionedGuidance` classes to make `tagId` optional, since it was causing errors on `dev` where `guidance` records had no `tagId`. This is consistent with the `guidance` table schema which allows the `tagId` field to be `NULL` [#54]
 - Updated `plans` resolver to have pagination for a specified `userId` with optional `search term`, and added a chained resolver for `PlanSearchResult` for `templateOwnerAffiliationName` [#281]
 - Updated `PlanSearchResult` model to include `createdById` and `templateOwnerAffiliationName` for the Admin Users page [#281]
 - Update local migration to add RO question to default template

--- a/src/models/Guidance.ts
+++ b/src/models/Guidance.ts
@@ -4,7 +4,7 @@ import { MySqlModel } from "./MySqlModel";
 export class Guidance extends MySqlModel {
   public guidanceGroupId: number;
   public guidanceText?: string;
-  public tagId: number;
+  public tagId?: number;
 
   private static tableName = 'guidance';
 

--- a/src/models/VersionedGuidance.ts
+++ b/src/models/VersionedGuidance.ts
@@ -5,7 +5,7 @@ export class VersionedGuidance extends MySqlModel {
   public versionedGuidanceGroupId: number;
   public guidanceId?: number;
   public guidanceText?: string;
-  public tagId: number;
+  public tagId?: number;
 
   private static tableName = 'versionedGuidance';
 
@@ -23,7 +23,6 @@ export class VersionedGuidance extends MySqlModel {
     await super.isValid();
 
     if (!this.versionedGuidanceGroupId) this.addError('versionedGuidanceGroupId', 'VersionedGuidanceGroup ID can\'t be blank');
-    if (!this.tagId) this.addError('tagId', 'Tag ID can\'t be blank');
     if (!this.guidanceText) this.addError('guidanceText', 'Guidance text can\'t be blank');
 
     return Object.keys(this.errors).length === 0;

--- a/src/models/__tests__/VersionedGuidance.spec.ts
+++ b/src/models/__tests__/VersionedGuidance.spec.ts
@@ -47,11 +47,9 @@ describe('VersionedGuidance', () => {
     expect(versionedGuidance.errors['versionedGuidanceGroupId']).toBeTruthy();
   });
 
-  it('should return false when calling isValid without a tagId', async () => {
+  it('should return true when calling isValid without a tagId', async () => {
     versionedGuidance.tagId = null;
-    expect(await versionedGuidance.isValid()).toBe(false);
-    expect(Object.keys(versionedGuidance.errors).length).toBe(1);
-    expect(versionedGuidance.errors['tagId']).toBeTruthy();
+    expect(await versionedGuidance.isValid()).toBe(true);
   });
 });
 

--- a/src/schemas/versionedGuidance.ts
+++ b/src/schemas/versionedGuidance.ts
@@ -64,7 +64,7 @@ export const typeDefs = gql`
     "The guidance text content"
     guidanceText: String
     "The Tag ID (one of the associated tags)"
-    tagId: Int!
+    tagId: Int
 
     "The VersionedGuidanceGroup this belongs to"
     versionedGuidanceGroup: VersionedGuidanceGroup

--- a/src/types.ts
+++ b/src/types.ts
@@ -5578,7 +5578,7 @@ export type VersionedGuidance = {
   /** The user who last modified the Object */
   modifiedById?: Maybe<Scalars['Int']['output']>;
   /** The Tag ID (one of the associated tags) */
-  tagId: Scalars['Int']['output'];
+  tagId?: Maybe<Scalars['Int']['output']>;
   /** All Tags associated with this VersionedGuidance */
   tags?: Maybe<Array<Tag>>;
   /** The VersionedGuidanceGroup this belongs to */
@@ -8556,7 +8556,7 @@ export type VersionedGuidanceResolvers<ContextType = MyContext, ParentType exten
   id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  tagId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  tagId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   tags?: Resolver<Maybe<Array<ResolversTypes['Tag']>>, ParentType, ContextType>;
   versionedGuidanceGroup?: Resolver<Maybe<ResolversTypes['VersionedGuidanceGroup']>, ParentType, ContextType>;
   versionedGuidanceGroupId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;


### PR DESCRIPTION
## Description

Trying to publish a guidanceGroup on `dev` was consistently failing, although I could not reproduce it locally.

After looking at the logs, the issue appeared to be that none of the `guidance` records on `dev` have `tagId` values, and it was required in the `Guidance` and `VersionedGuidance` models, even though the `guidance` table has it as optional (can be `NULL`).

- Updated `Guidance` and `VersionedGuidance` classes to make `tagId` optional, since it was causing errors on `dev` where `guidance` records had no `tagId`. This is consistent with the `guidance` table schema which allows the `tagId` field to be `NULL` 

Fixes # ([54](https://github.com/CDLUC3/dmptool-doc/issues/54))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tests passing


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules