### PR TITLE
Fixed bugs in removeProjectFunding to get it to work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,7 @@
 - Removed `ioredis` package
 
 ### Fixed
+- Fixed `removeProjectFunding`. There were several issues, one of which was not being able to delete a `projectFundings` record without removing it's foreign key dependency in `planFundings` first [#303]
 - Updated `immutable` to `v5.1.9` to address HIGH security vulnerability [#304]
 - Updated `brace-expansion` to `v5.0.7` and `js-yaml` to `v4.3.0` to address vulnerabilities [#310]
 - Build was breaking because of a `package-lock.json` was referencing a file for `dmptool-utils`.

--- a/src/resolvers/funding.ts
+++ b/src/resolvers/funding.ts
@@ -169,11 +169,29 @@ export const resolvers: Resolvers = {
           // Only allow the owner of the project to delete it
           const project = await Project.findById(reference, context, funding.projectId);
           if (await hasPermissionOnProject(context, project, ProjectCollaboratorAccessLevel.EDIT)) {
+
+            const plans = await Plan.findByProjectId(reference, context, funding.projectId);
+
+            // Delete the planFundings record(s) for this projectFundingId first, or the
+            // FK constraint (planfundings_ibfk_4) will block deleting the projectFunding below
+            for (const plan of plans) {
+              const planFunding = await PlanFunding.findByProjectFundingId(reference, context, plan.id, projectFundingId);
+              if (planFunding) {
+                const wasRemoved = await planFunding.delete(context);
+                if (!wasRemoved || wasRemoved.hasErrors()) {
+                  context.logger.error(
+                    prepareObjectForLogs({ projectFundingId, planId: plan.id }),
+                    `Failed to remove PlanFunding before deleting ProjectFunding in ${reference}`
+                  );
+                  throw InternalServerError();
+                }
+              }
+            }
+
             const removed = await funding.delete(context);
             if (removed && !removed.hasErrors()) {
-              const plans = await Plan.findByProjectId(reference, context, funding.projectId);
               for (const plan of plans) {
-                // Update the maDMP version of the Plan
+                // Update the maDMP version of the Plan now that the funding is actually gone
                 await saveMaDMPVersion(reference, context, plan.id, plan.dmpId);
               }
             }


### PR DESCRIPTION
## Description
While working on another ticket, I noticed that the "Remove funding" functionality was not working here https://dmptool-dev.uc3dev.cdlib.net/en-US/projects/136401/fundings/131497/edit.

- Fixed `removeProjectFunding`. There were several issues, one of which was not being able to delete a `projectFundings` record without removing it's foreign key dependency in `planFundings` first 

Fixes # ([311](https://github.com/CDLUC3/dmptool-doc/issues/311))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually tested


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules