### PR TITLE
Fixed build issue because package-lock.json was referencing a tarball dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,7 @@
 - Removed `ioredis` package
 
 ### Fixed
+- Build was breaking because of a `package-lock.json` was referencing a file for `dmptool-utils`.
 - Updated `requestFeedback` with better error messaging for when `feedbackEnabled` is false or there are no `feedbackEmails`. Also, added checks for `input.subHeaderLinks` and `input.ssoEmailDomains` in `updateAffiliations` since it was breaking that mutation when those fields were not included. Also, removed the debugging I had previously added to investigate the `requestFeedback` resolver failing. [#285]
 - Fixed error in `data-migrations/local-only/2026-05-08-1111-seed-project-plan.sql` when inserting data for `templates` and `versionedTemplates` tables which were missing the new `isDefault` value.
 - Fixed an issue with duplicate URIs being returned to `findRe3DataByURIs` by deduping [#33]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1668,7 +1668,7 @@
     },
     "node_modules/@dmptool/types": {
       "version": "4.0.0",
-      "resolved": "file:dmptool-types-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@dmptool/types/-/types-4.0.0.tgz",
       "integrity": "sha512-P0UGaP76K3Ex8m67rYh1wE31cF1qVd0Zb+07ifMWlYjmdCpDW1LaYVC1ywNaV7wmHqRL3hbYjCsAUbrv5N/94A==",
       "hasInstallScript": true,
       "license": "MIT",
@@ -1679,13 +1679,13 @@
     },
     "node_modules/@dmptool/utils": {
       "version": "2.1.6",
-      "resolved": "file:dmptool-utils-2.1.6.tgz",
-      "integrity": "sha512-89YP/oSseWSh4WmTaXK4fF9Cxa/RlPkXF8xTisQXLzCX4ZjUfEVKUhOIbumPVBs7Bp1thDyOn7dTg5OCQ1QVnw==",
+      "resolved": "https://registry.npmjs.org/@dmptool/utils/-/utils-2.1.6.tgz",
+      "integrity": "sha512-c0dZGrshnsentUxndyVwtcWf1H92xEi2/G4f6ZWmFVtl8F+X93aFRbHOVHZGkUC20EkNsBvkkhNfQC/m3kpZeA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/s3-presigned-post": "^3.1076.0",
-        "@dmptool/types": "file:./dmptool-types-4.0.0.tgz",
+        "@dmptool/types": "^4.0.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "date-fns": "^4.4.0",
         "jsonschema": "^1.5.0",


### PR DESCRIPTION
## Description

The build was still breaking due to `package-lock.json` referencing a tarball file for `dmptool-utils`. Probably something that I mistakenly added when testing a branch.
