### PR TITLE
Update project member resolvers for other affiliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated `updateProjectMember` resolver to handle `Other Affiliation`. Added a new, shared `resolveAffiliation` function to `affiliationService.ts`. Updated `updateProjectMember` schema to include `affiliationName` [#309]
 - Updated the `Answer` model to use the newly exported `DefaultResearchOutputTypeAnswer` from `@dmptool/types` instead of manually building it
 - Updated `Guidance` and `VersionedGuidance` classes to make `tagId` optional, since it was causing errors on `dev` where `guidance` records had no `tagId`. This is consistent with the `guidance` table schema which allows the `tagId` field to be `NULL` [#54]
 - Updated `emailService.ts` with the addition of `sendContactUsEmail` [#297]

--- a/src/resolvers/member.ts
+++ b/src/resolvers/member.ts
@@ -13,7 +13,7 @@ import { GraphQLError } from 'graphql';
 import { Plan } from '../models/Plan';
 import { isNullOrUndefined, normaliseDateTime } from "../utils/helpers";
 import { ProjectCollaboratorAccessLevel } from "../models/Collaborator";
-import { processOtherAffiliationName } from '../services/affiliationService';
+import { resolveAffiliation } from '../services/affiliationService';
 
 
 export const resolvers: Resolvers = {
@@ -100,34 +100,13 @@ export const resolvers: Resolvers = {
             throw NotFoundError();
           }
 
-          // If an affiliationId was provided, check if it exists and create it if it doesn't
-          if (input.affiliationId && input.affiliationId.length > 0) {
-            const existingAffiliation = await Affiliation.findByURI(reference, context, input.affiliationId);
-            if (!existingAffiliation && input.affiliationName) {
-              // Create the affiliation with the provided URI and name
-              const newAffiliation = new Affiliation({
-                uri: input.affiliationId,
-                name: input.affiliationName
-              });
-
-              const createdAffiliation = await newAffiliation.create(context);
-
-              if (!createdAffiliation || createdAffiliation.hasErrors()) {
-                const errorMember = new ProjectMember(input);
-                errorMember.addError('affiliation', 'Unable to create required affiliation');
-                return errorMember;
-              }
-
-              // Update the input to use the URI from the created affiliation
-              input.affiliationId = createdAffiliation.uri;
-            }
-          } else if (input.affiliationName) {
-            // If only an affiliationName was provided, then process it to generate a URI
-            const affiliation = await processOtherAffiliationName(context, input.affiliationName, context.token.id);
-            if (affiliation) {
-              input.affiliationId = String(affiliation.uri);
-            }
+          const { affiliationId, error } = await resolveAffiliation(reference, context, input, context.token.id);
+          if (error) {
+            const errorMember = new ProjectMember(input);
+            errorMember.addError('affiliation', error);
+            return errorMember;
           }
+          input.affiliationId = affiliationId;
 
           if (await hasPermissionOnProject(context, project)) {
             const newMember = new ProjectMember(input);
@@ -193,6 +172,15 @@ export const resolvers: Resolvers = {
           if (isNullOrUndefined(project)) {
             throw NotFoundError();
           }
+
+
+          const { affiliationId, error } = await resolveAffiliation(reference, context, input, context.token.id);
+          if (error) {
+            const errorMember = new ProjectMember(input);
+            errorMember.addError('affiliation', error);
+            return errorMember;
+          }
+          input.affiliationId = affiliationId;
 
           if (await hasPermissionOnProject(context, project)) {
             const toUpdate = new ProjectMember(input);

--- a/src/resolvers/member.ts
+++ b/src/resolvers/member.ts
@@ -177,7 +177,7 @@ export const resolvers: Resolvers = {
           const { affiliationId, error } = await resolveAffiliation(reference, context, input, context.token.id);
           if (error) {
             const errorMember = new ProjectMember(input);
-            errorMember.addError('affiliation', error);
+            errorMember.addError('affiliationId', error);
             return errorMember;
           }
           input.affiliationId = affiliationId;

--- a/src/schemas/member.ts
+++ b/src/schemas/member.ts
@@ -138,6 +138,8 @@ export const typeDefs = gql`
     projectMemberId: Int!
     "The Member's affiliation URI"
     affiliationId: String
+    "The Member's affiliation name"
+    affiliationName: String
     "The Member's first/given name"
     givenName: String
     "The Member's last/sur name"

--- a/src/services/__tests__/affiliationService.spec.ts
+++ b/src/services/__tests__/affiliationService.spec.ts
@@ -5,7 +5,8 @@ import { Affiliation, AffiliationProvenance, AffiliationType, DEFAULT_DMPTOOL_AF
 import {
   processOtherAffiliationName,
   reconcileAffiliationEmailDomains,
-  reconcileAffiliationLinks
+  reconcileAffiliationLinks,
+  resolveAffiliation
 } from "../affiliationService";
 import { getCurrentDate } from "../../utils/helpers";
 import { AffiliationEmailDomain } from "../../models/AffiliationEmailDomain";
@@ -303,6 +304,176 @@ describe('reconcileAffiliationLinks', () => {
     expect(result).toBe(true);
     expect(findByAffiliationIdSpy).not.toHaveBeenCalled();
     expect(toAdd.create).toHaveBeenCalledWith(context);
+  });
+});
+
+describe('resolveAffiliation', () => {
+  const reference = 'resolveAffiliation test';
+  let mockFindByURI: jest.Mock;
+
+  beforeEach(() => {
+    mockFindByURI = jest.fn();
+    (Affiliation.findByURI as jest.Mock) = mockFindByURI;
+  });
+
+  it('returns an error when affiliationId is "other" but no affiliationName is provided', async () => {
+    const result = await resolveAffiliation(
+      reference,
+      context,
+      { affiliationId: 'other', affiliationName: '' },
+      context.token.id,
+    );
+
+    expect(result.affiliationId).toBeNull();
+    expect(result.error).toEqual('An affiliation name is required when "Other" is selected');
+    expect(mockFindByURI).not.toHaveBeenCalled();
+  });
+
+  it('resolves the "other" sentinel via processOtherAffiliationName when a name is provided', async () => {
+    const name = casual.company_name;
+
+    const result = await resolveAffiliation(
+      reference,
+      context,
+      { affiliationId: 'other', affiliationName: name },
+      context.token.id,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(affiliationStore).toHaveLength(1);
+    expect(affiliationStore[0].displayName).toEqual(name);
+    expect(result.affiliationId).toEqual(affiliationStore[0].uri);
+    expect(mockFindByURI).not.toHaveBeenCalled();
+  });
+
+  it('returns the provided affiliationId unchanged when it already exists', async () => {
+    const uri = casual.url;
+    const existing = new Affiliation({ id: casual.integer(1, 9999), uri, name: casual.company_name });
+    mockFindByURI.mockResolvedValue(existing);
+
+    const result = await resolveAffiliation(
+      reference,
+      context,
+      { affiliationId: uri, affiliationName: casual.company_name },
+      context.token.id,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.affiliationId).toEqual(uri);
+    expect(mockFindByURI).toHaveBeenCalledWith(reference, context, uri);
+  });
+
+  it('creates a new affiliation when affiliationId is provided but does not exist yet', async () => {
+    const uri = casual.url;
+    const name = casual.company_name;
+    mockFindByURI.mockResolvedValue(undefined);
+
+    const createSpy = jest
+      .spyOn(Affiliation.prototype, 'create')
+      .mockImplementation(async function (this: Affiliation) {
+        return Object.assign(this, { hasErrors: () => false });
+      });
+
+    const result = await resolveAffiliation(
+      reference,
+      context,
+      { affiliationId: uri, affiliationName: name },
+      context.token.id,
+    );
+
+    expect(createSpy).toHaveBeenCalledWith(context);
+    expect(result.error).toBeUndefined();
+    expect(result.affiliationId).toEqual(uri);
+
+    createSpy.mockRestore();
+  });
+
+  it('returns an error when creating the new affiliation returns errors', async () => {
+    const uri = casual.url;
+    const name = casual.company_name;
+    mockFindByURI.mockResolvedValue(undefined);
+
+    const createSpy = jest
+      .spyOn(Affiliation.prototype, 'create')
+      .mockImplementation(async function (this: Affiliation) {
+        return Object.assign(this, { hasErrors: () => true });
+      });
+
+    const result = await resolveAffiliation(
+      reference,
+      context,
+      { affiliationId: uri, affiliationName: name },
+      context.token.id,
+    );
+
+    expect(result.affiliationId).toBeNull();
+    expect(result.error).toEqual('Unable to create required affiliation');
+
+    createSpy.mockRestore();
+  });
+
+  it('returns an error when creating the new affiliation returns null', async () => {
+    const uri = casual.url;
+    const name = casual.company_name;
+    mockFindByURI.mockResolvedValue(undefined);
+
+    const createSpy = jest.spyOn(Affiliation.prototype, 'create').mockResolvedValue(null);
+
+    const result = await resolveAffiliation(
+      reference,
+      context,
+      { affiliationId: uri, affiliationName: name },
+      context.token.id,
+    );
+
+    expect(result.affiliationId).toBeNull();
+    expect(result.error).toEqual('Unable to create required affiliation');
+
+    createSpy.mockRestore();
+  });
+
+  it('returns the affiliationId unchanged when it does not exist and no affiliationName is provided', async () => {
+    const uri = casual.url;
+    mockFindByURI.mockResolvedValue(undefined);
+
+    const result = await resolveAffiliation(
+      reference,
+      context,
+      { affiliationId: uri, affiliationName: '' },
+      context.token.id,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.affiliationId).toEqual(uri);
+  });
+
+  it('resolves via processOtherAffiliationName when only affiliationName is provided', async () => {
+    const name = casual.company_name;
+
+    const result = await resolveAffiliation(
+      reference,
+      context,
+      { affiliationId: '', affiliationName: name },
+      context.token.id,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(affiliationStore).toHaveLength(1);
+    expect(result.affiliationId).toEqual(affiliationStore[0].uri);
+    expect(mockFindByURI).not.toHaveBeenCalled();
+  });
+
+  it('returns a null affiliationId when neither affiliationId nor affiliationName are provided', async () => {
+    const result = await resolveAffiliation(
+      reference,
+      context,
+      { affiliationId: '', affiliationName: '' },
+      context.token.id,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.affiliationId).toBeNull();
+    expect(mockFindByURI).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/affiliationService.ts
+++ b/src/services/affiliationService.ts
@@ -1,8 +1,75 @@
 import { MyContext } from "../context";
 import { Affiliation } from "../models/Affiliation";
-import {AffiliationEmailDomain} from "../models/AffiliationEmailDomain";
+import { AffiliationEmailDomain } from "../models/AffiliationEmailDomain";
 import { isNullOrUndefined } from "../utils/helpers";
 import { AffiliationLink } from "../models/AffiliationLink";
+
+export interface AffiliationInput {
+  affiliationId?: string | null;
+  affiliationName?: string | null;
+}
+
+export interface ResolveAffiliationResult {
+  affiliationId: string | null;
+  error?: string;
+}
+
+
+/**
+ * Resolves the affiliationId to use for a ProjectMember create/update.
+ *
+ * - If affiliationId is set and doesn't already exist, creates a new Affiliation
+ *   using the provided id as the uri and affiliationName as its name.
+ * - If affiliationId is blank but affiliationName is set (the "Other" case),
+ *   delegates to processOtherAffiliationName to look up/generate a uri.
+ * - Otherwise returns the affiliationId unchanged (including null/blank).
+ *
+ * @param reference the reference for logging purposes
+ * @param context the Apollo context
+ * @param input the affiliationId/affiliationName pair from the mutation input
+ * @param userId the id of the user performing the action (used when registering a new affiliation)
+ */
+export const resolveAffiliation = async (
+  reference: string,
+  context: MyContext,
+  input: AffiliationInput,
+  userId?: number,
+): Promise<ResolveAffiliationResult> => {
+  // Guard against the frontend's "other" sentinel leaking through as a literal
+  // affiliationId instead of being left blank
+  if (input.affiliationId === 'other') {
+    if (input.affiliationName) {
+      const affiliation = await processOtherAffiliationName(context, input.affiliationName, userId);
+      return { affiliationId: affiliation ? String(affiliation.uri) : null };
+    }
+    return { affiliationId: null, error: 'An affiliation name is required when "Other" is selected' };
+  }
+
+  if (input.affiliationId && input.affiliationId.length > 0) {
+    const existingAffiliation = await Affiliation.findByURI(reference, context, input.affiliationId);
+    if (!existingAffiliation && input.affiliationName) {
+      const newAffiliation = new Affiliation({
+        uri: input.affiliationId,
+        name: input.affiliationName,
+      });
+
+      const createdAffiliation = await newAffiliation.create(context);
+
+      if (!createdAffiliation || createdAffiliation.hasErrors()) {
+        return { affiliationId: null, error: 'Unable to create required affiliation' };
+      }
+
+      return { affiliationId: createdAffiliation.uri };
+    }
+    return { affiliationId: input.affiliationId };
+  } else if (input.affiliationName) {
+    const affiliation = await processOtherAffiliationName(context, input.affiliationName, userId);
+    return { affiliationId: affiliation ? String(affiliation.uri) : null };
+  }
+
+  return { affiliationId: input.affiliationId ?? null };
+};
+
 
 export const processOtherAffiliationName = async (
   context: MyContext,

--- a/src/services/affiliationService.ts
+++ b/src/services/affiliationService.ts
@@ -67,7 +67,7 @@ export const resolveAffiliation = async (
     return { affiliationId: affiliation ? String(affiliation.uri) : null };
   }
 
-  return { affiliationId: input.affiliationId ?? null };
+  return { affiliationId: input.affiliationId || null };
 };
 
 

--- a/src/services/affiliationService.ts
+++ b/src/services/affiliationService.ts
@@ -4,7 +4,7 @@ import { AffiliationEmailDomain } from "../models/AffiliationEmailDomain";
 import { isNullOrUndefined } from "../utils/helpers";
 import { AffiliationLink } from "../models/AffiliationLink";
 
-export interface AffiliationInput {
+export interface ResolveAffiliationInput {
   affiliationId?: string | null;
   affiliationName?: string | null;
 }
@@ -32,7 +32,7 @@ export interface ResolveAffiliationResult {
 export const resolveAffiliation = async (
   reference: string,
   context: MyContext,
-  input: AffiliationInput,
+  input: ResolveAffiliationInput,
   userId?: number,
 ): Promise<ResolveAffiliationResult> => {
   // Guard against the frontend's "other" sentinel leaking through as a literal

--- a/src/types.ts
+++ b/src/types.ts
@@ -5182,6 +5182,8 @@ export type UpdateProjectInput = {
 export type UpdateProjectMemberInput = {
   /** The Member's affiliation URI */
   affiliationId?: InputMaybe<Scalars['String']['input']>;
+  /** The Member's affiliation name */
+  affiliationName?: InputMaybe<Scalars['String']['input']>;
   /** The Member's email address */
   email?: InputMaybe<Scalars['String']['input']>;
   /** The Member's first/given name */


### PR DESCRIPTION
## Description

- Updated `updateProjectMember` resolver to handle `Other Affiliation`. 
- Added a new, shared `resolveAffiliation` function to `affiliationService.ts`. 
- Updated `updateProjectMember` schema to include `affiliationName`

Fixes # ([309](https://github.com/CDLUC3/dmptool-doc/issues/309))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested with frontend PR branch: https://github.com/CDLUC3/dmptool-ui/pull/1348 where TypeAhead field was added to "Edit Project Member" form. Also added unit test.


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [*] Any dependent changes have been merged and published in downstream modules
* - Frontend work on PR branch: https://github.com/CDLUC3/dmptool-ui/pull/1348