### PR TITLE
Minor tweaks to entirePlanX resolvers to support updated REST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.1.0
 
 ### Added
+- Added versionedTemplate schema and resolver so we can fetch a versioned template by its id.
 - Added new helper SQL script to delete all existing research output questions and answers
 - Added new `TransactionClient` class to the `datasources/mysql.ts` file to allow for the use of MySQL transactions
 - Added a `AddAnswerInput`, `AddProjectInput`, `EntirePlanProjectFragment`, `EntirePlanMemberFragment`, `EntirePlanFundingFragment`, `EntirePlanAnswerFragment`, `AddEntirePlanInput`, `UpdateEntirePlanInput` to schema
@@ -120,6 +121,8 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Switched entirePlan schema, resolvers and service to use versionedXId instead of xId (e.g. use versionedTemplates instead of Templates)
+- Updated entirePlan service to use the default MemberRole when none is provided 
 - Fixed issue with JSON of default questions and answers in the local data migration file
 - Renamed old `Funding.findByProjectFundingId` to `Funding.findByPlanAndProjectFundingId`
 - Updated `sendContactUsEmail` in `emailService.ts` to not include a `bcc` [#303]

--- a/src/resolvers/versionedTemplate.ts
+++ b/src/resolvers/versionedTemplate.ts
@@ -21,6 +21,23 @@ import { isNullOrUndefined, normaliseDateTime } from "../utils/helpers";
 
 export const resolvers: Resolvers = {
   Query: {
+    // Get a VersionedTemplate by its id
+    versionedTemplate: async (_, { id }, context: MyContext): Promise<VersionedTemplate> => {
+      const  reference = 'versionedTemplate resolver';
+      try {
+        if (isAuthorized(context.token)) {
+          return await VersionedTemplate.findById(reference, context, id);
+        }
+        // Unauthorized!
+        throw context?.token ? ForbiddenError() : AuthenticationError();
+      } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+
+        context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
+        throw InternalServerError();
+      }
+    },
+
     // Get all of the versions for the specified VersionedTemplate (a.k. the Template history)
     //    - called from the Template history page
     templateVersions: async (_, { templateId }, context: MyContext): Promise<VersionedTemplate[]> => {

--- a/src/schemas/plan.ts
+++ b/src/schemas/plan.ts
@@ -343,8 +343,10 @@ export const typeDefs = gql`
   "Input to create/replace a Plan answer"
   input EntirePlanAnswerFragment {
     json: String!
-    sectionId: Int
-    questionId: Int
+    versionedSectionId: Int
+    versionedCustomSectionId: Int
+    versionedQuestionId: Int
+    versionedCustomQuestion: Int
   }
 
   "Input to create an entire Plan (and Project if applicable)"
@@ -362,7 +364,7 @@ export const typeDefs = gql`
     project: EntirePlanProjectFragment!
 
     "The id of the template being used (the default template will be used if not provided)"
-    templateId: Int
+    versionedTemplateId: Int
 
     "External identifiers for the plan (for use when integrating with external systems)"
     alternateIdentifiers: [String!]

--- a/src/schemas/versionedTemplate.ts
+++ b/src/schemas/versionedTemplate.ts
@@ -2,6 +2,8 @@ import gql from "graphql-tag";
 
 export const typeDefs = gql`
   extend type Query {
+    "Get a VersionedTemplate by its id"
+    versionedTemplate(id: Int!): VersionedTemplate
     "Get all of the VersionedTemplate for the specified Template (a.k. the Template history)"
     templateVersions(templateId: Int!): [VersionedTemplate]
     "Search for VersionedTemplate whose name or owning Org's name contains the search term"

--- a/src/services/__tests__/entirePlanService.spec.ts
+++ b/src/services/__tests__/entirePlanService.spec.ts
@@ -414,7 +414,10 @@ describe('entirePlanService', () => {
   describe('addEntirePlan', () => {
     const baseInput = {
       title: 'My Entire Plan',
-      templateId: 99,
+      status: 'DRAFT',
+      visibility: 'PRIVATE',
+      languageId: 'en-US',
+      versionedTemplateId: 99,
       project: {
         title: '  Existing Project  ',
         abstractText: '  project abstract  ',
@@ -423,9 +426,6 @@ describe('entirePlanService', () => {
         researchDomainUrl: 'https://ror.example.org/domain/202',
         isTestProject: true,
       },
-      alternateIdentifiers: [],
-      members: [],
-      funding: [],
     };
 
     const setupAddEntirePlanDefaults = () => {
@@ -446,7 +446,7 @@ describe('entirePlanService', () => {
           return this;
         });
       jest
-        .spyOn(VersionedTemplate, 'findActiveByTemplateId')
+        .spyOn(VersionedTemplate, 'findVersionedTemplateById')
         .mockResolvedValue(new VersionedTemplate({ id: 303, name: 'VT-1' }));
       jest.spyOn(AlternateIdentifier, 'findByPlanId').mockResolvedValue([]);
       jest
@@ -524,7 +524,7 @@ describe('entirePlanService', () => {
 
       const response = await addEntirePlan('test-ref', context, {
         ...baseInput,
-        templateId: undefined,
+        versionedTemplateId: undefined,
         project: {
           title: '  New Project  ',
           abstractText: '  new abstract  ',
@@ -553,7 +553,7 @@ describe('entirePlanService', () => {
     });
 
     it('throws a bad request error when the specified template cannot be found', async () => {
-      jest.spyOn(VersionedTemplate, 'findActiveByTemplateId').mockResolvedValue(null);
+      jest.spyOn(VersionedTemplate, 'findVersionedTemplateById').mockResolvedValue(null);
 
       await expect(addEntirePlan('test-ref', context, baseInput as never, plan)).rejects.toMatchObject({
         extensions: { code: BAD_REQUEST_ERROR_CODE },

--- a/src/services/entirePlanService.ts
+++ b/src/services/entirePlanService.ts
@@ -299,7 +299,13 @@ export const processMemberAssociations = async(
                 return await MemberRole.findByURL(reference, context, id);
               })
             )
-          ).filter((role): role is MemberRole => Boolean(role));
+          ).filter((role): role is MemberRole => Boolean(role)) || [];
+
+          // If there are no roles available, or the ones provided had no match then
+          // use the default role!
+          if (roles.length === 0) {
+            roles.push((await MemberRole.defaultRole(context)));
+          }
 
           // Add the roles to the new project member
           for (const role of roles) {
@@ -676,6 +682,7 @@ const processAssociatedObjectForEntirePlan = async (
 
 
   // 8th: Save the narrative answers
+
 }
 
 /**
@@ -724,19 +731,20 @@ const findOrInitializeProject = async (
  *
  * @param reference the string reference for logging
  * @param context the Apollo server context
- * @param templateId the id of the template to use
+ * @param versionedTemplateId the id of the versioned template to use
  */
 const findVersionedTemplateForEntirePlan = async (
   reference: string,
   context: MyContext,
-  templateId?: number,
+  versionedTemplateId?: number,
 ): Promise<VersionedTemplate | undefined> => {
   let versionedTemplate: VersionedTemplate | undefined;
 
-  if (templateId) {
-    versionedTemplate = await VersionedTemplate.findActiveByTemplateId(reference, context, templateId);
+
+  if (versionedTemplateId) {
+    versionedTemplate = await VersionedTemplate.findVersionedTemplateById(reference, context, versionedTemplateId);
     if (!versionedTemplate) {
-      context.logger.error({ ref: reference, templateId }, 'Unable to find the specified versioned template!');
+      context.logger.error({ ref: reference, versionedTemplateId }, 'Unable to find the specified versioned template!');
       throw BadRequestError('Unable to find the specified versioned template!');
     }
   } else {
@@ -810,7 +818,7 @@ export const addEntirePlan = async (
     const versionedTemplate: VersionedTemplate | undefined = await findVersionedTemplateForEntirePlan(
       reference,
       context,
-      input.templateId
+      input.versionedTemplateId
     );
     if (!versionedTemplate.id) {
       context.logger.fatal('Unable to find a suitable versioned template!');

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,10 +101,10 @@ export type AddEntirePlanInput = {
   project: EntirePlanProjectFragment;
   /** The status of the plan */
   status: PlanStatus;
-  /** The id of the template being used (the default template will be used if not provided) */
-  templateId?: InputMaybe<Scalars['Int']['input']>;
   /** The title of the plan */
   title: Scalars['String']['input'];
+  /** The id of the template being used (the default template will be used if not provided) */
+  versionedTemplateId?: InputMaybe<Scalars['Int']['input']>;
   /** The visibility of the plan */
   visibility: PlanVisibility;
 };
@@ -1117,8 +1117,10 @@ export type DoiMatchSource = {
 /** Input to create/replace a Plan answer */
 export type EntirePlanAnswerFragment = {
   json: Scalars['String']['input'];
-  questionId?: InputMaybe<Scalars['Int']['input']>;
-  sectionId?: InputMaybe<Scalars['Int']['input']>;
+  versionedCustomQuestion?: InputMaybe<Scalars['Int']['input']>;
+  versionedCustomSectionId?: InputMaybe<Scalars['Int']['input']>;
+  versionedQuestionId?: InputMaybe<Scalars['Int']['input']>;
+  versionedSectionId?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /** Input to create/replace a Project/Plan funding */
@@ -3682,6 +3684,8 @@ export type Query = {
   users?: Maybe<UserSearchResults>;
   /** Get all VersionedGuidance for a given affiliation and Tag IDs */
   versionedGuidance: Array<VersionedGuidance>;
+  /** Get a VersionedTemplate by its id */
+  versionedTemplate?: Maybe<VersionedTemplate>;
 };
 
 
@@ -4180,6 +4184,11 @@ export type QueryUsersArgs = {
 export type QueryVersionedGuidanceArgs = {
   affiliationId: Scalars['String']['input'];
   tagIds: Array<Scalars['Int']['input']>;
+};
+
+
+export type QueryVersionedTemplateArgs = {
+  id: Scalars['Int']['input'];
 };
 
 /** Question always belongs to a Section, which always belongs to a Template */
@@ -8131,6 +8140,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   userProjects?: Resolver<Maybe<ResolversTypes['ProjectSearchResults']>, ParentType, ContextType, RequireFields<QueryUserProjectsArgs, 'userId'>>;
   users?: Resolver<Maybe<ResolversTypes['UserSearchResults']>, ParentType, ContextType, Partial<QueryUsersArgs>>;
   versionedGuidance?: Resolver<Array<ResolversTypes['VersionedGuidance']>, ParentType, ContextType, RequireFields<QueryVersionedGuidanceArgs, 'affiliationId' | 'tagIds'>>;
+  versionedTemplate?: Resolver<Maybe<ResolversTypes['VersionedTemplate']>, ParentType, ContextType, RequireFields<QueryVersionedTemplateArgs, 'id'>>;
 };
 
 export type QuestionResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Question'] = ResolversParentTypes['Question']> = {


### PR DESCRIPTION
## Description

Part of [#261](https://github.com/CDLUC3/dmptool-doc/issues/261)

- Added `versionedTemplate` schema and resolver so we can fetch a versioned template by its id. 
- Switched `entirePlan` schema, resolvers and service to use `versionedXId` instead of `xId` (e.g. use versionedTemplates instead of Templates)
- Updated `entirePlan` service to use the default MemberRole when none is provided

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

REST API calls are working with switch to call `entirePlan` resolvers. I've done some limited testing, I'm sure there will be bugs that surface as we begin using and testing. I will 

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md and added documentation if necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules