### PR TITLE
Updated sendContactUsEmail in emailService.ts to not include a bcc address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated `sendContactUsEmail` in `emailService.ts` to not include a `bcc` [#303]
 - Added `plans` chained resolver to `ProjectSearchResult` in `project` resolver so that querying `userProjects` will include `plan` data for each project [#304]
 - Updated `updateProjectMember` resolver to handle `Other Affiliation`. Added a new, shared `resolveAffiliation` function to `affiliationService.ts`. Updated `updateProjectMember` schema to include `affiliationName` [#309]
 - Updated the `Answer` model to use the newly exported `DefaultResearchOutputTypeAnswer` from `@dmptool/types` instead of manually building it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,7 +247,6 @@
 - Removed `ioredis` package
 
 ### Fixed
-- Fixed `removeProjectFunding`. There were several issues, one of which was not being able to delete a `projectFundings` record without removing it's foreign key dependency in `planFundings` first [#303]
 - Updated `immutable` to `v5.1.9` to address HIGH security vulnerability [#304]
 - Updated `brace-expansion` to `v5.0.7` and `js-yaml` to `v4.3.0` to address vulnerabilities [#310]
 - Build was breaking because of a `package-lock.json` was referencing a file for `dmptool-utils`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,6 +247,7 @@
 - Removed `ioredis` package
 
 ### Fixed
+- Fixed `removeProjectFunding`. There were several issues, one of which was not being able to delete a `projectFundings` record without removing it's foreign key dependency in `planFundings` first [#303]
 - Updated `immutable` to `v5.1.9` to address HIGH security vulnerability [#304]
 - Updated `brace-expansion` to `v5.0.7` and `js-yaml` to `v4.3.0` to address vulnerabilities [#310]
 - Build was breaking because of a `package-lock.json` was referencing a file for `dmptool-utils`.

--- a/src/resolvers/funding.ts
+++ b/src/resolvers/funding.ts
@@ -169,29 +169,12 @@ export const resolvers: Resolvers = {
           // Only allow the owner of the project to delete it
           const project = await Project.findById(reference, context, funding.projectId);
           if (await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.EDIT)) {
-
-            const plans = await Plan.findByProjectId(reference, context, funding.projectId);
-
-            // Delete the planFundings record(s) for this projectFundingId first, or the
-            // FK constraint (planfundings_ibfk_4) will block deleting the projectFunding below
-            for (const plan of plans) {
-              const planFunding = await PlanFunding.findByProjectFundingId(reference, context, plan.id, projectFundingId);
-              if (planFunding) {
-                const wasRemoved = await planFunding.delete(context);
-                if (!wasRemoved || wasRemoved.hasErrors()) {
-                  context.logger.error(
-                    prepareObjectForLogs({ projectFundingId, planId: plan.id }),
-                    `Failed to remove PlanFunding before deleting ProjectFunding in ${reference}`
-                  );
-                  throw InternalServerError();
-                }
-              }
-            }
-
             const removed = await funding.delete(context);
+            console.log("***Removed funding", removed);
             if (removed && !removed.hasErrors()) {
+              const plans = await Plan.findByProjectId(reference, context, funding.projectId);
               for (const plan of plans) {
-                // Update the maDMP version of the Plan now that the funding is actually gone
+                // Update the maDMP version of the Plan
                 await saveMaDMPVersion(reference, context, plan.id, plan.dmpId);
               }
             }

--- a/src/resolvers/funding.ts
+++ b/src/resolvers/funding.ts
@@ -169,11 +169,29 @@ export const resolvers: Resolvers = {
           // Only allow the owner of the project to delete it
           const project = await Project.findById(reference, context, funding.projectId);
           if (await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.EDIT)) {
+
+            const plans = await Plan.findByProjectId(reference, context, funding.projectId);
+
+            // Delete the planFundings record(s) for this projectFundingId first, or the
+            // FK constraint (planfundings_ibfk_4) will block deleting the projectFunding below
+            for (const plan of plans) {
+              const planFunding = await PlanFunding.findByProjectFundingId(reference, context, plan.id, projectFundingId);
+              if (planFunding) {
+                const wasRemoved = await planFunding.delete(context);
+                if (!wasRemoved || wasRemoved.hasErrors()) {
+                  context.logger.error(
+                    prepareObjectForLogs({ projectFundingId, planId: plan.id }),
+                    `Failed to remove PlanFunding before deleting ProjectFunding in ${reference}`
+                  );
+                  throw InternalServerError();
+                }
+              }
+            }
+
             const removed = await funding.delete(context);
             if (removed && !removed.hasErrors()) {
-              const plans = await Plan.findByProjectId(reference, context, funding.projectId);
               for (const plan of plans) {
-                // Update the maDMP version of the Plan
+                // Update the maDMP version of the Plan now that the funding is actually gone
                 await saveMaDMPVersion(reference, context, plan.id, plan.dmpId);
               }
             }

--- a/src/services/__tests__/emailService.spec.ts
+++ b/src/services/__tests__/emailService.spec.ts
@@ -371,7 +371,7 @@ describe('sendEmail', () => {
     expect(logger.info).toHaveBeenCalledTimes(1);
     expect(mockSendEmail).toHaveBeenCalledTimes(1);
     expect(mockSendEmail).toHaveBeenCalledWith({
-      "bcc": email,
+      "bcc": "",
       "cc": "",
       "from": `"${generalConfig.applicationName}" <${emailConfig.doNotReplyAddress}>`,
       "html": expectedHtml,

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -339,7 +339,7 @@ export const sendContactUsEmail = async (
     'ContactUs',
     [emailConfig.helpDeskAddress], // to
     [],// cc
-    [email],// bcc
+    [],// bcc
     `${emailSubjects.contactUs}: ${subject}`,
     body,
     true, // asHTML


### PR DESCRIPTION

## Description

As part of "Contact Us" page improvements, we removed the `bcc` address from the `sendContactUsEmail`.

Fixes # ([303](https://github.com/CDLUC3/dmptool-doc/issues/303))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested manually and updated a unit test

## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules