### PR TITLE
Updated projectFunding to return readOnly data for project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated `projectFunding` query to return `readOnly` [#246]
 - Updated `versionedQuestion` resolver to use `findByVersionedQuestionConditionGroupId` in place of `findByVersionedQuestionId` [#508]
 - Updated `publishedConditionGroupsForQuestion` in `versionedQuestionCondition` resolver and added `conditions` chained resolver [#508]
 - Updated `question`, `questionCondition` and `versionedQuestionCondition` schemas [#508]

--- a/src/resolvers/funding.ts
+++ b/src/resolvers/funding.ts
@@ -6,7 +6,7 @@ import { PlanFunding, ProjectFunding } from "../models/Funding";
 import { MyContext } from '../context';
 import { isAuthorized } from '../services/authService';
 import { AuthenticationError, ForbiddenError, InternalServerError, NotFoundError } from '../utils/graphQLErrors';
-import { hasPermissionOnProject } from '../services/projectService';
+import { hasPermissionOnProject, isProjectReadOnlyForCurrentUser } from '../services/projectService';
 import { GraphQLError } from 'graphql';
 import { Plan } from '../models/Plan';
 import { ProjectCollaboratorAccessLevel } from "../models/Collaborator";
@@ -389,7 +389,12 @@ export const resolvers: Resolvers = {
   ProjectFunding: {
     project: async (parent: ProjectFunding, _, context: MyContext): Promise<Project> => {
       if (parent?.projectId) {
-        return await Project.findById('Chained ProjectFunding.project', context, parent.projectId);
+        const project = await Project.findById('Chained ProjectFunding.project', context, parent.projectId);
+        if (project) {
+          const readOnly = await isProjectReadOnlyForCurrentUser('Chained ProjectFunding.project', context, project);
+          return Object.assign(project, { readOnly }) as Project & { readOnly: boolean };
+        }
+        return null;
       }
       return null;
     },


### PR DESCRIPTION
## Description

- Updated `projectFunding` query to return `readOnly`

Fixes # ([246](https://github.com/CDLUC3/dmptool-doc/issues/246))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manuall tested in Apollo Explorer


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules