### PR TITLE
Updates for moving best practice tags from Section to Question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,14 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated `Plan.findByPlanId` to prefer questionTags and fall back to sectionTags [#274]
+- Updated `Question` model to have `tags`, since we moved the best practice tags to the Question page [#274]
+- Updated `Tag` model with functions for adding and removing tags from questions and versioned questions [#274]
+- Updated `addQuestion` and `updateQuestion` resolvers to add any tag data to `questionTags` table, and to include `tags` chained resolver [#274]
+- Removed `tags` from `section` resolver [#274]
+- Updated `addTemplate` mutation resolver so that make sure to copy over questionTags when cloning [#274]
+- Updated `guidanceService.ts` to prefer `questionTags` and fall back to `sectionTags` if there are no `questionTags`. That way we can ease into transitioning to `questionTags` [#274]
+- Updated `questionService`'s `generateQuestionVersion` to include `questionTags`, and also made sure to add current tags in `generateSectionVersion` before calling `generateQuestionVersion` [#274]
 - Updated `emailService` with a `sendResetPasswordEmail` to send an email with the `change password link` [#133]
 - Fixed issue with JSON of default questions and answers in the local data migration file
 - Renamed old `Funding.findByProjectFundingId` to `Funding.findByPlanAndProjectFundingId`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.1.0
 
 ### Added
+- Added `questionTags` and `versionedQuestionTags` tables [#274]
 - Added `getUserTokenVersion` and `bumpUserTokenVersion` to `tokenService` so that we can save the `tokenVersion` in the `JWT` payload, and validate it against the current version in `isRevokedCallback` on `/graphql` requests [#133]
 - Added new `PasswordResetToken` model, `passwordReset` resolver, `passwordReset` schema, and separate `passwordResetTokens` table to store the `resetPasswordToken` and `resetPasswordExpiresAt` [#133]
 - Added `passwordChangedAt` field to the `users` table, and `User` model to record when password last changed [#133]

--- a/data-migrations/2027-07-29-0848-create-questionTags.sql
+++ b/data-migrations/2027-07-29-0848-create-questionTags.sql
@@ -1,0 +1,42 @@
+-- Need to first drop table if it already exists because we have to rebuild them
+DROP TABLE IF EXISTS questionTags;
+DROP TABLE IF EXISTS versionedQuestionTags;
+
+
+CREATE TABLE `questionTags` (
+ `id` int unsigned NOT NULL AUTO_INCREMENT,
+ `questionId` int unsigned NOT NULL,
+ `tagId` int unsigned NOT NULL,
+ `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ `createdById` int unsigned NOT NULL,
+ `modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ `modifiedById` int unsigned NOT NULL,
+ PRIMARY KEY (`id`),
+ KEY `questionTags_idx` (`questionId`,`tagId`),
+ KEY `createdById` (`createdById`),
+ KEY `modifiedById` (`modifiedById`),
+ KEY `tagId` (`tagId`),
+ CONSTRAINT `questiontags_ibfk_1` FOREIGN KEY (`createdById`) REFERENCES `users` (`id`),
+ CONSTRAINT `questiontags_ibfk_2` FOREIGN KEY (`modifiedById`) REFERENCES `users` (`id`),
+ CONSTRAINT `questiontags_ibfk_3` FOREIGN KEY (`questionId`) REFERENCES `questions` (`id`) ON DELETE CASCADE,
+ CONSTRAINT `questiontags_ibfk_4` FOREIGN KEY (`tagId`) REFERENCES `tags` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `versionedQuestionTags` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `versionedQuestionId` int unsigned NOT NULL,
+  `tagId` int unsigned NOT NULL,
+  `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `createdById` int unsigned NOT NULL,
+  `modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `modifiedById` int unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `versionedQuestionTags_idx` (`versionedQuestionId`,`tagId`),
+  KEY `createdById` (`createdById`),
+  KEY `modifiedById` (`modifiedById`),
+  KEY `tagId` (`tagId`),
+  CONSTRAINT `versionedquestiontags_ibfk_1` FOREIGN KEY (`createdById`) REFERENCES `users` (`id`),
+  CONSTRAINT `versionedquestiontags_ibfk_2` FOREIGN KEY (`modifiedById`) REFERENCES `users` (`id`),
+  CONSTRAINT `versionedquestiontags_ibfk_3` FOREIGN KEY (`versionedQuestionId`) REFERENCES `versionedQuestions` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `versionedquestiontags_ibfk_4` FOREIGN KEY (`tagId`) REFERENCES `tags` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/data-migrations/local-only/2026-07-30-0223-insert-new-tags.sql
+++ b/data-migrations/local-only/2026-07-30-0223-insert-new-tags.sql
@@ -1,0 +1,9 @@
+SET @default_email_domain = 'example.com';
+SET @default_super_id := (SELECT userId FROM userEmails WHERE email = CONCAT('super@', @default_email_domain));
+SET @default_admin_id := (SELECT userId FROM userEmails WHERE email = CONCAT('admin@', @default_email_domain));
+
+INSERT INTO tags (name, slug, description, createdById, created, modifiedById, modified)
+VALUES ('Software management', 'software-management', 'Tracking and managing software used in research projects.', @default_super_id, NOW(), @default_admin_id, NOW());
+
+INSERT INTO tags (name, slug, description, createdById, created, modifiedById, modified)
+VALUES ('AI-Ready data', 'ai-ready-data', 'Data that is ready to be used with AI/ML models.', @default_super_id, NOW(), @default_admin_id, NOW());

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -406,7 +406,9 @@ export class PlanSectionProgress {
    */
   static async findByPlanId(reference: string, context: MyContext, planId: number, versionedTemplateId?: number): Promise<PlanSectionProgress[]> {
     // First fetch base sections and their question counts, which we will use as the foundation to build out the full section list with custom sections
-    // and adjusted question counts
+    // and adjusted question counts.
+    // COALESCE(questionTagAgg.tags, sectionTagAgg.tags, JSON_ARRAY()) ensures that we try and use question tags first, then section tags, and 
+    // if neither exist we return an empty array for the tags field.
     const sql = `SELECT
       vs.id AS versionedSectionId,
       vs.displayOrder,
@@ -421,10 +423,26 @@ export class PlanSectionProgress {
           WHEN a.id IS NOT NULL AND ${FILLED_ANSWER_CHECK} AND vq.required = 1
           THEN vq.id
         END) AS answeredRequiredQuestions,
-      COALESCE(tagAgg.tags, JSON_ARRAY()) AS tags
+      COALESCE(questionTagAgg.tags, sectionTagAgg.tags, JSON_ARRAY()) AS tags
     FROM plans p
       JOIN versionedTemplates vt ON p.versionedTemplateId = vt.id
       JOIN versionedSections vs ON vt.id = vs.versionedTemplateId
+      LEFT JOIN (
+        SELECT
+          vq2.versionedSectionId,
+          JSON_ARRAYAGG(
+            JSON_OBJECT(
+              'id', t.id,
+              'slug', t.slug,
+              'name', t.name,
+              'description', t.description
+            )
+          ) AS tags
+        FROM versionedQuestionTags vqt
+          JOIN versionedQuestions vq2 ON vq2.id = vqt.versionedQuestionId
+          JOIN tags t ON t.id = vqt.tagId
+        GROUP BY vq2.versionedSectionId
+      ) questionTagAgg ON questionTagAgg.versionedSectionId = vs.id
       LEFT JOIN (
         SELECT
           vst.versionedSectionId,
@@ -439,13 +457,13 @@ export class PlanSectionProgress {
         FROM versionedSectionTags vst
           JOIN tags t ON t.id = vst.tagId
         GROUP BY vst.versionedSectionId
-      ) tagAgg ON tagAgg.versionedSectionId = vs.id
+      ) sectionTagAgg ON sectionTagAgg.versionedSectionId = vs.id
       LEFT JOIN versionedQuestions vq ON vs.id = vq.versionedSectionId
       LEFT JOIN answers a
         ON a.planId = p.id
         AND a.versionedQuestionId = vq.id
     WHERE p.id = ?
-    GROUP BY vs.id, vs.displayOrder, vs.name, tagAgg.tags
+    GROUP BY vs.id, vs.displayOrder, vs.name, questionTagAgg.tags, sectionTagAgg.tags
     ORDER BY vs.displayOrder;
 `
 

--- a/src/models/Question.ts
+++ b/src/models/Question.ts
@@ -1,6 +1,7 @@
 import { QuestionSchemaMap } from "@dmptool/types";
 import { MyContext } from "../context";
 import { MySqlModel } from "./MySqlModel";
+import { Tag } from "./Tag";
 import { isNullOrUndefined, removeNullAndUndefinedFromJSON } from "../utils/helpers";
 
 export class Question extends MySqlModel {
@@ -15,6 +16,7 @@ export class Question extends MySqlModel {
   public useSampleTextAsDefault?: boolean;
   public required: boolean;
   public displayOrder: number;
+  public tags: Tag[];
   public isDirty: boolean;
 
   private tableName = 'questions';
@@ -39,6 +41,7 @@ export class Question extends MySqlModel {
     this.useSampleTextAsDefault = options.useSampleTextAsDefault ?? false;
     this.required = options.required ?? false;
     this.displayOrder = options.displayOrder;
+    this.tags = options.tags;
     this.isDirty = options.isDirty ?? false;
   }
 
@@ -96,7 +99,7 @@ export class Question extends MySqlModel {
     // First make sure the record is valid
     if (await this.isValid()) {
       // Save the record and then fetch it
-      const newId = await Question.insert(context, this.tableName, this, 'Question.create', ['questionType']);
+      const newId = await Question.insert(context, this.tableName, this, 'Question.create', ['questionType', 'tags']);
       const response = await Question.findById('Question.create', context, newId);
       return response;
 
@@ -111,7 +114,7 @@ export class Question extends MySqlModel {
       this.prepForSave();
 
       if (await this.isValid()) {
-        await Question.update(context, this.tableName, this, 'Question.update', ['questionType'], noTouch);
+        await Question.update(context, this.tableName, this, 'Question.update', ['questionType', 'tags'], noTouch);
         return await Question.findById('Question.update', context, this.id);
       }
     }

--- a/src/models/Tag.ts
+++ b/src/models/Tag.ts
@@ -77,33 +77,33 @@ export class Tag extends MySqlModel {
     return null;
   }
 
-  // Add this Tag to a Section
-  async addToSection(context: MyContext, sectionId: number): Promise<boolean> {
-    const reference = 'Tag.addToSection';
-    const sql = 'INSERT INTO sectionTags (tagId, sectionId, createdById, modifiedById) VALUES (?, ?, ?, ?)';
+  // Add this Tag to a Question
+  async addToQuestion(context: MyContext, questionId: number): Promise<boolean> {
+    const reference = 'Tag.addToQuestion';
+    const sql = 'INSERT INTO questionTags (tagId, questionId, createdById, modifiedById) VALUES (?, ?, ?, ?)';
     const userId = context.token?.id?.toString();
-    const vals = [this.id?.toString(), sectionId?.toString(), userId, userId];
+    const vals = [this.id?.toString(), questionId?.toString(), userId, userId];
     const results = await Tag.query(context, sql, vals, reference);
 
     if (!results) {
-      const payload = { tagId: this.id, sectionId };
-      const msg = 'Unable to add the tag to the section';
+      const payload = { tagId: this.id, questionId };
+      const msg = 'Unable to add the tag to the question';
       context.logger.error(prepareObjectForLogs(payload), msg);
       return false;
     }
     return true;
   }
 
-  // Remove this Tag from a Section
-  async removeFromSection(context: MyContext, sectionId: number): Promise<boolean> {
-    const reference = 'Tag.removeFromSection';
-    const sql = 'DELETE FROM sectionTags WHERE tagId = ? AND sectionId = ?';
-    const vals = [this.id?.toString(), sectionId?.toString()];
+  // Remove this Tag from a Question
+  async removeFromQuestion(context: MyContext, questionId: number): Promise<boolean> {
+    const reference = 'Tag.removeFromQuestion';
+    const sql = 'DELETE FROM questionTags WHERE tagId = ? AND questionId = ?';
+    const vals = [this.id?.toString(), questionId?.toString()];
     const results = await Tag.query(context, sql, vals, reference);
 
     if (!results) {
-      const payload = { tagId: this.id, sectionId };
-      const msg = 'Unable to remove the tag from the section';
+      const payload = { tagId: this.id, questionId };
+      const msg = 'Unable to remove the tag from the question';
       context.logger.error(prepareObjectForLogs(payload), `${reference} - ${msg}`);
       return false;
     }
@@ -127,6 +127,23 @@ export class Tag extends MySqlModel {
     return true;
   }
 
+  // Add this Tag to a VersionedQuestionTags
+  async addToVersionedQuestionTags(context: MyContext, versionedQuestionId: number): Promise<boolean> {
+    const reference = 'Tag.addToVersionedQuestionTags';
+    const sql = 'INSERT INTO versionedQuestionTags (tagId, versionedQuestionId, createdById, modifiedById) VALUES (?, ?, ?, ?)';
+    const userId = context.token?.id?.toString();
+    const vals = [this.id?.toString(), versionedQuestionId?.toString(), userId, userId];
+    const results = await Tag.query(context, sql, vals, reference);
+
+    if (!results) {
+      const payload = { tagId: this.id, versionedQuestionId };
+      const msg = 'Unable to add the tag to the versioned question';
+      context.logger.error(prepareObjectForLogs(payload), msg);
+      return false;
+    }
+    return true;
+  }
+
   static async findAll(reference: string, context: MyContext): Promise<Tag[]> {
     const sql = 'SELECT * FROM tags';
     const results = await Tag.query(context, sql, [], reference);
@@ -139,9 +156,15 @@ export class Tag extends MySqlModel {
     return Array.isArray(result) ? result.map(item => new Tag(item)) : [];
   }
 
-  static async findByVersionedSectionId(reference: string, context: MyContext, versionedSectionId: number): Promise<Tag[]> {
-    const sql = `SELECT tags.* FROM versionedSectionTags vst JOIN tags ON vst.tagId = tags.id WHERE vst.versionedSectionId = ?;`;
-    const result = await Tag.query(context, sql, [versionedSectionId?.toString()], reference);
+  static async findByQuestionId(reference: string, context: MyContext, questionId: number): Promise<Tag[]> {
+    const sql = `SELECT tags.* FROM questionTags JOIN tags ON questionTags.tagId = tags.id WHERE questionTags.questionId = ?;`;
+    const result = await Tag.query(context, sql, [questionId?.toString()], reference);
+    return Array.isArray(result) ? result.map(item => new Tag(item)) : [];
+  }
+
+  static async findByVersionedQuestionId(reference: string, context: MyContext, questionId: number): Promise<Tag[]> {
+    const sql = `SELECT tags.* FROM versionedQuestionTags JOIN tags ON versionedQuestionTags.tagId = tags.id WHERE versionedQuestionTags.versionedQuestionId = ?;`;
+    const result = await Tag.query(context, sql, [questionId?.toString()], reference);
     return Array.isArray(result) ? result.map(item => new Tag(item)) : [];
   }
 

--- a/src/models/__tests__/Question.spec.ts
+++ b/src/models/__tests__/Question.spec.ts
@@ -36,6 +36,13 @@ describe('Question', () => {
     sampleText: casual.sentences(10),
     useSampleTextAsDefault: true,
     displayOrder: casual.integer(1, 20),
+    tags: [
+      {
+        id: casual.integer(1, 9),
+        name: casual.word,
+        description: casual.sentences(3),
+      }
+    ]
   }
   beforeEach(() => {
     question = new Question(questionData);
@@ -49,6 +56,7 @@ describe('Question', () => {
     expect(question.sampleText).toEqual(questionData.sampleText);
     expect(question.useSampleTextAsDefault).toEqual(questionData.useSampleTextAsDefault);
     expect(question.displayOrder).toEqual(questionData.displayOrder);
+    expect(question.tags).toEqual(questionData.tags);
     expect(question.required).toEqual(false);
   });
 
@@ -140,6 +148,13 @@ describe('ResearchOutputTable Question', () => {
     sampleText: casual.sentences(10),
     useSampleTextAsDefault: true,
     displayOrder: casual.integer(1, 20),
+    tags: [
+      {
+        id: casual.integer(1, 9),
+        name: casual.word,
+        description: casual.sentences(3),
+      }
+    ]
   }
   beforeEach(() => {
     question = new Question(questionData);

--- a/src/models/__tests__/Tag.spec.ts
+++ b/src/models/__tests__/Tag.spec.ts
@@ -152,7 +152,7 @@ describe('delete', () => {
   });
 });
 
-describe('addToSection', () => {
+describe('addToQuestion', () => {
   let context;
   let mockTag;
 
@@ -172,28 +172,28 @@ describe('addToSection', () => {
     jest.clearAllMocks();
   });
 
-  it('associates the Tag to the specified Section', async () => {
-    const sectionId = casual.integer(1, 999);
+  it('associates the Tag to the specified Question', async () => {
+    const questionId = casual.integer(1, 999);
     const querySpy = jest.spyOn(Tag, 'query').mockResolvedValueOnce(mockTag);
-    const result = await mockTag.addToSection(context, sectionId);
+    const result = await mockTag.addToQuestion(context, questionId);
     expect(querySpy).toHaveBeenCalledTimes(1);
-    const expectedSql = 'INSERT INTO sectionTags (tagId, sectionId, createdById, modifiedById) VALUES (?, ?, ?, ?)';
+    const expectedSql = 'INSERT INTO questionTags (tagId, questionId, createdById, modifiedById) VALUES (?, ?, ?, ?)';
     const userId = context.token.id.toString();
-    const vals = [mockTag.id.toString(), sectionId.toString(), userId, userId]
-    expect(querySpy).toHaveBeenLastCalledWith(context, expectedSql, vals, 'Tag.addToSection')
+    const vals = [mockTag.id.toString(), questionId.toString(), userId, userId]
+    expect(querySpy).toHaveBeenLastCalledWith(context, expectedSql, vals, 'Tag.addToQuestion')
     expect(result).toBe(true);
   });
 
-  it('returns null if the Tag cannot be associated with the Section', async () => {
-    const sectionId = casual.integer(1, 999);
+  it('returns null if the Tag cannot be associated with the Question', async () => {
+    const questionId = casual.integer(1, 999);
     const querySpy = jest.spyOn(Tag, 'query').mockResolvedValueOnce(null);
-    const result = await mockTag.addToSection(context, sectionId);
+    const result = await mockTag.addToQuestion(context, questionId);
     expect(querySpy).toHaveBeenCalledTimes(1);
     expect(result).toBe(false);
   });
 });
 
-describe('removeFromSection', () => {
+describe('removeFromQuestion', () => {
   let context;
   let mockTag;
 
@@ -213,21 +213,21 @@ describe('removeFromSection', () => {
     jest.clearAllMocks();
   });
 
-  it('removes the Tag association with the specified Section', async () => {
-    const sectionId = casual.integer(1, 999);
+  it('removes the Tag association with the specified Question', async () => {
+    const questionId = casual.integer(1, 999);
     const querySpy = jest.spyOn(Tag, 'query').mockResolvedValueOnce(mockTag);
-    const result = await mockTag.removeFromSection(context, sectionId);
+    const result = await mockTag.removeFromQuestion(context, questionId);
     expect(querySpy).toHaveBeenCalledTimes(1);
-    const expectedSql = 'DELETE FROM sectionTags WHERE tagId = ? AND sectionId = ?';
-    const vals = [mockTag.id.toString(), sectionId.toString()]
-    expect(querySpy).toHaveBeenLastCalledWith(context, expectedSql, vals, 'Tag.removeFromSection')
+    const expectedSql = 'DELETE FROM questionTags WHERE tagId = ? AND questionId = ?';
+    const vals = [mockTag.id.toString(), questionId.toString()]
+    expect(querySpy).toHaveBeenLastCalledWith(context, expectedSql, vals, 'Tag.removeFromQuestion')
     expect(result).toBe(true);
   });
 
-  it('returns null if the Tag cannot be removed from the Section', async () => {
-    const sectionId = casual.integer(1, 999);
+  it('returns null if the Tag cannot be removed from the Question', async () => {
+    const questionId = casual.integer(1, 999);
     const querySpy = jest.spyOn(Tag, 'query').mockResolvedValueOnce(null);
-    const result = await mockTag.removeFromSection(context, sectionId);
+    const result = await mockTag.removeFromQuestion(context, questionId);
     expect(querySpy).toHaveBeenCalledTimes(1);
     expect(result).toBe(false);
   });
@@ -265,10 +265,51 @@ describe('addToVersionedSectionTags', () => {
     expect(result).toBe(true);
   });
 
-  it('returns null if the Tag cannot be associated with the Section', async () => {
-    const sectionId = casual.integer(1, 999);
+  it('returns false if the Tag cannot be associated with the Section', async () => {
+    const versionedSectionId = casual.integer(1, 999);
     const querySpy = jest.spyOn(Tag, 'query').mockResolvedValueOnce(null);
-    const result = await mockTag.addToSection(context, sectionId);
+    const result = await mockTag.addToVersionedSectionTags(context, versionedSectionId);
+    expect(querySpy).toHaveBeenCalledTimes(1);
+    expect(result).toBe(false);
+  });
+});
+
+describe('addToVersionedQuestionTags', () => {
+  let context;
+  let mockTag;
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+
+    context = await buildMockContextWithToken(logger);
+
+    mockTag = new Tag({
+      id: casual.integer(1, 99),
+      name: casual.word,
+      description: casual.sentences(3)
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('associates the Tag to the specified Question', async () => {
+    const versionedQuestionId = casual.integer(1, 999);
+    const querySpy = jest.spyOn(Tag, 'query').mockResolvedValueOnce(mockTag);
+    const result = await mockTag.addToVersionedQuestionTags(context, versionedQuestionId);
+    expect(querySpy).toHaveBeenCalledTimes(1);
+    const expectedSql = 'INSERT INTO versionedQuestionTags (tagId, versionedQuestionId, createdById, modifiedById) VALUES (?, ?, ?, ?)';
+    const userId = context.token.id.toString();
+    const vals = [mockTag.id.toString(), versionedQuestionId.toString(), userId, userId]
+    expect(querySpy).toHaveBeenLastCalledWith(context, expectedSql, vals, 'Tag.addToVersionedQuestionTags');
+    expect(result).toBe(true);
+  });
+
+  it('returns null if the Tag cannot be associated with the Question', async () => {
+    const questionId = casual.integer(1, 999);
+    const querySpy = jest.spyOn(Tag, 'query').mockResolvedValueOnce(null);
+    const result = await mockTag.addToQuestion(context, questionId);
     expect(querySpy).toHaveBeenCalledTimes(1);
     expect(result).toBe(false);
   });
@@ -346,44 +387,6 @@ describe('findBySectionId', () => {
     const expectedSql = `SELECT tags.* FROM sectionTags JOIN tags ON sectionTags.tagId = tags.id WHERE sectionTags.sectionId = ?;`;
     expect(localQuery).toHaveBeenCalledTimes(1);
     expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [sectionId.toString()], 'Tag query');
-    expect(result).toEqual([tag]);
-  });
-});
-
-describe('findByVersionedSectionId', () => {
-  const originalQuery = Tag.query;
-
-  let localQuery;
-  let context;
-  let tag;
-
-  beforeEach(async () => {
-    jest.resetAllMocks();
-
-    localQuery = jest.fn();
-    (Tag.query as jest.Mock) = localQuery;
-
-    context = await buildMockContextWithToken(logger);
-
-    tag = new Tag({
-      id: casual.integer(1, 9),
-      name: casual.sentence,
-      description: casual.sentence,
-    })
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-    Tag.query = originalQuery;
-  });
-
-  it('should call query with correct params and return the tag', async () => {
-    localQuery.mockResolvedValueOnce([tag]);
-    const versionedSectionId = 1;
-    const result = await Tag.findByVersionedSectionId('Tag query', context, versionedSectionId);
-    const expectedSql = `SELECT tags.* FROM versionedSectionTags vst JOIN tags ON vst.tagId = tags.id WHERE vst.versionedSectionId = ?;`;
-    expect(localQuery).toHaveBeenCalledTimes(1);
-    expect(localQuery).toHaveBeenLastCalledWith(context, expectedSql, [versionedSectionId.toString()], 'Tag query');
     expect(result).toEqual([tag]);
   });
 });

--- a/src/resolvers/question.ts
+++ b/src/resolvers/question.ts
@@ -327,7 +327,7 @@ export const resolvers: Resolvers = {
   },
 
   Question: {
-    // Chained resolver to fetch the Affiliation info for the user
+    // Chained resolver to fetch the Tag info
     tags: async (parent: Question, _, context: MyContext): Promise<Tag[]> => {
       return await Tag.findByQuestionId('Chained Question.tags', context, parent.id);
     },

--- a/src/resolvers/question.ts
+++ b/src/resolvers/question.ts
@@ -5,6 +5,7 @@ import { Template } from "../models/Template";
 import { updateDisplayOrders } from "../services/questionService";
 import { AuthenticationError, BadRequestError, ForbiddenError, InternalServerError, NotFoundError } from "../utils/graphQLErrors";
 import { QuestionCondition } from "../models/QuestionCondition";
+import { Tag } from "../models/Tag";
 import { prepareObjectForLogs } from "../logger";
 import { isAdmin, isAuthorized } from "../services/authService";
 import { hasPermissionOnSection } from "../services/sectionService";
@@ -58,7 +59,8 @@ export const resolvers: Resolvers = {
       guidanceText,
       sampleText,
       useSampleTextAsDefault,
-      required
+      required,
+      tags,
     } }, context: MyContext): Promise<Question> => {
 
       const reference = 'addQuestion resolver';
@@ -95,8 +97,30 @@ export const resolvers: Resolvers = {
             // Update the associated template to set isDirty=1
             await Template.markTemplateAsDirty('Question resolver - addQuestion', context, templateId);
 
-            // Return newly created question
-            return await Question.findById(reference, context, questionId);
+            // Add any new Tags provided in the request
+            const addTagErrors = [];
+            if (Array.isArray(tags) && tags.length > 0) {
+              for (const item of tags) {
+                const tag = await Tag.findById(reference, context, item.id);
+
+                if (!tag) {
+                  addTagErrors.push(`Tag ${item.id} not found`);
+                }
+
+                const wasAdded = tag.addToQuestion(context, questionId)
+                if (!wasAdded) {
+                  addTagErrors.push(tag.name);
+                }
+
+              }
+            }
+
+            if (addTagErrors.length > 0) {
+              newQuestion.addError('tags', `Saved but we were unable to assign tags: ${addTagErrors.join(', ')}`);
+            }
+
+            // Return newly created section with tags
+            return newQuestion.hasErrors() ? newQuestion : await Question.findById(reference, context, newQuestion.id);
           }
           // Otherwise it had errors so return it as-is
           return newQuestion;
@@ -120,9 +144,9 @@ export const resolvers: Resolvers = {
       guidanceText,
       sampleText,
       useSampleTextAsDefault,
-      required
+      required,
+      tags
     } }, context: MyContext): Promise<Question> => {
-
       const reference = 'updateQuestion resolver';
       try {
         // Get Question based on provided questionId
@@ -152,9 +176,51 @@ export const resolvers: Resolvers = {
           });
 
           const updatedQuestion = await question.update(context);
+
           if (updatedQuestion && !updatedQuestion.hasErrors()) {
             // Update the associated template to set isDirty=1
             await Template.markTemplateAsDirty('Question resolver - updateQuestion', context, questionData.templateId);
+
+            // Get current tags for the question
+            const currentTags = await Tag.findByQuestionId(reference, context, questionData.id);
+            const currentTagIds = currentTags.map((tag) => tag.id);
+
+            // Use the helper function to determine which Tags to keep and which to remove
+            const { idsToBeRemoved, idsToBeSaved } = Question.reconcileAssociationIds(
+              currentTagIds,
+              tags ? (tags as Tag[]).map((d) => d.id) : []
+            );
+
+            // Delete any Tag associations that were removed
+            const removeTagErrors = [];
+            for (const id of idsToBeRemoved) {
+              const tag = await Tag.findById(reference, context, id as number);
+              if (tag) {
+                const wasRemoved = tag.removeFromQuestion(context, updatedQuestion.id)
+                if (!wasRemoved) {
+                  removeTagErrors.push(tag.name);
+                }
+              }
+            }
+            // if any errors were found when adding/removing tags then return them
+            if (removeTagErrors.length > 0) {
+              updatedQuestion.addError('tags', `Saved but we were unable to remove tags: ${removeTagErrors.join(', ')}`);
+            }
+
+            // Add any new Tag associations
+            const addTagErrors = [];
+            for (const id of idsToBeSaved) {
+              const tag = await Tag.findById(reference, context, id as number);
+              if (tag) {
+                const wasAdded = tag.addToQuestion(context, updatedQuestion.id)
+                if (!wasAdded) {
+                  addTagErrors.push(tag.name);
+                }
+              }
+            }
+            if (addTagErrors.length > 0) {
+              updatedQuestion.addError('tags', `Saved but we were unable to assign tags: ${addTagErrors.join(', ')}`);
+            }
 
             // Refetch the question or the updated question with errors
             const final = await Question.findById(reference, context, questionId);
@@ -261,6 +327,10 @@ export const resolvers: Resolvers = {
   },
 
   Question: {
+    // Chained resolver to fetch the Affiliation info for the user
+    tags: async (parent: Question, _, context: MyContext): Promise<Tag[]> => {
+      return await Tag.findByQuestionId('Chained Question.tags', context, parent.id);
+    },
     questionConditions: async (parent: Question, _, context: MyContext): Promise<QuestionCondition[]> => {
       return await QuestionCondition.findByQuestionId(
         'Chained Question.questionConditions',

--- a/src/resolvers/section.ts
+++ b/src/resolvers/section.ts
@@ -62,7 +62,6 @@ export const resolvers: Resolvers = {
           introduction,
           requirements,
           guidance,
-          tags,
           displayOrder
         }
       },
@@ -90,6 +89,7 @@ export const resolvers: Resolvers = {
 
           // create the new section
           const newSection = await section.create(context, templateId);
+
           // if the section was not created, return the errors
           if (!newSection?.id) {
             // A null was returned so add a generic error and return it
@@ -97,28 +97,6 @@ export const resolvers: Resolvers = {
               section.addError('general', 'Unable to create the section');
             }
             return section;
-          }
-
-          // Add any new Tags provided in the request
-          const addTagErrors = [];
-          if (Array.isArray(tags) && tags.length > 0) {
-            for (const item of tags) {
-              const tag = await Tag.findById(reference, context, item.id);
-
-              if (!tag) {
-                addTagErrors.push(`Tag ${item.id} not found`);
-              }
-
-              const wasAdded = tag.addToSection(context, newSection.id)
-              if (!wasAdded) {
-                addTagErrors.push(tag.name);
-              }
-
-            }
-          }
-
-          if (addTagErrors.length > 0) {
-            newSection.addError('tags', `Saved but we were unable to assign tags: ${addTagErrors.join(', ')}`);
           }
 
           // if a copyFromVersionedSectionId is provided, clone all the questions
@@ -141,29 +119,22 @@ export const resolvers: Resolvers = {
               });
 
               const addedQuestion = await newQuestion.create(context);
+
               if (!addedQuestion?.id) {
                 // A null was returned so add a generic error and return it
                 if (!newQuestion.errors['general']) {
                   newQuestion.addError('general', 'Unable to create the question');
                 }
-              }
-            }
-
-            const versionedTags = await Tag.findByVersionedSectionId(reference, context, original.sectionId);
-            // Add tags from the copied versionedSection to the section
-            if (versionedTags && Array.isArray(versionedTags) && versionedTags.length > 0) {
-              const addTagErrors = [];
-              for (const tagIn of versionedTags) {
-                const tag = await Tag.findById(reference, context, tagIn.id);
-                if (tag) {
-                  const wasAdded = tag.addToSection(context, newSection.id)
+              } else {
+                // Copy the source versioned question's tags onto the newly cloned question
+                const sourceTags = await Tag.findByVersionedQuestionId(reference, context, versionedQuestion.id);
+                for (const tag of sourceTags) {
+                  const wasAdded = await tag.addToQuestion(context, addedQuestion.id);
                   if (!wasAdded) {
-                    addTagErrors.push(tag.name);
+                    context.logger.error(`${reference} failed to copy tag ${tag.id} to cloned question ${addedQuestion.id}`);
+                    newQuestion.addError('general', 'Question created but unable to copy all tags');
                   }
                 }
-              }
-              if (addTagErrors.length > 0) {
-                newSection.addError('tags', `Section created but we were unable to assign tags: ${addTagErrors.join(', ')}`);
               }
             }
           }
@@ -171,8 +142,8 @@ export const resolvers: Resolvers = {
           // Update the associated template to set isDirty=1
           await Template.markTemplateAsDirty('Section resolver - addSection', context, templateId);
 
-          // Return newly created section with tags
-          return newSection.hasErrors() ? newSection : await Section.findById(reference, context, newSection.id);
+          // Return newly created section
+          return await Section.findById(reference, context, newSection.id);
         }
         throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {
@@ -193,7 +164,6 @@ export const resolvers: Resolvers = {
           introduction,
           requirements,
           guidance,
-          tags,
           displayOrder,
           bestPractice
         }
@@ -237,52 +207,11 @@ export const resolvers: Resolvers = {
             return section;
           }
 
-          // Get current tags for the section
-          const currentTags = await Tag.findBySectionId(reference, context, sectionId);
-          const currentTagIds = currentTags.map((tag) => tag.id);
-
-          // Use the helper function to determine which Tags to keep and which to remove
-          const { idsToBeRemoved, idsToBeSaved } = Section.reconcileAssociationIds(
-            currentTagIds,
-            tags ? (tags as Tag[]).map((d) => d.id) : []
-          );
-
-          // Delete any Tag associations that were removed
-          const removeTagErrors = [];
-          for (const id of idsToBeRemoved) {
-            const tag = await Tag.findById(reference, context, id as number);
-            if (tag) {
-              const wasRemoved = tag.removeFromSection(context, updatedSection.id)
-              if (!wasRemoved) {
-                removeTagErrors.push(tag.name);
-              }
-            }
-          }
-          // if any errors were found when adding/removing tags then return them
-          if (removeTagErrors.length > 0) {
-            updatedSection.addError('tags', `Saved but we were unable to remove tags: ${removeTagErrors.join(', ')}`);
-          }
-
-          // Add any new Tag associations
-          const addTagErrors = [];
-          for (const id of idsToBeSaved) {
-            const tag = await Tag.findById(reference, context, id as number);
-            if (tag) {
-              const wasAdded = tag.addToSection(context, updatedSection.id)
-              if (!wasAdded) {
-                addTagErrors.push(tag.name);
-              }
-            }
-          }
-          if (addTagErrors.length > 0) {
-            updatedSection.addError('tags', `Saved but we were unable to assign tags: ${addTagErrors.join(', ')}`);
-          }
-
           // Update the associated template to set isDirty=1
           await Template.markTemplateAsDirty('Section resolver - updateSection', context, sectionData.templateId);
 
-          // Return newly updated section with tags
-          return updatedSection.hasErrors() ? updatedSection : await Section.findById(reference, context, updatedSection.id);
+          // Return newly updated section
+          return await Section.findById(reference, context, updatedSection.id);
         }
         throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {

--- a/src/resolvers/template.ts
+++ b/src/resolvers/template.ts
@@ -7,6 +7,7 @@ import { Question } from "../models/Question";
 import { VersionedSection } from '../models/VersionedSection';
 import { VersionedQuestion } from "../models/VersionedQuestion";
 import { User, UserRole } from '../models/User';
+import { Tag } from "../models/Tag";
 import { MyContext } from "../context";
 import {
   cloneTemplate,
@@ -192,6 +193,17 @@ export const resolvers: Resolvers = {
                       if (newQuestion && newQuestion.hasErrors()) {
                         context.logger.error(`${reference} failed to clone question`);
                         newTemplate.addError('questions', 'Created Template but unable to clone all questions');
+                      } else if (newQuestion?.id) {
+                        // Get tags that belong to the source question, so we can copy them onto the clone
+                        const sourceTags = await Tag.findByQuestionId(reference, context, q.id);
+
+                        for (const tag of sourceTags) {
+                          const wasAdded = await tag.addToQuestion(context, newQuestion.id);
+                          if (!wasAdded) {
+                            context.logger.error(`${reference} failed to copy tag ${tag.id} to cloned question ${newQuestion.id}`);
+                            newTemplate.addError('questions', 'Created Template but unable to clone all question tags');
+                          }
+                        }
                       }
                     }
                   }

--- a/src/schemas/question.ts
+++ b/src/schemas/question.ts
@@ -58,6 +58,8 @@ export const typeDefs = gql`
     useSampleTextAsDefault: Boolean
     "To indicate whether the question is required to be completed"
     required: Boolean
+    "The Tags associated with this question. A question might not have any tags"
+    tags: [Tag]
 
     "The conditional logic triggered by this question"
     questionConditions: [QuestionCondition!]
@@ -111,6 +113,8 @@ export const typeDefs = gql`
     useSampleTextAsDefault: Boolean
     "To indicate whether the question is required to be completed"
     required: Boolean
+    "The Tags associated with this question. A question might not have any tags"
+    tags: [TagInput!]
   }
 
   input UpdateQuestionInput {
@@ -132,5 +136,7 @@ export const typeDefs = gql`
     useSampleTextAsDefault: Boolean
     "To indicate whether the question is required to be completed"
     required: Boolean
+    "The Tags associated with this question. A question might not have any tags"
+    tags: [TagInput!]
   }
 `

--- a/src/schemas/section.ts
+++ b/src/schemas/section.ts
@@ -96,8 +96,6 @@ export const typeDefs = gql`
     guidance: String
     "The order in which the section will be displayed in the template"
     displayOrder: Int
-    "The Tags associated with this section. A section might not have any tags"
-    tags: [TagInput!]
   }
 
   "Input for updating a section"
@@ -116,7 +114,5 @@ export const typeDefs = gql`
     displayOrder: Int
     "Whether or not this Section is designated as a 'Best Practice' section"
     bestPractice: Boolean
-    "The Tags associated with this section. A section might not have any tags"
-    tags: [TagInput!]
   }
 `;

--- a/src/services/__tests__/integrationVersioning.spec.ts
+++ b/src/services/__tests__/integrationVersioning.spec.ts
@@ -125,7 +125,14 @@ describe('Integration test: Template Versioning', () => {
       const section = sectionStore.find(s => s.id === sectionId);
       return section ? section.tags : [];
     });
+
+    const mockFindTagsByQuestionId = jest.fn().mockImplementation(async (_, __, questionId) => {
+      const question = questionStore.find(q => q.id === questionId);
+      return question?.tags ?? [];
+    });
+
     const mockAddToVersionedSectionTags = jest.fn().mockImplementation(async () => true);
+    const mockAddToVersionedQuestionTags = jest.fn().mockImplementation(async () => true);
 
     // Add the entry to the appropriate store
     mockInsert = jest.fn().mockImplementation(async (context, table, obj) => {
@@ -301,6 +308,10 @@ describe('Integration test: Template Versioning', () => {
         guidanceText: casual.sentences(2),
         sampleText: casual.sentences(2),
         required: true,
+        tags: [
+          new Tag({ id: casual.integer(1, 9999), name: casual.words(3) }),
+          new Tag({ id: casual.integer(1, 9999), name: casual.words(1) }),
+        ],
         displayOrder: casual.integer(1, 9),
         isDirty: true,
         createdById: casual.integer(1, 999),
@@ -318,6 +329,10 @@ describe('Integration test: Template Versioning', () => {
         guidanceText: casual.sentences(2),
         sampleText: casual.sentences(2),
         required: true,
+        tags: [
+          new Tag({ id: casual.integer(1, 9999), name: casual.words(3) }),
+          new Tag({ id: casual.integer(1, 9999), name: casual.words(1) }),
+        ],
         displayOrder: casual.integer(1, 9),
         isDirty: true,
         createdById: casual.integer(1, 999),
@@ -335,6 +350,10 @@ describe('Integration test: Template Versioning', () => {
         guidanceText: casual.sentences(2),
         sampleText: casual.sentences(2),
         required: true,
+        tags: [
+          new Tag({ id: casual.integer(1, 9999), name: casual.words(3) }),
+          new Tag({ id: casual.integer(1, 9999), name: casual.words(1) }),
+        ],
         displayOrder: casual.integer(1, 9),
         isDirty: true,
         createdById: casual.integer(1, 999),
@@ -404,7 +423,9 @@ describe('Integration test: Template Versioning', () => {
     // Tag dataStore mocks
     (Tag.findById as jest.Mock) = mockFindTagById;
     (Tag.findBySectionId as jest.Mock) = mockFindTagsBySectionId;
+    (Tag.findByQuestionId as jest.Mock) = mockFindTagsByQuestionId;
     (Tag.prototype.addToVersionedSectionTags as unknown as jest.Mock) = mockAddToVersionedSectionTags;
+    (Tag.prototype.addToVersionedQuestionTags as unknown as jest.Mock) = mockAddToVersionedQuestionTags;
   });
 
   afterEach(() => {

--- a/src/services/__tests__/questionService.spec.ts
+++ b/src/services/__tests__/questionService.spec.ts
@@ -10,10 +10,11 @@ import { Question } from "../../models/Question";
 import { VersionedQuestion } from "../../models/VersionedQuestion";
 import { QuestionCondition, QuestionConditionActionType, QuestionConditionCondition } from "../../models/QuestionCondition";
 import { VersionedQuestionCondition } from "../../models/VersionedQuestionCondition";
+import { Tag } from "../../models/Tag";
 import { getRandomEnumValue } from "../../__tests__/helpers";
 import { getCurrentDate } from "../../utils/helpers";
 import { CURRENT_SCHEMA_VERSION } from "@dmptool/types";
-import {MyContext} from "../../context";
+import { MyContext } from "../../context";
 
 // Pulling context in here so that the mysql gets mocked
 jest.mock('../../context.ts');
@@ -184,6 +185,8 @@ describe('generateQuestionVersion', () => {
   let mockUpdate;
   let mockFindQuestionById;
   let mockFindVersionedQuestionById;
+  let mockFindTagById;
+  let mockAddToVersionedQuestionTags;
 
   beforeEach(() => {
     // Mock the QuestionConditions
@@ -298,6 +301,14 @@ describe('generateQuestionVersion', () => {
       }
       return obj;
     });
+
+    mockAddToVersionedQuestionTags = jest.fn().mockResolvedValue(true);
+    (Tag.prototype.addToVersionedQuestionTags as jest.Mock) = mockAddToVersionedQuestionTags;
+
+    mockFindTagById = jest.fn().mockImplementation((_, __, id) => {
+      return new Tag({ id, name: `tag-${id}`, description: casual.sentence });
+    });
+
   });
 
   it('does not allow an unsaved question to be versioned', async () => {
@@ -380,6 +391,95 @@ describe('generateQuestionVersion', () => {
     expect(updated.modifiedById).toEqual(question.modifiedById);
     expect(updated.modified).toEqual(question.modified);
     expect(updated.isDirty).toEqual(false);
+  });
+  it('versions the Question and assigns its tags', async () => {
+    const tag1 = { id: casual.integer(1, 99), name: casual.word };
+    const tag2 = { id: casual.integer(1, 99), name: casual.word };
+    const question = new Question({ ...questionStore[0], tags: [tag1, tag2] });
+
+    (VersionedQuestion.insert as jest.Mock) = mockInsert;
+    (VersionedQuestion.findById as jest.Mock) = mockFindVersionedQuestionById;
+    (Question.update as jest.Mock) = mockUpdate;
+    (Question.findById as jest.Mock) = mockFindQuestionById;
+    (Tag.findById as jest.Mock) = mockFindTagById;
+
+    const versionedTemplateId = casual.integer(1, 999);
+    const versionedSectionId = casual.integer(1, 999);
+
+    expect(
+      await generateQuestionVersion(context, question, versionedTemplateId, versionedSectionId)
+    ).toEqual(true);
+
+    const newVersion = versionedQuestionStore[0];
+    expect(mockFindTagById).toHaveBeenCalledTimes(2);
+    expect(mockFindTagById).toHaveBeenCalledWith('generateQuestionVersion', context, tag1.id);
+    expect(mockFindTagById).toHaveBeenCalledWith('generateQuestionVersion', context, tag2.id);
+    expect(mockAddToVersionedQuestionTags).toHaveBeenCalledTimes(2);
+    expect(mockAddToVersionedQuestionTags).toHaveBeenCalledWith(context, newVersion.id);
+    expect(newVersion.errors?.tags).toBeUndefined();
+  });
+
+  it('adds a tags error when a tag fails to be assigned', async () => {
+    const tagName = `tag-10`;
+    const question = new Question({ ...questionStore[0], tags: [{ id: 10, name: tagName }] });
+
+    (VersionedQuestion.insert as jest.Mock) = mockInsert;
+    (VersionedQuestion.findById as jest.Mock) = mockFindVersionedQuestionById;
+    (Question.update as jest.Mock) = mockUpdate;
+    (Question.findById as jest.Mock) = mockFindQuestionById;
+    (Tag.findById as jest.Mock) = mockFindTagById; // now returns id + matching name
+    (Tag.prototype.addToVersionedQuestionTags as jest.Mock) = jest.fn().mockResolvedValue(false);
+
+    const versionedTemplateId = casual.integer(1, 999);
+    const versionedSectionId = casual.integer(1, 999);
+
+    expect(
+      await generateQuestionVersion(context, question, versionedTemplateId, versionedSectionId)
+    ).toEqual(true);
+
+    const newVersion = versionedQuestionStore[0];
+    expect(newVersion.errors.tags).toContain("Saved but we were unable to assign tags: tag-10");
+  });
+
+  it('adds a tags error when a tag fails to be assigned', async () => {
+    const tag = { id: 10, name: 'Data Formatting' };
+    const question = new Question({ ...questionStore[0], tags: [tag] });
+
+    (VersionedQuestion.insert as jest.Mock) = mockInsert;
+    (VersionedQuestion.findById as jest.Mock) = mockFindVersionedQuestionById;
+    (Question.update as jest.Mock) = mockUpdate;
+    (Question.findById as jest.Mock) = mockFindQuestionById;
+    (Tag.findById as jest.Mock) = mockFindTagById;
+    (Tag.prototype.addToVersionedQuestionTags as jest.Mock) = jest.fn().mockResolvedValue(false);
+
+    const versionedTemplateId = casual.integer(1, 999);
+    const versionedSectionId = casual.integer(1, 999);
+
+    expect(
+      await generateQuestionVersion(context, question, versionedTemplateId, versionedSectionId)
+    ).toEqual(true);
+
+    const newVersion = versionedQuestionStore[0];
+    expect(newVersion.errors.tags).toContain("Saved but we were unable to assign tags: tag-10");
+  });
+
+  it('skips tag assignment when the question has no tags', async () => {
+    const question = new Question({ ...questionStore[0], tags: [] });
+
+    (VersionedQuestion.insert as jest.Mock) = mockInsert;
+    (VersionedQuestion.findById as jest.Mock) = mockFindVersionedQuestionById;
+    (Question.update as jest.Mock) = mockUpdate;
+    (Question.findById as jest.Mock) = mockFindQuestionById;
+    (Tag.findById as jest.Mock) = mockFindTagById;
+
+    const versionedTemplateId = casual.integer(1, 999);
+    const versionedSectionId = casual.integer(1, 999);
+
+    expect(
+      await generateQuestionVersion(context, question, versionedTemplateId, versionedSectionId)
+    ).toEqual(true);
+
+    expect(mockFindTagById).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/__tests__/sectionService.spec.ts
+++ b/src/services/__tests__/sectionService.spec.ts
@@ -11,9 +11,15 @@ import { VersionedSection } from "../../models/VersionedSection";
 import { Tag } from "../../models/Tag";
 import { getCurrentDate } from "../../utils/helpers";
 import { Question } from "../../models/Question";
+import { generateQuestionVersion } from "../questionService";
 
 // Pulling context in here so that the mysql gets mocked
 jest.mock('../../context.ts');
+
+jest.mock("../questionService", () => ({
+  ...jest.requireActual("../questionService"),
+  generateQuestionVersion: jest.fn(),
+}));
 
 let context;
 
@@ -89,7 +95,6 @@ describe('cloneSection', () => {
   let requirements;
   let guidance;
   let displayOrder;
-  let tags;
   let isDirty;
   let createdById;
 
@@ -101,11 +106,10 @@ describe('cloneSection', () => {
     requirements = casual.sentences(5);
     guidance = casual.sentences(5);
     displayOrder = casual.integer(1, 9);
-    tags = null;
     isDirty = true;
     createdById = casual.integer(1, 999);
 
-    section = new Section({ id, templateId, name, introduction, requirements, guidance, displayOrder, tags, isDirty, createdById });
+    section = new Section({ id, templateId, name, introduction, requirements, guidance, displayOrder, isDirty, createdById });
   });
 
   it('Clone retains the expected parts of the specified Section', () => {
@@ -169,6 +173,7 @@ describe('generateSectionVersion', () => {
   let mockTagFindById;
   let mockAddToVersionedSectionTags;
   let mockQuestionFindBySectionId;
+  let mockTagFindByQuestionId;
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -176,6 +181,10 @@ describe('generateSectionVersion', () => {
     // Mock the Questions
     mockQuestionFindBySectionId = jest.fn().mockResolvedValue([]);
     (Question.findBySectionId as jest.Mock) = mockQuestionFindBySectionId;
+
+    // Mock Tag.findByQuestionId (used to populate questionInstance.tags before versioning)
+    mockTagFindByQuestionId = jest.fn().mockResolvedValue([]);
+    (Tag.findByQuestionId as jest.Mock) = mockTagFindByQuestionId;
 
     const tstamp = getCurrentDate();
 
@@ -425,6 +434,34 @@ describe('generateSectionVersion', () => {
 
     expect(mockTagFindById).not.toHaveBeenCalled();
     expect(mockAddToVersionedSectionTags).not.toHaveBeenCalled();
+  });
+
+  it('fetches tags for each question and passes them to generateQuestionVersion', async () => {
+    const section = new Section(sectionStore[0]);
+    section.tags = [];
+
+    const question1 = new Question({ id: casual.integer(1, 99), sectionId: section.id });
+    mockQuestionFindBySectionId.mockResolvedValue([question1]);
+
+    const question1Tags = [new Tag({ id: 10, name: casual.word })];
+    mockTagFindByQuestionId.mockResolvedValue(question1Tags);
+
+    (VersionedSection.insert as jest.Mock) = mockInsert;
+    (VersionedSection.findById as jest.Mock) = mockFindVersionedSectionbyId;
+    (Section.update as jest.Mock) = mockUpdate;
+    (Section.findById as jest.Mock) = mockFindSectionById;
+    (generateQuestionVersion as jest.Mock).mockResolvedValue(true);
+
+    const versionedTemplateId = casual.integer(1, 999);
+    expect(await generateSectionVersion(context, section, versionedTemplateId)).toEqual(true);
+
+    expect(mockTagFindByQuestionId).toHaveBeenCalledWith('generateSectionVersion', context, question1.id);
+    expect(generateQuestionVersion).toHaveBeenCalledWith(
+      context,
+      expect.objectContaining({ id: question1.id, tags: question1Tags }),
+      versionedTemplateId,
+      expect.any(Number)
+    );
   });
 });
 

--- a/src/services/guidanceService.ts
+++ b/src/services/guidanceService.ts
@@ -62,6 +62,15 @@ export const hasPermissionOnGuidanceGroup = async (
   return context?.token?.affiliationId === guidanceGroup.affiliationId || isSuperAdmin(context?.token);
 };
 
+// Resolve a tags map from a primary source, falling back to a secondary source if the primary is empty
+async function resolveTagsMap(
+  primary: Promise<Record<number, string>>,
+  fallback: () => Promise<Record<number, string>>
+): Promise<Record<number, string>> {
+  const primaryTags = await primary;
+  return Object.keys(primaryTags).length > 0 ? primaryTags : await fallback();
+}
+
 // Creates a new Version/Snapshot of the specified GuidanceGroup
 // - Creates a new VersionedGuidanceGroup including all of the related Guidance
 // - Resets the isDirty flag on the GuidanceGroup
@@ -299,7 +308,6 @@ export async function getGuidanceSourcesForPlan(
   customQuestionId?: number
 ): Promise<GuidanceSource[]> {
   const reference = 'getGuidanceSourcesForPlan';
-
   try {
     // Get plan details
     const plan = await Plan.findById(reference, context, planId);
@@ -327,7 +335,7 @@ export async function getGuidanceSourcesForPlan(
     // First, get guidance text from template/section/question, and tagsMap
     // ============================================================
 
-    // Get section tag IDs and section-level guidance
+    // Get question/section tag IDs and section-level guidance
     let tagsMap: Record<number, string>;
     let guidanceText: string | null = null;
 
@@ -338,9 +346,8 @@ export async function getGuidanceSourcesForPlan(
       if (!question) {
         return [];
       }
-
-      // Get tags for the question's section
-      tagsMap = await getSectionTags(context, question.versionedSectionId);
+      // If the question has tags, then use them rather than the section tags, which we're moving off of
+      tagsMap = await resolveTagsMap(getQuestionTags(context, versionedQuestionId), () => getSectionTags(context, question.versionedSectionId));
       guidanceText = question.guidanceText || null; // Question-level guidance
     } else if (customQuestionId) {
       // Custom question: guidance is owned by the user's institution
@@ -351,14 +358,28 @@ export async function getGuidanceSourcesForPlan(
       guidanceText = customQuestion.guidanceText || null;
       // Get tags from the parent section (which may be BASE or CUSTOM)
       if (customQuestion.versionedSectionType === 'BASE') {
-        tagsMap = await getSectionTags(context, customQuestion.versionedSectionId);
+        // Prefer the union of question-level tags in the section; fall back to
+        // legacy section-level tags during the transition period.
+        const sectionId = customQuestion.versionedSectionId;
+
+        tagsMap = await resolveTagsMap(
+          getQuestionTagsForSection(context, sectionId),
+          () => getSectionTags(context, sectionId)
+        );
       } else {
-        // CUSTOM parent section — fall back to template-wide tags
-        tagsMap = await getSectionTagsMap(context, versionedTemplateId);
+        // CUSTOM parent section — no specific section to derive tags from,
+        // so fall back to template-wide tags (question tags preferred, section tags as legacy fallback)
+        tagsMap = await resolveTagsMap(getQuestionTagsMap(context, versionedTemplateId),
+          () => getSectionTagsMap(context, versionedTemplateId)
+        );
       }
     } else if (versionedSectionId) { // Otherwise, get tags and guidance for the section id provided
 
-      tagsMap = await getSectionTags(context, versionedSectionId);
+      tagsMap = await resolveTagsMap(
+        getQuestionTagsForSection(context, versionedSectionId),
+        () => getSectionTags(context, versionedSectionId)
+      );
+
       const section = await VersionedSection.findById(reference, context, versionedSectionId);
       guidanceText = section?.guidance || null; // Section-level guidance
     } else if (customSectionId) {
@@ -367,7 +388,9 @@ export async function getGuidanceSourcesForPlan(
       const customSection = await VersionedCustomSection.findById(reference, context, customSectionId);
       if (!customSection) return [];
       guidanceText = customSection?.guidance || null;
-      tagsMap = await getSectionTagsMap(context, versionedTemplateId);
+
+      // Same template-wide fallback pattern as the CUSTOM customQuestion branch above
+      tagsMap = await resolveTagsMap(getQuestionTagsMap(context, versionedTemplateId), () => getSectionTagsMap(context, versionedTemplateId));
     }
 
 
@@ -563,48 +586,61 @@ export async function getGuidanceSourcesForPlan(
     // ============================================================
     // 3. Template Owner's Guidance
     // ============================================================
-    if (templateOwnerUri && !processedOrgURIs.has(templateOwnerUri)) {
-      const affiliation = await Affiliation.findByURI(reference, context, templateOwnerUri);
+    // ============================================================
+    // 3. Template Owner's Guidance
+    // ============================================================
+    if (templateOwnerUri) {
+      const alreadyAdded = processedOrgURIs.has(templateOwnerUri);
+      const existingSource = alreadyAdded
+        ? guidanceSources.find(s => s.orgURI === templateOwnerUri)
+        : null;
 
-      if (affiliation) {
-        // Fetch TAG-BASED guidance
-        const tagBasedGuidance = await VersionedGuidance.findByAffiliationAndTagIds(
-          reference,
-          context,
-          templateOwnerUri,
-          sectionTagIds
-        );
-
-        const items = groupGuidanceByTag(tagBasedGuidance, sectionTagIds, tagsMap);
-
-        // Only prepend section-level guidanceText for versioned sections/questions.
-        // For custom sections/questions, the content was created by the user's institution —
-        // the template owner has no guidance to contribute here.
+      if (alreadyAdded && existingSource) {
+        // Template owner's affiliation guidance was already added in step 2
+        // (e.g., because the current user shares the template owner's affiliation).
+        // Still need to attach the section/question's own guidanceText, which is
+        // only ever sourced here.
         if (guidanceText && !customSectionId && !customQuestionId) {
-          items.unshift({
-            title: affiliation.displayName || affiliation.name,
+          existingSource.items.unshift({
+            title: existingSource.label,
             guidanceText
           });
         }
+      } else {
+        const affiliation = await Affiliation.findByURI(reference, context, templateOwnerUri);
 
-        // Always include template owner as a source, even with no guidance for a custom section
-        // so that the Guidance Panel can show "no guidance available"
-        guidanceSources.push({
-          id: `affiliation-${templateOwnerUri}`,
-          type: GuidanceSourceType.TEMPLATE_OWNER,
-          label: affiliation.displayName || affiliation.name,
-          shortName: (affiliation.acronyms && affiliation.acronyms[0]) ||
-            affiliation.displayName ||
-            affiliation.name,
-          orgURI: templateOwnerUri,
-          items,
-          hasGuidance: true
-        });
+        if (affiliation) {
+          const tagBasedGuidance = await VersionedGuidance.findByAffiliationAndTagIds(
+            reference,
+            context,
+            templateOwnerUri,
+            sectionTagIds
+          );
 
-        processedOrgURIs.add(templateOwnerUri);
+          const items = groupGuidanceByTag(tagBasedGuidance, sectionTagIds, tagsMap);
 
+          if (guidanceText && !customSectionId && !customQuestionId) {
+            items.unshift({
+              title: affiliation.displayName || affiliation.name,
+              guidanceText
+            });
+          }
+
+          guidanceSources.push({
+            id: `affiliation-${templateOwnerUri}`,
+            type: GuidanceSourceType.TEMPLATE_OWNER,
+            label: affiliation.displayName || affiliation.name,
+            shortName: (affiliation.acronyms && affiliation.acronyms[0]) ||
+              affiliation.displayName ||
+              affiliation.name,
+            orgURI: templateOwnerUri,
+            items,
+            hasGuidance: true
+          });
+
+          processedOrgURIs.add(templateOwnerUri);
+        }
       }
-
     }
 
     // ============================================================
@@ -692,6 +728,41 @@ export async function getSectionTags(
 }
 
 /**
+ * Get question tags for a specific question (tagId -> tagName)
+ */
+export async function getQuestionTags(
+  context: MyContext,
+  versionedQuestionId: number
+): Promise<Record<number, string>> {
+  const sql = `
+    SELECT DISTINCT
+      t.id,
+      t.name
+    FROM tags t
+    JOIN versionedQuestionTags vqt ON t.id = vqt.tagId
+    WHERE vqt.versionedQuestionId = ?
+    ORDER BY t.name;
+  `;
+
+  try {
+    const results = await PlanGuidance.query(context, sql, [versionedQuestionId.toString()]);
+    const tagsMap: Record<number, string> = {};
+
+    if (results) {
+      (results as TagRow[]).forEach((row) => {
+        tagsMap[row.id] = row.name;
+      });
+    }
+
+    return tagsMap;
+  } catch (err) {
+    context.logger.error({ err, sql, versionedQuestionId }, 'Error fetching question tags');
+    return {};
+  }
+}
+
+
+/**
  * Get section tag IDs for all sections in a template (just IDs, no names)
  */
 export async function getSectionTagIds(
@@ -746,6 +817,79 @@ export async function getSectionTagsMap(
     return tagsMap;
   } catch (err) {
     context.logger.error({ err, sql, versionedTemplateId }, 'Error fetching section tags');
+    return {};
+  }
+}
+
+/**
+ * Get the union of question-level tags across an entire template (tagId -> tagName).
+ * Template-wide equivalent of getSectionTagsMap, used as a fallback when a custom
+ * section/question has no specific parent section to derive tags from.
+ */
+export async function getQuestionTagsMap(
+  context: MyContext,
+  versionedTemplateId: number
+): Promise<Record<number, string>> {
+  const sql = `
+    SELECT DISTINCT
+      t.id,
+      t.name
+    FROM tags t
+    JOIN versionedQuestionTags vqt ON t.id = vqt.tagId
+    JOIN versionedQuestions vq ON vqt.versionedQuestionId = vq.id
+    WHERE vq.versionedTemplateId = ?
+    ORDER BY t.name;
+  `;
+
+  try {
+    const results = await PlanGuidance.query(context, sql, [versionedTemplateId.toString()]);
+    const tagsMap: Record<number, string> = {};
+
+    if (results) {
+      (results as TagRow[]).forEach((row) => {
+        tagsMap[row.id] = row.name;
+      });
+    }
+
+    return tagsMap;
+  } catch (err) {
+    context.logger.error({ err, sql, versionedTemplateId }, 'Error fetching question tags map');
+    return {};
+  }
+}
+
+/**
+ * Get the union of tags across all questions in a section (tagId -> tagName).
+ * Used as a stand-in for custom questions, which don't yet support their own tags.
+ */
+export async function getQuestionTagsForSection(
+  context: MyContext,
+  versionedSectionId: number
+): Promise<Record<number, string>> {
+  const sql = `
+    SELECT DISTINCT
+      t.id,
+      t.name
+    FROM tags t
+    JOIN versionedQuestionTags vqt ON t.id = vqt.tagId
+    JOIN versionedQuestions vq ON vqt.versionedQuestionId = vq.id
+    WHERE vq.versionedSectionId = ?
+    ORDER BY t.name;
+  `;
+
+  try {
+    const results = await PlanGuidance.query(context, sql, [versionedSectionId.toString()]);
+    const tagsMap: Record<number, string> = {};
+
+    if (results) {
+      (results as TagRow[]).forEach((row) => {
+        tagsMap[row.id] = row.name;
+      });
+    }
+
+    return tagsMap;
+  } catch (err) {
+    context.logger.error({ err, sql, versionedSectionId }, 'Error fetching question tags for section');
     return {};
   }
 }

--- a/src/services/guidanceService.ts
+++ b/src/services/guidanceService.ts
@@ -586,9 +586,6 @@ export async function getGuidanceSourcesForPlan(
     // ============================================================
     // 3. Template Owner's Guidance
     // ============================================================
-    // ============================================================
-    // 3. Template Owner's Guidance
-    // ============================================================
     if (templateOwnerUri) {
       const alreadyAdded = processedOrgURIs.has(templateOwnerUri);
       const existingSource = alreadyAdded

--- a/src/services/questionService.ts
+++ b/src/services/questionService.ts
@@ -2,6 +2,7 @@ import { MyContext } from "../context";
 import { Template } from "../models/Template";
 import { hasPermissionOnTemplate } from "./templateService";
 import { Question } from "../models/Question";
+import { Tag } from "../models/Tag";
 import { VersionedQuestion } from "../models/VersionedQuestion";
 import { NotFoundError } from "../utils/graphQLErrors";
 import { QuestionCondition } from "../models/QuestionCondition";
@@ -61,6 +62,30 @@ export const generateQuestionVersion = async (
     const saved = await versionedQuestion.create(context);
 
     if (saved && !saved.hasErrors()) {
+
+      // Get tags associated with question so we can add it to versionedQuestionTags table
+      const addTagErrors = [];
+      if (Array.isArray(question.tags) && question.tags.length > 0) {
+        for (const item of question.tags) {
+          const tag = await Tag.findById('generateQuestionVersion', context, item.id);
+
+          if (!tag) {
+            addTagErrors.push(`Tag ${item.id} not found`);
+            continue; // <-- Add this line to skip calling addToVersionedQuestionTags on null
+          }
+
+          const wasAdded = await tag.addToVersionedQuestionTags(context, saved.id);
+          if (!wasAdded) {
+            addTagErrors.push(tag.name);
+          }
+
+        }
+      }
+
+      if (addTagErrors.length > 0) {
+        saved.addError('tags', `Saved but we were unable to assign tags: ${addTagErrors.join(', ')}`);
+      }
+
       // Version any QuestionConditions as well
       const questionConditions = await QuestionCondition.findByQuestionId('generateQuestionVersion', context, saved.questionId);
       let allConditionsWereVersioned = true;
@@ -208,5 +233,5 @@ export const updateDisplayOrders = async (
       }
     }
   }
-  return  reorderedQuestions;
+  return reorderedQuestions;
 }

--- a/src/services/sectionService.ts
+++ b/src/services/sectionService.ts
@@ -18,6 +18,7 @@ export const generateSectionVersion = async (
   section: Section,
   versionedTemplateId: number,
 ): Promise<boolean> => {
+  const ref = 'generateSectionVersion';
 
   // If the section has no id then it has not yet been saved so throw an error
   if (!section.id) {
@@ -79,6 +80,10 @@ export const generateSectionVersion = async (
         const questionInstance = new Question({
           ...question
         });
+
+        // Get current tags for the question so we can add it to versionedQuestionTags table
+        const currentTags = await Tag.findByQuestionId(ref, context, questionInstance.id);
+        questionInstance.tags = currentTags;
 
         const passed = await generateQuestionVersion(context, questionInstance, versionedTemplateId, created.id);
         if (!passed) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -242,6 +242,8 @@ export type AddQuestionInput = {
   sampleText?: InputMaybe<Scalars['String']['input']>;
   /** The unique id of the Section that the question belongs to */
   sectionId: Scalars['Int']['input'];
+  /** The Tags associated with this question. A question might not have any tags */
+  tags?: InputMaybe<Array<TagInput>>;
   /** The unique id of the Template that the question belongs to */
   templateId: Scalars['Int']['input'];
   /** Boolean indicating whether we should use content from sampleText as the default answer */
@@ -320,8 +322,6 @@ export type AddSectionInput = {
   name: Scalars['String']['input'];
   /** Requirements that a user must consider in this section */
   requirements?: InputMaybe<Scalars['String']['input']>;
-  /** The Tags associated with this section. A section might not have any tags */
-  tags?: InputMaybe<Array<TagInput>>;
   /** The id of the template that the section belongs to */
   templateId: Scalars['Int']['input'];
 };
@@ -4241,6 +4241,8 @@ export type Question = {
   sectionId: Scalars['Int']['output'];
   /** The original question id if this question is a copy of another */
   sourceQestionId?: Maybe<Scalars['Int']['output']>;
+  /** The Tags associated with this question. A question might not have any tags */
+  tags?: Maybe<Array<Maybe<Tag>>>;
   /** The unique id of the Template that the question belongs to */
   templateId: Scalars['Int']['output'];
   /** Boolean indicating whether we should use content from sampleText as the default answer */
@@ -5408,6 +5410,8 @@ export type UpdateQuestionInput = {
   requirementText?: InputMaybe<Scalars['String']['input']>;
   /** Sample text to possibly provide a starting point or example to answer question */
   sampleText?: InputMaybe<Scalars['String']['input']>;
+  /** The Tags associated with this question. A question might not have any tags */
+  tags?: InputMaybe<Array<TagInput>>;
   /** Boolean indicating whether we should use content from sampleText as the default answer */
   useSampleTextAsDefault?: InputMaybe<Scalars['Boolean']['input']>;
 };
@@ -5462,8 +5466,6 @@ export type UpdateSectionInput = {
   requirements?: InputMaybe<Scalars['String']['input']>;
   /** The unique identifer for the Section */
   sectionId: Scalars['Int']['input'];
-  /** The Tags associated with this section. A section might not have any tags */
-  tags?: InputMaybe<Array<TagInput>>;
 };
 
 /** Input parameters for updating a Template Customization */
@@ -8178,6 +8180,7 @@ export type QuestionResolvers<ContextType = MyContext, ParentType extends Resolv
   sampleText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   sectionId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sourceQestionId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  tags?: Resolver<Maybe<Array<Maybe<ResolversTypes['Tag']>>>, ParentType, ContextType>;
   templateId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   useSampleTextAsDefault?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
 };


### PR DESCRIPTION
## Description

- Added `questionTags` and `versionedQuestionTags` tables
- Updated `Plan.findByPlanId` to prefer questionTags and fall back to sectionTags
- Updated `Question` model to have `tags`, since we moved the best practice tags to the Question page
- Updated `Tag` model with functions for adding and removing tags from questions and versioned questions
- Updated `addQuestion` and `updateQuestion` resolvers to add any tag data to `questionTags` table, and to include `tags` chained resolver
- Removed `tags` from `section` resolver
- Updated `addTemplate` mutation resolver so that make sure to copy over questionTags when cloning
- Updated `guidanceService.ts` to prefer `questionTags` and fall back to `sectionTags` if there are no `questionTags`. That way we can ease into transitioning to `questionTags`
- Updated `questionService`'s `generateQuestionVersion` to include `questionTags`, and also made sure to add current tags in `generateSectionVersion` before calling `generateQuestionVersion`

Fixes # ([274](https://github.com/CDLUC3/dmptool-doc/issues/274))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested with frontend changes: https://github.com/CDLUC3/dmptool-ui/tree/feature/274/JS-update-tags

## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules
Note: There are frontend changes that accompany this that you can use to test out the UI.

## Screenshots
## Question Add/Edit pages now include best practice tags
<img width="784" height="846" alt="image" src="https://github.com/user-attachments/assets/f0144aac-05aa-4e4c-a3d4-1be9a8a3e09a" />

## Section Add/Edit pages no longer include the best practice tags
<img width="783" height="807" alt="image" src="https://github.com/user-attachments/assets/2ab791f1-ac46-4d49-926b-62f36b4e0758" />


## Guidance on plans checks for `questionTags` first. If present it uses that over `sectionTags`. In the case below, since one of the questions has `Ethics & privacy` in the `questionTags`, it will display that over using any `sectionTags`
<img width="930" height="581" alt="image" src="https://github.com/user-attachments/assets/9267d5fc-e6d4-4980-9a52-2483cc80c50e" />


## If sectionTags exist, and there are no `questionTags` saved at the Question level, it will fall back to the `sectionTags`, as in this case where `sectionTags` for this section have `Storage & security` and `Data volume` checked
<img width="958" height="638" alt="image" src="https://github.com/user-attachments/assets/63969594-a39c-44bb-8780-184a6fc30bdf" />
