### PR TITLE
Re-throw GraphQLErrors so auth failures return UNAUTHENTICATED instead of INTERNAL_SERVER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,7 @@
 - Removed `ioredis` package
 
 ### Fixed
+- Re-throw `GraphQLError` from the `catch` blocks in the `user`, `affiliation` and `superAdmin` resolvers so that `UNAUTHENTICATED`, `FORBIDDEN` and `NOT_FOUND` reach the client instead of being masked as `INTERNAL_SERVER` [#283]
 - Added missing `fast-xml-parser` back so that `re3data-os-populate.ts` can run
 - Fixed `removeProjectFunding`. There were several issues, one of which was not being able to delete a `projectFundings` record without removing it's foreign key dependency in `planFundings` first [#303]
 - Updated `immutable` to `v5.1.9` to address HIGH security vulnerability [#304]

--- a/src/resolvers/__tests__/affiliation.spec.ts
+++ b/src/resolvers/__tests__/affiliation.spec.ts
@@ -818,6 +818,18 @@ describe('affiliation resolver', () => {
       `;
     });
 
+    it('should return an UNAUTHENTICATED error when there is no token', async () => {
+      const uri = casual.url;
+      const mockAffiliation = buildMockAffiliation({ uri });
+
+      (Affiliation.findByURI as jest.Mock).mockResolvedValue(mockAffiliation);
+
+      const result = await executeQuery(query, { uri }, null);
+
+      expect(result.body.singleResult.errors).toBeDefined();
+      expect(result.body.singleResult.errors[0].extensions.code).toBe('UNAUTHENTICATED');
+    });
+
     it('should return all guidance groups for a superAdmin', async () => {
       const uri = casual.url;
       const mockAffiliation = buildMockAffiliation({ uri });

--- a/src/resolvers/__tests__/superAdmin.spec.ts
+++ b/src/resolvers/__tests__/superAdmin.spec.ts
@@ -1,0 +1,92 @@
+import { ApolloServer } from "@apollo/server";
+import { typeDefs } from "../../schema";
+import { resolvers } from "../../resolver";
+import casual from "casual";
+import assert from "assert";
+import { buildContext, mockToken } from "../../__mocks__/context";
+import { logger } from "../../logger";
+import { JWTAccessToken } from "../../services/tokenService";
+import { UserRole } from "../../models/User";
+import { Plan } from "../../models/Plan";
+import { saveMaDMPVersion } from "../../services/planService";
+
+jest.mock('../../context.ts');
+jest.mock('../../datasources/cache');
+jest.mock('../../services/planService');
+jest.mock('../../services/openSearchService');
+
+let testServer: ApolloServer;
+let planId: number;
+let researcherToken: JWTAccessToken;
+let superAdminToken: JWTAccessToken;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function executeQuery(query: string, variables: any, token: JWTAccessToken): Promise<any> {
+  const context = buildContext(logger, token, null);
+  return await testServer.executeOperation({ query, variables }, { contextValue: context });
+}
+
+const query = `
+  mutation SuperSyncPlanMaDMP($planId: Int!) {
+    superSyncPlanMaDMP(planId: $planId)
+  }
+`;
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+
+  testServer = new ApolloServer({ typeDefs, resolvers });
+
+  planId = casual.integer(1, 9999);
+
+  researcherToken = await mockToken();
+  researcherToken.role = UserRole.RESEARCHER;
+
+  superAdminToken = await mockToken();
+  superAdminToken.role = UserRole.SUPERADMIN;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('superSyncPlanMaDMP mutation', () => {
+  it('returns a 403 when the user is not a super admin', async () => {
+    const resp = await executeQuery(query, { planId }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('returns a 404 when the plan is not found', async () => {
+    jest.spyOn(Plan, 'findById').mockResolvedValue(null);
+
+    const resp = await executeQuery(query, { planId }, superAdminToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
+  });
+
+  it('returns true when the plan was synchronized', async () => {
+    jest.spyOn(Plan, 'findById').mockResolvedValue({ id: planId, dmpId: casual.uuid } as Plan);
+    (saveMaDMPVersion as jest.Mock).mockResolvedValue(true);
+
+    const resp = await executeQuery(query, { planId }, superAdminToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeUndefined();
+    expect(resp.body.singleResult.data.superSyncPlanMaDMP).toBe(true);
+  });
+
+  it('returns a 500 on a fatal error', async () => {
+    jest.spyOn(Plan, 'findById').mockRejectedValue(new Error('DB error'));
+
+    const resp = await executeQuery(query, { planId }, superAdminToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('INTERNAL_SERVER');
+  });
+});

--- a/src/resolvers/__tests__/user.spec.ts
+++ b/src/resolvers/__tests__/user.spec.ts
@@ -1,0 +1,423 @@
+import { ApolloServer } from "@apollo/server";
+import { typeDefs } from "../../schema";
+import { resolvers } from "../../resolver";
+import casual from "casual";
+import assert from "assert";
+import { buildContext, mockToken } from "../../__mocks__/context";
+import { logger } from "../../logger";
+import { JWTAccessToken } from "../../services/tokenService";
+import { User, UserRole } from "../../models/User";
+import { UserEmail } from "../../models/UserEmail";
+
+jest.mock('../../context.ts');
+jest.mock('../../datasources/cache');
+jest.mock('../../services/emailService');
+jest.mock('../../services/openSearchService');
+
+let testServer: ApolloServer;
+let affiliationId: string;
+let userId: number;
+let researcherToken: JWTAccessToken;
+let adminToken: JWTAccessToken;
+let activeUser: User;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function executeQuery(query: string, variables: any, token: JWTAccessToken): Promise<any> {
+  const context = buildContext(logger, token, null);
+  return await testServer.executeOperation({ query, variables }, { contextValue: context });
+}
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+
+  testServer = new ApolloServer({ typeDefs, resolvers });
+
+  affiliationId = casual.url;
+  userId = casual.integer(1, 9999);
+
+  researcherToken = await mockToken();
+  researcherToken.role = UserRole.RESEARCHER;
+  researcherToken.affiliationId = affiliationId;
+
+  adminToken = await mockToken();
+  adminToken.role = UserRole.ADMIN;
+  adminToken.affiliationId = affiliationId;
+
+  activeUser = new User({
+    id: userId,
+    givenName: casual.first_name,
+    surName: casual.last_name,
+    affiliationId,
+    role: UserRole.RESEARCHER,
+  });
+  activeUser.active = true;
+  activeUser.locked = false;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// updateUserProfile mutation
+// ---------------------------------------------------------------------------
+describe('updateUserProfile mutation', () => {
+  let query: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let input: any;
+
+  beforeEach(() => {
+    query = `
+      mutation UpdateUserProfile($input: UpdateUserProfileInput!) {
+        updateUserProfile(input: $input) {
+          id
+          givenName
+        }
+      }
+    `;
+    input = { givenName: casual.first_name, surName: casual.last_name, affiliationId };
+  });
+
+  it('returns a 401 when the user is not authenticated', async () => {
+    const resp = await executeQuery(query, { input }, null);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+
+  it('returns a 403 when the user account is locked', async () => {
+    const lockedUser = new User({ id: userId, affiliationId, role: UserRole.RESEARCHER });
+    lockedUser.active = true;
+    lockedUser.locked = true;
+    jest.spyOn(User, 'findById').mockResolvedValue(lockedUser);
+
+    const resp = await executeQuery(query, { input }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('returns a 500 on a fatal error', async () => {
+    jest.spyOn(User, 'findById').mockRejectedValue(new Error('DB error'));
+
+    const resp = await executeQuery(query, { input }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('INTERNAL_SERVER');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateUserNotifications mutation
+// ---------------------------------------------------------------------------
+describe('updateUserNotifications mutation', () => {
+  let query: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let input: any;
+
+  beforeEach(() => {
+    query = `
+      mutation UpdateUserNotifications($input: UpdateUserNotificationsInput!) {
+        updateUserNotifications(input: $input) {
+          id
+        }
+      }
+    `;
+    input = {
+      notify_on_comment_added: true,
+      notify_on_template_shared: true,
+      notify_on_feedback_complete: true,
+      notify_on_plan_shared: true,
+      notify_on_plan_visibility_change: true,
+    };
+  });
+
+  it('returns a 401 when the user is not authenticated', async () => {
+    const resp = await executeQuery(query, { input }, null);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+
+  it('returns a 403 when the user account is inactive', async () => {
+    const inactiveUser = new User({ id: userId, affiliationId, role: UserRole.RESEARCHER });
+    inactiveUser.active = false;
+    jest.spyOn(User, 'findById').mockResolvedValue(inactiveUser);
+
+    const resp = await executeQuery(query, { input }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setUserOrcid mutation
+// ---------------------------------------------------------------------------
+describe('setUserOrcid mutation', () => {
+  const query = `
+    mutation SetUserOrcid($orcid: String!) {
+      setUserOrcid(orcid: $orcid) {
+        id
+      }
+    }
+  `;
+
+  it('returns a 401 when the user is not authenticated', async () => {
+    const resp = await executeQuery(query, { orcid: '0000-0000-0000-0000' }, null);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addUserEmail mutation
+// ---------------------------------------------------------------------------
+describe('addUserEmail mutation', () => {
+  const query = `
+    mutation AddUserEmail($email: String!, $isPrimary: Boolean!) {
+      addUserEmail(email: $email, isPrimary: $isPrimary) {
+        id
+      }
+    }
+  `;
+
+  it('returns a 401 when the user is not authenticated', async () => {
+    const resp = await executeQuery(query, { email: casual.email, isPrimary: false }, null);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeUserEmail mutation
+// ---------------------------------------------------------------------------
+describe('removeUserEmail mutation', () => {
+  const query = `
+    mutation RemoveUserEmail($email: String!) {
+      removeUserEmail(email: $email) {
+        id
+      }
+    }
+  `;
+
+  it('returns a 401 when the user is not authenticated', async () => {
+    const resp = await executeQuery(query, { email: casual.email }, null);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+
+  it('returns a 404 when the email does not belong to the user', async () => {
+    jest.spyOn(User, 'findById').mockResolvedValue(activeUser);
+    jest.spyOn(UserEmail, 'findByUserIdAndEmail').mockResolvedValue(null);
+
+    const resp = await executeQuery(query, { email: casual.email }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setPrimaryUserEmail mutation
+// ---------------------------------------------------------------------------
+describe('setPrimaryUserEmail mutation', () => {
+  const query = `
+    mutation SetPrimaryUserEmail($email: String!) {
+      setPrimaryUserEmail(email: $email) {
+        id
+      }
+    }
+  `;
+
+  it('returns a 401 when the user is not authenticated', async () => {
+    const resp = await executeQuery(query, { email: casual.email }, null);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+
+  it('returns a 404 when the email does not belong to the user', async () => {
+    jest.spyOn(User, 'findById').mockResolvedValue(activeUser);
+    jest.spyOn(UserEmail, 'findByUserId').mockResolvedValue([]);
+
+    const resp = await executeQuery(query, { email: casual.email }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updatePassword mutation
+// ---------------------------------------------------------------------------
+describe('updatePassword mutation', () => {
+  const query = `
+    mutation UpdatePassword($oldPassword: String!, $newPassword: String!, $email: String!) {
+      updatePassword(oldPassword: $oldPassword, newPassword: $newPassword, email: $email) {
+        id
+      }
+    }
+  `;
+
+  it('returns a 401 when the user is not authenticated', async () => {
+    const variables = { oldPassword: casual.password, newPassword: casual.password, email: casual.email };
+    const resp = await executeQuery(query, variables, null);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deactivateUser mutation
+// ---------------------------------------------------------------------------
+describe('deactivateUser mutation', () => {
+  const query = `
+    mutation DeactivateUser($userId: Int!) {
+      deactivateUser(userId: $userId) {
+        id
+      }
+    }
+  `;
+
+  it('returns a 401 when the user is not authenticated', async () => {
+    const resp = await executeQuery(query, { userId }, null);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+
+  it('returns a 403 when the user is not an admin', async () => {
+    const resp = await executeQuery(query, { userId }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('returns a 404 when the user is not found', async () => {
+    jest.spyOn(User, 'findById').mockResolvedValue(null);
+
+    const resp = await executeQuery(query, { userId }, adminToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
+  });
+
+  it('returns a 403 when the admin belongs to a different affiliation', async () => {
+    const otherUser = new User({ id: userId, affiliationId: casual.url, role: UserRole.RESEARCHER });
+    jest.spyOn(User, 'findById').mockResolvedValue(otherUser);
+
+    const resp = await executeQuery(query, { userId }, adminToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('returns a 500 on a fatal error', async () => {
+    jest.spyOn(User, 'findById').mockRejectedValue(new Error('DB error'));
+
+    const resp = await executeQuery(query, { userId }, adminToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('INTERNAL_SERVER');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// activateUser mutation
+// ---------------------------------------------------------------------------
+describe('activateUser mutation', () => {
+  const query = `
+    mutation ActivateUser($userId: Int!) {
+      activateUser(userId: $userId) {
+        id
+      }
+    }
+  `;
+
+  it('returns a 401 when the user is not authenticated', async () => {
+    const resp = await executeQuery(query, { userId }, null);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+
+  it('returns a 403 when the user is not an admin', async () => {
+    const resp = await executeQuery(query, { userId }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('returns a 404 when the user is not found', async () => {
+    jest.spyOn(User, 'findById').mockResolvedValue(null);
+
+    const resp = await executeQuery(query, { userId }, adminToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeUsers mutation
+// ---------------------------------------------------------------------------
+describe('mergeUsers mutation', () => {
+  const query = `
+    mutation MergeUsers($userIdToBeMerged: Int!, $userIdToKeep: Int!) {
+      mergeUsers(userIdToBeMerged: $userIdToBeMerged, userIdToKeep: $userIdToKeep) {
+        id
+      }
+    }
+  `;
+
+  it('returns a 401 when the user is not authenticated', async () => {
+    const resp = await executeQuery(query, { userIdToBeMerged: userId, userIdToKeep: userId + 1 }, null);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('UNAUTHENTICATED');
+  });
+
+  it('returns a 403 when the user is not an admin', async () => {
+    const resp = await executeQuery(query, { userIdToBeMerged: userId, userIdToKeep: userId + 1 }, researcherToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('FORBIDDEN');
+  });
+
+  it('returns a 404 when one of the users is not found', async () => {
+    jest.spyOn(User, 'findById').mockResolvedValue(null);
+
+    const resp = await executeQuery(query, { userIdToBeMerged: userId, userIdToKeep: userId + 1 }, adminToken);
+
+    assert(resp.body.kind === 'single');
+    expect(resp.body.singleResult.errors).toBeDefined();
+    expect(resp.body.singleResult.errors[0].extensions.code).toEqual('NOT_FOUND');
+  });
+});

--- a/src/resolvers/affiliation.ts
+++ b/src/resolvers/affiliation.ts
@@ -469,6 +469,8 @@ export const resolvers: Resolvers = {
 
         return publishedOnly;
       } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
         throw InternalServerError();
       }

--- a/src/resolvers/superAdmin.ts
+++ b/src/resolvers/superAdmin.ts
@@ -1,3 +1,4 @@
+import { GraphQLError } from "graphql";
 import { Resolvers } from "../types";
 import { MyContext } from "../context";
 import { ForbiddenError, NotFoundError, InternalServerError } from "../utils/graphQLErrors";
@@ -27,6 +28,8 @@ export const resolvers: Resolvers = {
 
         return false;
       } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+
         context.logger.error(prepareObjectForLogs(err), `${reference} error initializing maDMP record`);
         throw InternalServerError();
       }

--- a/src/resolvers/user.ts
+++ b/src/resolvers/user.ts
@@ -135,6 +135,8 @@ export const resolvers: Resolvers = {
         // Unauthenticated
         throw AuthenticationError();
       } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
         throw InternalServerError();
       }
@@ -296,6 +298,8 @@ export const resolvers: Resolvers = {
         // Unauthenticated
         throw AuthenticationError();
       } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
         throw InternalServerError();
       }
@@ -322,6 +326,8 @@ export const resolvers: Resolvers = {
         // Unauthenticated
         throw AuthenticationError();
       } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
         throw InternalServerError();
       }
@@ -347,6 +353,8 @@ export const resolvers: Resolvers = {
         // Unauthenticated
         throw AuthenticationError();
       } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
         throw InternalServerError();
       }
@@ -377,6 +385,8 @@ export const resolvers: Resolvers = {
         // Unauthenticated
         throw AuthenticationError();
       } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+
         context.logger.error(prepareObjectForLogs(err), `Failure in ${ref}`);
         throw InternalServerError();
       }
@@ -430,6 +440,8 @@ export const resolvers: Resolvers = {
         // Unauthenticated
         throw AuthenticationError();
       } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+
         context.logger.error(prepareObjectForLogs(err), `Failure in ${ref}`);
         throw InternalServerError();
       }
@@ -455,6 +467,8 @@ export const resolvers: Resolvers = {
         // Unauthenticated
         throw AuthenticationError();
       } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
         throw InternalServerError();
       }
@@ -488,6 +502,8 @@ export const resolvers: Resolvers = {
         // Unauthorized!
         throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
         throw InternalServerError();
       }
@@ -520,6 +536,8 @@ export const resolvers: Resolvers = {
         // Unauthorized!
         throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
         throw InternalServerError();
       }
@@ -578,6 +596,8 @@ export const resolvers: Resolvers = {
         // Unauthorized!
         throw context?.token ? ForbiddenError() : AuthenticationError();
       } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
         throw InternalServerError();
       }


### PR DESCRIPTION
This PR proposes re-throwing `GraphQLError`s from the `catch` blocks in the `user`, `affiliation` and `superAdmin` resolvers, so that authentication and authorization failures reach the client as `UNAUTHENTICATED` / `FORBIDDEN` / `NOT_FOUND` instead of being masked as `INTERNAL_SERVER` (Fixes #283). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/197. You can sign in with your GitHub ID to claim ownership of the project.

## What is wrong

Twelve resolvers throw an `AuthenticationError`, `ForbiddenError` or `NotFoundError` and then catch it a few lines later. Their `catch` blocks log whatever arrives and unconditionally throw `InternalServerError()`, so a `GraphQLError` the resolver raised deliberately is swallowed and the client receives `INTERNAL_SERVER`. As #283 describes, an expired or missing token on the account profile page therefore never tells the frontend to refresh the auth token.

The affected resolvers are `updateUserProfile`, `updateUserNotifications`, `setUserOrcid`, `addUserEmail`, `removeUserEmail`, `setPrimaryUserEmail`, `updatePassword`, `deactivateUser`, `activateUser` and `mergeUsers` in `src/resolvers/user.ts`, the `Affiliation.guidanceGroups` field resolver in `src/resolvers/affiliation.ts`, and `superSyncPlanMaDMP` in `src/resolvers/superAdmin.ts`.

## The change

Each of those `catch` blocks now starts with the guard the rest of the codebase already uses — `archiveUser` in the same file has it, and so does `authenticatedResolver` in `src/services/authService.ts`:

```ts
} catch (err) {
  if (err instanceof GraphQLError) throw err;

  context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
  throw InternalServerError();
}
```

That is the whole source change: 24 added lines across three resolver files, plus the `GraphQLError` import that `src/resolvers/superAdmin.ts` was missing. Unexpected errors still log and still return `INTERNAL_SERVER`, so nothing that was a 500 stops being one. No signature, schema or public behavior changes, and any client already handling `INTERNAL_SERVER` keeps working — it simply starts receiving the more specific code the resolver intended.

We looked for the same defect everywhere else in `src/resolvers/`: of the 208 `try`/`catch` pairs there, these 12 were the only ones where a `GraphQLError` raised inside the matching `try` could be swallowed. The 20 unguarded blocks that remain have no such throw in their `try`, so we left them alone rather than widen the diff.

## How it was verified

Reproduced on `main` at `2450df1` with the new spec, which drives the real schema and resolvers through `ApolloServer` exactly like the existing resolver specs:

```
$ npx jest src/resolvers/__tests__/user.spec.ts --coverage=false
● setPrimaryUserEmail mutation › returns a 401 when the user is not authenticated
    Expected: "UNAUTHENTICATED"
    Received: "INTERNAL_SERVER"
Tests:       21 failed, 2 passed, 23 total
```

The two that pass unfixed are the deliberate controls: a resolver that hits a rejected `User.findById` must still answer `INTERNAL_SERVER`.

With the fix applied, the three specs covering the changed files pass in full (61 tests), and reverting only the resolver changes while keeping the tests turns 23 of them red — so the new coverage genuinely tracks this defect:

```
$ npx jest src/resolvers/__tests__/user.spec.ts src/resolvers/__tests__/superAdmin.spec.ts src/resolvers/__tests__/affiliation.spec.ts --coverage=false
Tests:       61 passed, 61 total
```

Full suite, before and after, run the same way on the same machine (`npm run test-no-db`, which skips the container-backed `relatedWorksTables` spec):

```
before:  Test Suites: 1 skipped, 98 passed   Tests: 38 skipped, 2395 passed, 2433 total
after:   Test Suites: 1 skipped, 100 passed  Tests: 38 skipped, 2423 passed, 2461 total
```

No new failures; the 28 added tests are the whole difference. `npm run lint` and `npx tsc --noEmit` are both clean. `CHANGELOG.md` has an entry under `### Fixed`.

## How this was managed

We tracked this work on a board imported from this repository's own issues and pull requests — 754 stories in all — and did it against the story for issue #283: https://eastagiletracker.com/projects/197/stories/57371. The board itself is at https://eastagiletracker.com/projects/197.

![board](https://raw.githubusercontent.com/eastagiletracker/dmptool-apollo-server/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
