### PR TITLE
Bug/339/js fix bugs for landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,12 @@
 - added data-migration to fix question JSON so that `"selected": 0` is now `"selected": false` (and `1` -> `true`).
 
 ### Updated
+- Updated updateAnswer resolver to update `plan.modified` to reflect that something had changed (for versioning) [#339]
+- Added `isPrimaryContact` to UpdateProjectMemberInput because the `isPrimaryContact` field value was being overwritten to false when the input didn’t include it [#339]
+- Added `owner` and `relatedWorks` to `PlanVersionSnapshot` schema [#339]
+- Updated getPlanVersions in `planService` to exclude the `VERSION#latest` used for the dropdown list.[#339]
+- Updated `getPlanVersionSnapshot to fetch the planId and projectId to pass to `mapDMPToolDMPToSnapshot`[#339]
+- Updated `maDMPToolDMPToSnapshot` to get `isPrimaryContact` from correct place, and added `owner` and `relatedWorks` to the response[#339]
 - Updated resolvers to use the new `handleAsyncUpdates` function instead of calling `saveMaDMPRecord` directly
 - Updated docker-compose.yaml to install OpenSearch for use with our search indices
 - Updated docker-compose.yaml to include a health check so we can wait to start Apollo server after LocalStack is ready

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN pip install --no-cache-dir awscli-local
 COPY package*.json tsconfig.json codegen.ts .env dmptool-*.tgz ./
 
 # Install dependencies in /app
-RUN npm ci
+RUN npm install
 
 # Copy the rest of our Apollo Server folder into /app
 COPY . .

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@aws-sdk/signature-v4": "^3.374.0",
         "@aws-sdk/util-dynamodb": "^3.996.5",
         "@dmptool/types": "^4.0.0",
-        "@dmptool/utils": "^2.1.7",
+        "@dmptool/utils": "^2.1.6",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@graphql-tools/merge": "^9.1.10",
         "@graphql-tools/mock": "^9.1.8",
@@ -4834,9 +4834,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4851,9 +4848,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4868,9 +4862,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4885,9 +4876,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4902,9 +4890,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4919,9 +4904,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4936,9 +4918,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4953,9 +4932,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4970,9 +4946,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4987,9 +4960,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/models/Collaborator.ts
+++ b/src/models/Collaborator.ts
@@ -600,4 +600,23 @@ export class ProjectCollaborator extends Collaborator {
     if (!Array.isArray(results) || results.length === 0) return null;
     return Object.assign(new ProjectCollaborator(results[0]), { affiliationId: results[0].affiliationId ?? null }) as ProjectCollaboratorWithUser;
   }
+
+  // Get owner user for project
+  static async findOwnerByProjectId(
+    reference: string,
+    context: MyContext,
+    projectId: number,
+  ): Promise<ProjectCollaboratorWithUser | null> {
+    const sql = `SELECT  pc.id AS collaboratorId, pc.projectId, pc.email, pc.accessLevel, pc.created AS collaboratorCreated,
+    u.id AS userId, u.affiliationId, u.active
+    FROM projectCollaborators pc
+    INNER JOIN users u ON pc.userId = u.id
+    WHERE pc.projectId = ?
+    AND pc.accessLevel = "OWN"
+    `;
+    const vals = [projectId?.toString()];
+    const results = await ProjectCollaborator.query(context, sql, vals, reference);
+    if (!Array.isArray(results) || results.length === 0) return null;
+    return Object.assign(new ProjectCollaborator(results[0]), { affiliationId: results[0].affiliationId ?? null }) as ProjectCollaboratorWithUser;
+  }
 }

--- a/src/models/__tests__/Collaborator.spec.ts
+++ b/src/models/__tests__/Collaborator.spec.ts
@@ -976,6 +976,93 @@ describe('ProjectCollaborator', () => {
     });
   });
 
+  describe('findOwnerByProjectId', () => {
+    const originalQuery = ProjectCollaborator.query;
+
+    let localQuery;
+    let projectId;
+
+    beforeEach(async () => {
+      jest.resetAllMocks();
+      projectId = casual.integer(1, 999);
+
+      localQuery = jest.fn();
+      (ProjectCollaborator.query as jest.Mock) = localQuery;
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      ProjectCollaborator.query = originalQuery;
+    });
+
+    it('returns null when no results are found', async () => {
+      localQuery.mockResolvedValueOnce([]);
+
+      const result = await ProjectCollaborator.findOwnerByProjectId(
+        'Test', context, projectId
+      );
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when query returns a non-array', async () => {
+      localQuery.mockResolvedValueOnce(null);
+
+      const result = await ProjectCollaborator.findOwnerByProjectId(
+        'Test', context, projectId
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns a ProjectCollaboratorWithUser with affiliationId from the result row', async () => {
+      const affiliationId = casual.uuid;
+      const row = {
+        collaboratorId: casual.integer(1, 99),
+        projectId,
+        email: casual.email,
+        accessLevel: 'OWN', // Testing for OWN access level
+        collaboratorCreated: new Date().toISOString(),
+        userId: casual.integer(1, 99),
+        affiliationId,
+        active: 1,
+      };
+      localQuery.mockResolvedValueOnce([row]);
+
+      const result = await ProjectCollaborator.findOwnerByProjectId(
+        'Test', context, projectId
+      );
+      expect(localQuery).toHaveBeenCalledTimes(1);
+      expect(localQuery).toHaveBeenCalledWith(
+        context,
+        expect.stringContaining('pc.accessLevel = "OWN"'),
+        [projectId.toString()],
+        'Test'
+      );
+      expect(result).toBeInstanceOf(ProjectCollaborator);
+      expect(result.affiliationId).toEqual(affiliationId);
+    });
+
+    it('sets affiliationId to null when the row has no affiliationId', async () => {
+      const row = {
+        collaboratorId: casual.integer(1, 99),
+        projectId,
+        email: casual.email,
+        accessLevel: 'PRIMARY',
+        collaboratorCreated: new Date().toISOString(),
+        userId: casual.integer(1, 99),
+        affiliationId: null,
+        active: 1,
+      };
+      localQuery.mockResolvedValueOnce([row]);
+
+      const result = await ProjectCollaborator.findOwnerByProjectId(
+        'Test', context, projectId
+      );
+      expect(result).toBeInstanceOf(ProjectCollaborator);
+      expect(result.affiliationId).toBeNull();
+    });
+  });
+
   describe('findPotentialCollaboratorByORCID', () => {
     const originalFindByOrcid = User.findByOrcid;
     const originalProjectMemberFindByOrcid = ProjectCollaborator.findPotentialCollaboratorByORCID;

--- a/src/resolvers/answer.ts
+++ b/src/resolvers/answer.ts
@@ -156,6 +156,10 @@ export const resolvers: Resolvers = {
             const updatedAnswer = await answer.update(context);
 
             if (updatedAnswer && !updatedAnswer.hasErrors()) {
+              // Update the plan's modified timestamp to reflect that something changed
+              plan.modified = new Date().toISOString();
+              await plan.update(context);
+
               // Handle OpenSearch index update and maDMP JSON versioning in Dynamo
               await handleAsyncUpdates(reference, context, plan, project);
             }

--- a/src/resolvers/plan.ts
+++ b/src/resolvers/plan.ts
@@ -18,6 +18,10 @@ import { VersionedTemplate } from "../models/VersionedTemplate";
 import { Answer } from "../models/Answer";
 import { ProjectCollaboratorAccessLevel } from "../models/Collaborator";
 import { AlternateIdentifier } from "../models/AlternateIdentifier";
+import {
+  RelatedWorkSearchResult,
+  RelatedWorkStatus
+} from "../models/RelatedWork";
 import { isNullOrUndefined, normaliseDateTime } from "../utils/helpers";
 import {
   AuthenticationError,
@@ -37,7 +41,9 @@ import {
   PaginatedPlanResults,
   PlanFeedbackStatus,
   Resolvers,
-  UpdateEntirePlanInput
+  UpdateEntirePlanInput,
+  RelatedWorksFilterOptions,
+  PlanVersionSnapshot
 } from "../types";
 import { prepareObjectForLogs } from "../logger";
 // Services
@@ -45,6 +51,7 @@ import {
   buildDataCiteXMLForPlan,
   ensureDefaultPlanContact,
   getPlanVersions,
+  getPlanVersionSnapshot,
   saveMaDMPVersion
 } from "../services/planService";
 import {
@@ -195,6 +202,23 @@ export const resolvers: Resolvers = {
         }
 
         return plan;
+      } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+        context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
+        throw InternalServerError();
+      }
+    },
+    // in Query resolvers, alongside publicPlanByDMPId
+    publicPlanVersionByDMPId: async (_, { dmpId, version }, context: MyContext): Promise<PlanVersionSnapshot> => {
+      const reference = 'publicPlanVersionByDMPId resolver';
+      try {
+        const snapshot = await getPlanVersionSnapshot(reference, context, dmpId, version);
+
+        if (!snapshot) {
+          throw NotFoundError(`Version ${version} of DMP ${dmpId} not found`);
+        }
+
+        return snapshot;
       } catch (err) {
         if (err instanceof GraphQLError) throw err;
         context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
@@ -763,6 +787,31 @@ export const resolvers: Resolvers = {
       }
       return null;
     },
+    owner: async (parent: Plan, _, context: MyContext): Promise<Affiliation> => {
+      if (!parent?.id) return null;
+      const reference = 'Chained Plan.owner';
+
+      // Get Affiliation info for the plan's primary contact, if one exists
+      const primaryContactMember = await PlanMember.findPrimaryContact(reference, context, parent.id);
+      if (primaryContactMember?.projectMemberId) {
+        const projectMember = await ProjectMember.findById(reference, context, primaryContactMember.projectMemberId);
+        if (projectMember?.affiliationId) {
+          const affiliation = await Affiliation.findByURI(reference, context, projectMember.affiliationId);
+          if (affiliation) return affiliation;
+        }
+      }
+
+      // Fall back to the plan creator's affiliation
+      if (parent?.createdById) {
+        const user = await User.findById(reference, context, parent.createdById);
+        if (user?.affiliationId) {
+          return await Affiliation.findByURI(reference, context, user.affiliationId);
+        }
+      }
+
+      return null;
+    },
+
     // The project the plan is associated with
     project: async (parent: Plan, _, context: MyContext): Promise<Project> => {
       if (parent?.projectId) {
@@ -835,6 +884,41 @@ export const resolvers: Resolvers = {
     versions: async (parent: Plan, _, context: MyContext) => {
       if (!parent?.dmpId) return [];
       return await getPlanVersions('Chained Plan.versions', context, parent.dmpId);
+    },
+    // Other works related to this plan's project
+    relatedWorks: async (
+      parent: Plan,
+      _: Record<string, never>,
+      context: MyContext,
+    ): Promise<RelatedWorkSearchResult[]> => {
+      if (!parent?.id || !parent?.projectId) {
+        return [];
+      }
+
+      const isPubliclyVisible = parent.visibility === 'PUBLIC' && !!parent.registered;
+
+      let effectiveFilters: RelatedWorksFilterOptions = {};
+
+      if (isPubliclyVisible) {
+        // Public visitors only ever see curated/accepted related works.
+        effectiveFilters = { status: 'ACCEPTED' as RelatedWorkStatus };
+      } else {
+        if (!isAuthorized(context.token)) return [];
+
+        const project = await Project.findById('plan.relatedWorks resolver', context, parent.projectId);
+        if (!project || !(await hasPermissionOnProject(context, project))) return [];
+      }
+
+      const result = await RelatedWorkSearchResult.search(
+        'plan.relatedWorks resolver',
+        context,
+        parent.projectId,
+        parent.id,
+        undefined,
+        effectiveFilters,
+      );
+
+      return result.items;
     },
     created: (parent: Plan) => {
       return normaliseDateTime(parent.created);

--- a/src/resolvers/plan.ts
+++ b/src/resolvers/plan.ts
@@ -16,12 +16,8 @@ import { PlanFeedback } from "../models/PlanFeedback";
 import { Affiliation } from "../models/Affiliation";
 import { VersionedTemplate } from "../models/VersionedTemplate";
 import { Answer } from "../models/Answer";
-import { ProjectCollaboratorAccessLevel } from "../models/Collaborator";
+import { ProjectCollaborator, ProjectCollaboratorAccessLevel } from "../models/Collaborator";
 import { AlternateIdentifier } from "../models/AlternateIdentifier";
-import {
-  RelatedWorkSearchResult,
-  RelatedWorkStatus
-} from "../models/RelatedWork";
 import { isNullOrUndefined, normaliseDateTime } from "../utils/helpers";
 import {
   AuthenticationError,
@@ -42,7 +38,6 @@ import {
   PlanFeedbackStatus,
   Resolvers,
   UpdateEntirePlanInput,
-  RelatedWorksFilterOptions,
   PlanVersionSnapshot
 } from "../types";
 import { prepareObjectForLogs } from "../logger";
@@ -789,12 +784,17 @@ export const resolvers: Resolvers = {
       if (!parent?.id) return null;
       const reference = 'Chained Plan.owner';
 
-      // Get Affiliation info for the plan's primary contact, if one exists
-      const primaryContactMember = await PlanMember.findPrimaryContact(reference, context, parent.id);
-      if (primaryContactMember?.projectMemberId) {
-        const projectMember = await ProjectMember.findById(reference, context, primaryContactMember.projectMemberId);
-        if (projectMember?.affiliationId) {
-          const affiliation = await Affiliation.findByURI(reference, context, projectMember.affiliationId);
+      // First, try to get the project owner (collaborator with OWN access level)
+      const projectOwner = await ProjectCollaborator.findOwnerByProjectId(
+        reference,
+        context,
+        parent.projectId
+      );
+
+      if (projectOwner?.userId) {
+        const user = await User.findById(reference, context, projectOwner.userId);
+        if (user?.affiliationId) {
+          const affiliation = await Affiliation.findByURI(reference, context, user.affiliationId);
           if (affiliation) return affiliation;
         }
       }
@@ -882,41 +882,6 @@ export const resolvers: Resolvers = {
     versions: async (parent: Plan, _, context: MyContext) => {
       if (!parent?.dmpId) return [];
       return await getPlanVersions('Chained Plan.versions', context, parent.dmpId);
-    },
-    // Other works related to this plan's project
-    relatedWorks: async (
-      parent: Plan,
-      _: Record<string, never>,
-      context: MyContext,
-    ): Promise<RelatedWorkSearchResult[]> => {
-      if (!parent?.id || !parent?.projectId) {
-        return [];
-      }
-
-      const isPubliclyVisible = parent.visibility === 'PUBLIC' && !!parent.registered;
-
-      let effectiveFilters: RelatedWorksFilterOptions = {};
-
-      if (isPubliclyVisible) {
-        // Public visitors only ever see curated/accepted related works.
-        effectiveFilters = { status: 'ACCEPTED' as RelatedWorkStatus };
-      } else {
-        if (!isAuthorized(context.token)) return [];
-
-        const project = await Project.findById('plan.relatedWorks resolver', context, parent.projectId);
-        if (!project || !(await hasPermissionOnProject(context, project))) return [];
-      }
-
-      const result = await RelatedWorkSearchResult.search(
-        'plan.relatedWorks resolver',
-        context,
-        parent.projectId,
-        parent.id,
-        undefined,
-        effectiveFilters,
-      );
-
-      return result.items;
     },
     created: (parent: Plan) => {
       return normaliseDateTime(parent.created);

--- a/src/resolvers/plan.ts
+++ b/src/resolvers/plan.ts
@@ -191,25 +191,7 @@ export const resolvers: Resolvers = {
       }
     },
 
-    // Find a published plan by its DMP id (publicly accessible so not checking permissions)
-    publicPlanByDMPId: async (_, { dmpId }, context: MyContext): Promise<Plan> => {
-      const reference = 'publicPlanByDMPId resolver';
-      try {
-        const plan = await Plan.findByDMPId(reference, context, dmpId);
-
-        // Treat "not found" and "not registered" identically - don't leak existence of private plans
-        if (isNullOrUndefined(plan) || plan.registered === null) {
-          throw NotFoundError(`Plan with DMP id, ${dmpId}, not found`);
-        }
-
-        return plan;
-      } catch (err) {
-        if (err instanceof GraphQLError) throw err;
-        context.logger.error(prepareObjectForLogs(err), `Failure in ${reference}`);
-        throw InternalServerError();
-      }
-    },
-    // in Query resolvers, alongside publicPlanByDMPId
+    // Find a published plan by its DMP id and version (publicly accessible so not checking permissions)
     publicPlanVersionByDMPId: async (_, { dmpId, version }, context: MyContext): Promise<PlanVersionSnapshot> => {
       const reference = 'publicPlanVersionByDMPId resolver';
       try {

--- a/src/schemas/member.ts
+++ b/src/schemas/member.ts
@@ -148,6 +148,8 @@ export const typeDefs = gql`
     orcid: String
     "The Member's email address"
     email: String
+    "Whether or not the Member the primary contact for the Plan"
+    isPrimaryContact: Boolean
     "The roles the Member has on the research project"
     memberRoleIds: [Int!]
   }

--- a/src/schemas/plan.ts
+++ b/src/schemas/plan.ts
@@ -13,6 +13,8 @@ export const typeDefs = gql`
     planByDMPId(dmpId: String!): Plan
     "Get a public plan by its DMP id"
     publicPlanByDMPId(dmpId: String!): Plan
+    "Get data for one versioned plan"
+    publicPlanVersionByDMPId(dmpId: String!, version: String!): PlanVersionSnapshot
     "Lookup a plan by an alternate identifier"
     planByAlternateIdentifier(alternateIdentifier: String!): Plan
   }
@@ -46,6 +48,81 @@ export const typeDefs = gql`
     removeEntirePlanByDMPId(dmpId: String!): Boolean
   }
 
+  type PlanVersionSnapshot {
+  isHistoricalVersion: Boolean!
+  versionTimestamp: String!
+
+  title: String
+  dmpId: String
+  created: String
+  modified: String
+  registered: String
+  visibility: PlanVisibility
+
+  versionedTemplate: PlanVersionSnapshotTemplate
+
+  project: PlanVersionSnapshotProject
+  members: [PlanVersionSnapshotMember!]
+  fundings: [PlanVersionSnapshotFunding!]
+  answers: [PlanVersionSnapshotAnswer!]
+  versions: [PlanVersionSnapshotVersion!]
+
+  "Bare related-work identifiers only — full citation metadata isn't preserved in archived snapshots"
+  relatedWorkIdentifiers: [String!]
+}
+
+type PlanVersionSnapshotTemplate {
+  id: Int
+  title: String
+  version: String
+}
+
+type PlanVersionSnapshotVersion {
+  timestamp: String
+  url: String
+}
+
+type PlanVersionSnapshotProject {
+  title: String
+  abstractText: String
+  startDate: String
+  endDate: String
+  researchDomain: PlanVersionSnapshotResearchDomain
+}
+
+type PlanVersionSnapshotResearchDomain {
+  name: String
+}
+
+type PlanVersionSnapshotFunding {
+  funderName: String
+  funderUri: String
+  status: String
+  grantId: String
+  funderOpportunityNumber: String
+  funderProjectNumber: String
+}
+
+type PlanVersionSnapshotMemberRole {
+  id: Int
+  label: String
+  uri: String
+}
+
+type PlanVersionSnapshotMember {
+  name: String
+  orcid: String
+  affiliationName: String
+  isPrimaryContact: Boolean
+  memberRoles: [PlanVersionSnapshotMemberRole!]
+}
+
+type PlanVersionSnapshotAnswer {
+  id: Int
+  questionText: String
+  json: String
+}
+    
   type PlanSearchResult{
     "The unique identifer for the Object"
     id: Int
@@ -176,6 +253,8 @@ export const typeDefs = gql`
     createdById: Int
     "The user who created the plan"
     planCreator: User
+    "The affiliation that owns the plan"
+    owner: Affiliation
     "The timestamp when the Object was created"
     created: String
     "The user who last modified the Object"
@@ -232,6 +311,9 @@ export const typeDefs = gql`
 
     "Indicates that the plan is not editable by the user (i.e. readOnly = true means the user cannot edit the plan)"
     readOnly: Boolean
+
+    "Other works related to this plan's project (e.g. publications, datasets)"
+    relatedWorks: [RelatedWorkSearchResult!]
   }
     
   input UpdatePlanInput {
@@ -298,9 +380,9 @@ export const typeDefs = gql`
   "A version of the plan"
   type PlanVersion {
     "The timestamp of the version, equates to the plan's modified date"
-    timestamp: String
-    "The DMPHub URL for the version"
-    url: String
+    modified: String
+    "The DMP ID for the version"
+    dmpId: String
   }
 
   "Errors associated with the AlternateIdentifier"

--- a/src/schemas/plan.ts
+++ b/src/schemas/plan.ts
@@ -11,9 +11,7 @@ export const typeDefs = gql`
     plan(planId: Int!): Plan
     "Lookup a plan by its DMP id"
     planByDMPId(dmpId: String!): Plan
-    "Get a public plan by its DMP id"
-    publicPlanByDMPId(dmpId: String!): Plan
-    "Get data for one versioned plan"
+    "Get data for a specific version of a plan"
     publicPlanVersionByDMPId(dmpId: String!, version: String!): PlanVersionSnapshot
     "Lookup a plan by an alternate identifier"
     planByAlternateIdentifier(alternateIdentifier: String!): Plan
@@ -51,6 +49,7 @@ export const typeDefs = gql`
   type PlanVersionSnapshot {
   isHistoricalVersion: Boolean!
   versionTimestamp: String!
+  latestVersionTimestamp: String!
 
   title: String
   dmpId: String
@@ -68,7 +67,7 @@ export const typeDefs = gql`
   fundings: [PlanVersionSnapshotFunding!]
   answers: [PlanVersionSnapshotAnswer!]
   versions: [PlanVersionSnapshotVersion!]
-  relatedWorks: [RelatedWorkSearchResult!]
+  relatedWorks: [PlanVersionSnapshotRelatedWork!]
 
   "Bare related-work identifiers only — full citation metadata isn't preserved in archived snapshots"
   relatedWorkIdentifiers: [String!]
@@ -108,7 +107,7 @@ type PlanVersionSnapshotResearchDomain {
 type PlanVersionSnapshotFunding {
   funderName: String
   funderUri: String
-  status: String
+  status: ProjectFundingStatus
   grantId: String
   funderOpportunityNumber: String
   funderProjectNumber: String
@@ -127,6 +126,44 @@ type PlanVersionSnapshotMember {
   isPrimaryContact: Boolean
   memberRoles: [PlanVersionSnapshotMemberRole!]
 }
+
+type PlanVersionSnapshotRelatedWork {
+  "The unique identifier for the Object"
+  id: Int
+  "The version of the work"
+  workVersion: PlanVersionSnapshotWorkVersion!
+}
+
+"""
+A lighter-weight view of a WorkVersion for use within a plan version snapshot —
+ only the fields needed for citation display, since full work-version metadata
+ (hash, institutions, funders, awards, timestamps) isn't preserved in archived snapshots.
+"""
+type PlanVersionSnapshotWorkVersion {
+  "The type of the work"
+  workType: WorkType!
+  "The date that the work was published YYYY-MM-DD"
+  publicationDate: String
+  "The title of the work"
+  title: String
+  "The authors of the work"
+  authors: [Author!]!
+  "The venue where the work was published, e.g. IEEE Transactions on Software Engineering, Zenodo etc"
+  publicationVenue: String
+  "The name of the source where the work was found"
+  sourceName: String!
+  "The URL for the source of the work"
+  sourceUrl: String
+  "The work"
+  work: PlanVersionSnapshotWork!
+}
+
+"A lighter-weight view of a Work for use within a plan version snapshot."
+type PlanVersionSnapshotWork {
+  "The Digital Object Identifier (DOI) of the work"
+  doi: String!
+}
+
 
 type PlanVersionSnapshotAnswer {
   id: Int

--- a/src/schemas/plan.ts
+++ b/src/schemas/plan.ts
@@ -59,6 +59,8 @@ export const typeDefs = gql`
   registered: String
   visibility: PlanVisibility
 
+  owner: PlanVersionSnapshotOwner
+
   versionedTemplate: PlanVersionSnapshotTemplate
 
   project: PlanVersionSnapshotProject
@@ -66,9 +68,18 @@ export const typeDefs = gql`
   fundings: [PlanVersionSnapshotFunding!]
   answers: [PlanVersionSnapshotAnswer!]
   versions: [PlanVersionSnapshotVersion!]
+  relatedWorks: [RelatedWorkSearchResult!]
 
   "Bare related-work identifiers only — full citation metadata isn't preserved in archived snapshots"
   relatedWorkIdentifiers: [String!]
+}
+
+type PlanVersionSnapshotOwner {
+  id: Int
+  name: String
+  displayName: String
+  uri: String
+  homepage: String
 }
 
 type PlanVersionSnapshotTemplate {

--- a/src/services/__tests__/planService.spec.ts
+++ b/src/services/__tests__/planService.spec.ts
@@ -27,7 +27,8 @@ import {
   deleteDMP, DMPExists, planToDMPCommonStandard,
   tombstoneDMP,
   updateDMP,
-  getDMPVersions
+  getDMPVersions,
+  getDMPs,
 } from '@dmptool/utils';
 import { getDynamoConnectionParams } from '../../config/awsConfig';
 import { generalConfig } from '../../config/generalConfig';
@@ -673,6 +674,7 @@ describe('getPlanVersions', () => {
   const reference = 'test-reference';
   const dmpId = 'https://doi.org/11.2222/3A4B5c';
   const mockGetDMPVersions = getDMPVersions as jest.MockedFunction<typeof getDMPVersions>;
+  const mockGetDMPs = getDMPs as jest.MockedFunction<typeof getDMPs>;
 
   beforeEach(async () => {
     context = await buildMockContextWithToken(logger);
@@ -690,6 +692,8 @@ describe('getPlanVersions', () => {
 
   it('should return an empty array when no versions are found', async () => {
     mockGetDMPVersions.mockResolvedValue([]);
+    /*eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    mockGetDMPs.mockResolvedValue([{ dmp: { modified: '2026-08-01T14:32:00Z' } }] as any);
 
     const result = await getPlanVersions(reference, context, dmpId);
 
@@ -697,33 +701,76 @@ describe('getPlanVersions', () => {
     expect(mockGetDMPVersions).toHaveBeenCalledWith(getDynamoConnectionParams(context.logger), dmpId);
   });
 
-  it('should map each version to a timestamp and public-facing URL', async () => {
+  it('should fetch the latest version to filter it out', async () => {
+    mockGetDMPVersions.mockResolvedValue([]);
+    /*eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    mockGetDMPs.mockResolvedValue([{ dmp: { modified: '2026-08-01T14:32:00Z' } }] as any);
+
+    await getPlanVersions(reference, context, dmpId);
+
+    expect(mockGetDMPs).toHaveBeenCalledWith(
+      getDynamoConnectionParams(context.logger),
+      generalConfig.domain,
+      dmpId,
+      'latest'
+    );
+  });
+
+  it('should filter out the version matching the latest modified timestamp', async () => {
+    const latestModified = '2026-08-01T14:32:00Z';
+    mockGetDMPVersions.mockResolvedValue([
+      { dmpId, modified: latestModified },  // This should be filtered out (matches latest)
+      { dmpId, modified: '2026-06-15T09:10:00Z' },
+    ]);
+    /*eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    mockGetDMPs.mockResolvedValue([{ dmp: { modified: latestModified } }] as any);
+
+    const result = await getPlanVersions(reference, context, dmpId);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].modified).toBe('2026-06-15T09:10:00Z');
+  });
+
+  it('should map each historical version to a timestamp and public-facing URL using generalConfig.domain', async () => {
+    const latestModified = '2026-09-01T00:00:00Z';
     mockGetDMPVersions.mockResolvedValue([
       { dmpId, modified: '2026-08-01T14:32:00Z' },
       { dmpId, modified: '2026-06-15T09:10:00Z' },
     ]);
+    /*eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    mockGetDMPs.mockResolvedValue([{ dmp: { modified: latestModified } }] as any);
 
     const result = await getPlanVersions(reference, context, dmpId);
 
     expect(result).toEqual([
       {
-        timestamp: "2026-08-01T14:32:00Z",
-        url: "https://localhost:3000/dmps/doi.org/11.2222/3A4B5c?version=2026-08-01T14%3A32%3A00Z",
-        dmpId: "https://doi.org/11.2222/3A4B5c",
-        modified: "2026-08-01T14:32:00Z",
-
+        timestamp: '2026-08-01T14:32:00Z',
+        url: `https://${generalConfig.domain}/dmps/doi.org/11.2222/3A4B5c?version=2026-08-01T14%3A32%3A00Z`,
+        dmpId: 'https://doi.org/11.2222/3A4B5c',
+        modified: '2026-08-01T14:32:00Z',
       },
       {
         timestamp: '2026-06-15T09:10:00Z',
-        url: "https://localhost:3000/dmps/doi.org/11.2222/3A4B5c?version=2026-06-15T09%3A10%3A00Z",
-        dmpId: "https://doi.org/11.2222/3A4B5c",
-        modified: "2026-06-15T09:10:00Z"
+        url: `https://${generalConfig.domain}/dmps/doi.org/11.2222/3A4B5c?version=2026-06-15T09%3A10%3A00Z`,
+        dmpId: 'https://doi.org/11.2222/3A4B5c',
+        modified: '2026-06-15T09:10:00Z',
       },
     ]);
   });
 
-  it('should return an empty array and logs an error if getDMPVersions throws', async () => {
+  it('should return an empty array and log an error if getDMPVersions throws', async () => {
     mockGetDMPVersions.mockRejectedValue(new Error('dynamo error'));
+
+    const result = await getPlanVersions(reference, context, dmpId);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should return an empty array and log an error if getDMPs throws', async () => {
+    mockGetDMPVersions.mockResolvedValue([
+      { dmpId, modified: '2026-08-01T14:32:00Z' },
+    ]);
+    mockGetDMPs.mockRejectedValue(new Error('dynamo error'));
 
     const result = await getPlanVersions(reference, context, dmpId);
 

--- a/src/services/planService.ts
+++ b/src/services/planService.ts
@@ -7,6 +7,7 @@ import { Project } from "../models/Project";
 import { PlanFunding, ProjectFunding } from "../models/Funding";
 import { Affiliation } from "../models/Affiliation";
 import { AlternateIdentifier } from "../models/AlternateIdentifier";
+import { AcceptedWork } from "../models/RelatedWork";
 import {
   createDMP,
   deleteDMP,
@@ -17,7 +18,8 @@ import {
   tombstoneDMP,
   updateDMP,
   getDMPVersions,
-  getDMPs
+  getDMPs,
+  DMPVersionType,
 } from "@dmptool/utils";
 import { getDynamoConnectionParams } from "../config/awsConfig";
 import { generalConfig } from "../config/generalConfig";
@@ -422,10 +424,16 @@ export async function getPlanVersions(
 
   const dynamoConfig: DynamoConnectionParams = getDynamoConnectionParams(context.logger);
   try {
-    const versions = await getDMPVersions(dynamoConfig, dmpId);
+    const versions: DMPVersionType[] = await getDMPVersions(dynamoConfig, dmpId);
 
-    // Map each version to include timestamp and public-facing URL
-    return versions.map((v) => ({
+    // Get the current latest version to filter it out
+    const latest = await getDMPs(dynamoConfig, generalConfig.domain, dmpId, 'latest');
+    const latestModified = latest[0]?.dmp?.modified;
+
+    // Filter out the current VERSION#latest - only return timestamped snapshots
+    const historicalVersions = versions.filter(v => v.modified !== latestModified);
+
+    return historicalVersions.map((v) => ({
       dmpId: v.dmpId,
       modified: v.modified,
       timestamp: v.modified,
@@ -465,7 +473,12 @@ export async function getPlanVersionSnapshot(
       return null;
     }
 
-    return await mapDMPToolDMPToSnapshot(results[0], version, context);
+    // Fetch the planId from the database by dmpId
+    const plan = await Plan.findByDMPId(reference, context, dmpId);
+    const planId = plan?.id;
+    const projectId = plan?.projectId;
+
+    return await mapDMPToolDMPToSnapshot(results[0], version, context, planId, projectId);
   } catch (err) {
     context.logger.error({ dmpId, version, reference, err }, 'Unable to fetch DMP version snapshot.');
     return null;
@@ -475,13 +488,13 @@ export async function getPlanVersionSnapshot(
 export async function mapDMPToolDMPToSnapshot(
   result: DMPToolDMPType,
   version: string,
-  context: MyContext
+  context: MyContext,
+  planId: number,
+  projectId?: number
 ): Promise<PlanVersionSnapshot> {
 
-  console.log("***Result from DynamoDB: ", JSON.stringify(result, null, 2));
   const dmp = result.dmp;
   const project = dmp.project?.[0];
-
   const dmpId = dmp.dmp_id?.identifier; // already a full https://doi.org/... URL
 
   // Flatten narrative answers into the same {id, json} shape as live `answers`
@@ -495,28 +508,90 @@ export async function mapDMPToolDMPToSnapshot(
       }))
   );
 
-  // Contact's email lets us flag which contributor is the primary contact
-  const contactEmail = dmp.contact?.mbox;
-
   // Fetch every known role once, then match against contributor role URIs in memory.
   const allMemberRoles = await MemberRole.all('mapDMPToolDMPToSnapshot.memberRoles', context);
   const roleByUri = new Map(allMemberRoles.map((r) => [r.uri, r]));
 
-  const members = (dmp.contributor ?? []).map((c) => ({
-    name: c.name,
-    orcid: c.contributor_id?.find((id) => id.type === 'orcid')?.identifier,
-    affiliationName: c.affiliation?.[0]?.name,
-    isPrimaryContact: contactEmail
-      ? c.contributor_id?.some((id) => id.identifier === contactEmail) ?? false
-      : false,
-    memberRoles: (c.role ?? []).map((uri) => {
-      const matched = roleByUri.get(uri);
-      return matched
-        ? { id: matched.id, label: matched.label, uri: matched.uri }
-        : { id: undefined, label: uri, uri }; // fallback if a role URI isn't found in the table
-    }),
-  }));
+  // Map contributors and look up isPrimaryContact from database
+  const members = [];
 
+  for (const c of (dmp.contributor ?? [])) {
+    let isPrimaryContact = false;
+
+    // If we have a projectId, query the database for the actual isPrimaryContact value
+    if (projectId && c.contributor_id) {
+      // Try to find by email first (most reliable)
+      if (c.contact_mbox || c.mbox) {
+        const email = c.contact_mbox || c.mbox;
+        const dbMember = await ProjectMember.findByProjectAndEmail(
+          'mapDMPToolDMPToSnapshot.isPrimaryContact',
+          context,
+          projectId,
+          email
+        );
+
+        if (dbMember) {
+          isPrimaryContact = dbMember.isPrimaryContact;
+        }
+      } else if (c.name) {
+        // Fallback to name if no email (extract given/sur name)
+        const nameParts = c.name.split(' ');
+        const givenName = nameParts[0];
+        const surName = nameParts.length > 1 ? nameParts.slice(1).join(' ') : '';
+
+        const dbMember = await ProjectMember.findByProjectAndName(
+          'mapDMPToolDMPToSnapshot.isPrimaryContact',
+          context,
+          projectId,
+          givenName,
+          surName
+        );
+        if (dbMember) {
+          isPrimaryContact = dbMember.isPrimaryContact;
+        }
+      }
+    }
+
+    members.push({
+      name: c.name,
+      orcid: c.contributor_id?.find((id) => id.type === 'orcid')?.identifier,
+      affiliationName: c.affiliation?.[0]?.name,
+      isPrimaryContact,
+      memberRoles: (c.role ?? []).map((uri) => {
+        const matched = roleByUri.get(uri);
+        return matched
+          ? { id: matched.id, label: matched.label, uri: matched.uri }
+          : { id: undefined, label: uri, uri };
+      }),
+    });
+  }
+
+
+  // Get the organization from the plan owner (affiliation)
+  const ownerAffiliation = dmp.contributor?.find(c => c.name === dmp.contact?.name)?.affiliation?.[0];
+  const affiliationURI = ownerAffiliation.affiliation_id?.identifier;
+  const affiliation = await Affiliation.findByURI('mapDMPToolDMPToSnapshot.ownerAffiliation', context, affiliationURI);
+
+  // Get the related works
+  let relatedWorks = [];
+  if (dmpId) {
+    const acceptedWorks = await AcceptedWork.findByPlanId('mapDMPToolDMPToSnapshot.relatedWorks', context, planId);
+    relatedWorks = acceptedWorks.map((work) => ({
+      id: work.id,
+      workVersion: {
+        title: work.title,
+        publicationDate: work.publicationDate,
+        workType: work.workType,
+        publicationVenue: work.publicationVenue,
+        sourceName: work.sourceName,
+        sourceUrl: work.sourceUrl,
+        authors: work.authors,
+        work: {
+          doi: work.doi,
+        }
+      }
+    }));
+  }
   return {
     isHistoricalVersion: true,
     versionTimestamp: version,
@@ -527,6 +602,14 @@ export async function mapDMPToolDMPToSnapshot(
     modified: dmp.modified,
     registered: dmp.registered,
     visibility: dmp.privacy === 'public' ? PlanVisibility.PUBLIC : PlanVisibility.PRIVATE,
+
+    owner: ownerAffiliation ? {
+      id: affiliation?.id,
+      name: affiliation?.name || affiliation?.displayName || ownerAffiliation.name,
+      displayName: affiliation?.displayName || ownerAffiliation.name,
+      uri: affiliation?.uri || ownerAffiliation?.affiliation_id?.identifier,
+      homepage: affiliation?.homepage
+    } : undefined,
 
     versionedTemplate: dmp.narrative?.template
       ? {
@@ -573,7 +656,7 @@ export async function mapDMPToolDMPToSnapshot(
       timestamp: v.version,
       url: v.access_url,
     })),
-
+    relatedWorks,
     relatedWorkIdentifiers: (dmp.related_identifier ?? []).map((r) => r.identifier),
   };
 }

--- a/src/services/planService.ts
+++ b/src/services/planService.ts
@@ -33,6 +33,7 @@ import {
 } from "./dataciteXMLService";
 import { removeIndexItem, updateIndexItem } from "./indexDMPService";
 import { PlanVersionSnapshot } from "../types";
+import { ProjectFundingStatus } from "../models/Funding";
 
 
 /**
@@ -426,11 +427,13 @@ export async function getPlanVersions(
   try {
     const versions: DMPVersionType[] = await getDMPVersions(dynamoConfig, dmpId);
 
-    // Get the current latest version to filter it out
+    // Fetch the current latest snapshot's modified timestamp so it can be
+    // excluded below. "VERSION#latest" isn't a queryable timestamped snapshot —
+    // including it would produce a version-picker link that 404s when clicked.
     const latest = await getDMPs(dynamoConfig, generalConfig.domain, dmpId, 'latest');
     const latestModified = latest[0]?.dmp?.modified;
 
-    // Filter out the current VERSION#latest - only return timestamped snapshots
+    // Only return genuinely historical, timestamp-queryable versions.
     const historicalVersions = versions.filter(v => v.modified !== latestModified);
 
     return historicalVersions.map((v) => ({
@@ -485,6 +488,18 @@ export async function getPlanVersionSnapshot(
   }
 }
 
+function mapFundingStatus(status?: string | null): ProjectFundingStatus {
+  switch (status?.toLowerCase()) {
+    case 'granted':
+      return ProjectFundingStatus.GRANTED;
+    case 'denied':
+      return ProjectFundingStatus.DENIED;
+    case 'planned':
+    default:
+      return ProjectFundingStatus.PLANNED;
+  }
+}
+
 export async function mapDMPToolDMPToSnapshot(
   result: DMPToolDMPType,
   version: string,
@@ -512,89 +527,113 @@ export async function mapDMPToolDMPToSnapshot(
   const allMemberRoles = await MemberRole.all('mapDMPToolDMPToSnapshot.memberRoles', context);
   const roleByUri = new Map(allMemberRoles.map((r) => [r.uri, r]));
 
-  // Map contributors and look up isPrimaryContact from database
-  const members = [];
+  // Get the organization from the plan owner (affiliation) — this is computed
+  // synchronously so we can kick off the affiliation lookup in parallel below.
+  const ownerAffiliation = dmp.contributor?.find(c => c.name === dmp.contact?.name)?.affiliation?.[0];
+  const affiliationURI = ownerAffiliation?.affiliation_id?.identifier;
 
-  for (const c of (dmp.contributor ?? [])) {
-    let isPrimaryContact = false;
+  // Run the independent async lookups concurrently instead of sequentially:
+  // - members: maps contributors and looks up isPrimaryContact per-contributor
+  // - affiliation: resolves the owner's affiliation record
+  // - acceptedWorks: fetches related works for this plan
+  const [members, affiliation, acceptedWorks] = await Promise.all([
+    Promise.all(
+      (dmp.contributor ?? []).map(async (c) => {
+        let isPrimaryContact = false;
 
-    // If we have a projectId, query the database for the actual isPrimaryContact value
-    if (projectId && c.contributor_id) {
-      // Try to find by email first (most reliable)
-      if (c.contact_mbox || c.mbox) {
-        const email = c.contact_mbox || c.mbox;
-        const dbMember = await ProjectMember.findByProjectAndEmail(
-          'mapDMPToolDMPToSnapshot.isPrimaryContact',
-          context,
-          projectId,
-          email
-        );
+        // If we have a projectId, query the database for the actual isPrimaryContact value
+        if (projectId && c.contributor_id) {
+          // Try to find by email first (most reliable)
+          if (c.contact_mbox || c.mbox) {
+            const email = c.contact_mbox || c.mbox;
+            const dbMember = await ProjectMember.findByProjectAndEmail(
+              'mapDMPToolDMPToSnapshot.isPrimaryContact',
+              context,
+              projectId,
+              email
+            );
 
-        if (dbMember) {
-          isPrimaryContact = dbMember.isPrimaryContact;
+            if (dbMember) {
+              isPrimaryContact = dbMember.isPrimaryContact;
+            }
+          } else if (c.name) {
+            // Fallback to name if no email (extract given/sur name)
+            const nameParts = c.name.split(' ');
+            const givenName = nameParts[0];
+            const surName = nameParts.length > 1 ? nameParts.slice(1).join(' ') : '';
+
+            const dbMember = await ProjectMember.findByProjectAndName(
+              'mapDMPToolDMPToSnapshot.isPrimaryContact',
+              context,
+              projectId,
+              givenName,
+              surName
+            );
+            if (dbMember) {
+              isPrimaryContact = dbMember.isPrimaryContact;
+            }
+          }
         }
-      } else if (c.name) {
-        // Fallback to name if no email (extract given/sur name)
-        const nameParts = c.name.split(' ');
-        const givenName = nameParts[0];
-        const surName = nameParts.length > 1 ? nameParts.slice(1).join(' ') : '';
 
-        const dbMember = await ProjectMember.findByProjectAndName(
-          'mapDMPToolDMPToSnapshot.isPrimaryContact',
-          context,
-          projectId,
-          givenName,
-          surName
-        );
-        if (dbMember) {
-          isPrimaryContact = dbMember.isPrimaryContact;
-        }
+        return {
+          name: c.name,
+          orcid: c.contributor_id?.find((id) => id.type === 'orcid')?.identifier,
+          affiliationName: c.affiliation?.[0]?.name,
+          isPrimaryContact,
+          memberRoles: (c.role ?? []).map((uri) => {
+            const matched = roleByUri.get(uri);
+            return matched
+              ? { id: matched.id, label: matched.label, uri: matched.uri }
+              : { id: undefined, label: uri, uri };
+          }),
+        };
+      })
+    ),
+    affiliationURI
+      ? Affiliation.findByURI('mapDMPToolDMPToSnapshot.ownerAffiliation', context, affiliationURI)
+      : Promise.resolve(undefined),
+    planId
+      ? AcceptedWork.findByPlanId('mapDMPToolDMPToSnapshot.relatedWorks', context, planId)
+      : Promise.resolve([]),
+  ]);
+
+  // Map the accepted works into the snapshot's relatedWorks shape
+  const relatedWorks: PlanVersionSnapshot['relatedWorks'] = acceptedWorks.map((work) => ({
+    id: work.id,
+    workVersion: {
+      title: work.title,
+      publicationDate: work.publicationDate,
+      workType: work.workType,
+      publicationVenue: work.publicationVenue,
+      sourceName: work.sourceName,
+      sourceUrl: work.sourceUrl,
+      authors: work.authors,
+      work: {
+        doi: work.doi,
       }
     }
+  }));
 
-    members.push({
-      name: c.name,
-      orcid: c.contributor_id?.find((id) => id.type === 'orcid')?.identifier,
-      affiliationName: c.affiliation?.[0]?.name,
-      isPrimaryContact,
-      memberRoles: (c.role ?? []).map((uri) => {
-        const matched = roleByUri.get(uri);
-        return matched
-          ? { id: matched.id, label: matched.label, uri: matched.uri }
-          : { id: undefined, label: uri, uri };
-      }),
-    });
+  // Determine the actual current "latest" snapshot's modified timestamp,
+  // so we can exclude it from the historical versions list — VERSION#latest
+  // is not queryable by its own timestamp, only by the literal string 'latest'.
+  let latestModified: string | undefined;
+  if (version === 'latest') {
+    latestModified = dmp.modified;
+  } else {
+    const dynamoConfig = getDynamoConnectionParams(context.logger);
+    const latest = await getDMPs(dynamoConfig, generalConfig.domain, dmpId, 'latest');
+    latestModified = latest[0]?.dmp?.modified;
   }
 
+  const historicalVersions = (dmp.version ?? []).filter(
+    (v) => v.version !== latestModified
+  );
 
-  // Get the organization from the plan owner (affiliation)
-  const ownerAffiliation = dmp.contributor?.find(c => c.name === dmp.contact?.name)?.affiliation?.[0];
-  const affiliationURI = ownerAffiliation.affiliation_id?.identifier;
-  const affiliation = await Affiliation.findByURI('mapDMPToolDMPToSnapshot.ownerAffiliation', context, affiliationURI);
-
-  // Get the related works
-  let relatedWorks = [];
-  if (dmpId) {
-    const acceptedWorks = await AcceptedWork.findByPlanId('mapDMPToolDMPToSnapshot.relatedWorks', context, planId);
-    relatedWorks = acceptedWorks.map((work) => ({
-      id: work.id,
-      workVersion: {
-        title: work.title,
-        publicationDate: work.publicationDate,
-        workType: work.workType,
-        publicationVenue: work.publicationVenue,
-        sourceName: work.sourceName,
-        sourceUrl: work.sourceUrl,
-        authors: work.authors,
-        work: {
-          doi: work.doi,
-        }
-      }
-    }));
-  }
   return {
     isHistoricalVersion: true,
     versionTimestamp: version,
+    latestVersionTimestamp: latestModified,
 
     title: dmp.title,
     dmpId,
@@ -631,7 +670,7 @@ export async function mapDMPToolDMPToSnapshot(
       }
       : undefined,
     members: members,
-    fundings: (project.funding ?? []).map((f) => {
+    fundings: (project?.funding ?? []).map((f) => {
       const funderIdentifier = f.funder_id?.identifier;
       const opportunity = dmp.funding_opportunity?.find(
         (fo) => fo.funder_id?.identifier === funderIdentifier
@@ -643,7 +682,7 @@ export async function mapDMPToolDMPToSnapshot(
       return {
         funderName: f.name,
         funderUri: funderIdentifier,
-        status: f.funding_status,
+        status: mapFundingStatus(f.funding_status),  // normalize here
         grantId: f.grant_id?.identifier,
         funderOpportunityNumber: opportunity?.opportunity_identifier?.identifier,
         funderProjectNumber: fundingProject?.project_identifier?.identifier,
@@ -652,7 +691,7 @@ export async function mapDMPToolDMPToSnapshot(
 
     answers,
 
-    versions: (dmp.version ?? []).map((v) => ({
+    versions: historicalVersions.map((v) => ({
       timestamp: v.version,
       url: v.access_url,
     })),

--- a/src/services/planService.ts
+++ b/src/services/planService.ts
@@ -2,7 +2,7 @@ import { MyContext } from "../context";
 import { MemberRole } from "../models/MemberRole";
 import { isNullOrUndefined } from "../utils/helpers";
 import { PlanMember, ProjectMember } from "../models/Member";
-import { Plan } from "../models/Plan";
+import { Plan, PlanVisibility } from "../models/Plan";
 import { Project } from "../models/Project";
 import { PlanFunding, ProjectFunding } from "../models/Funding";
 import { Affiliation } from "../models/Affiliation";
@@ -16,7 +16,8 @@ import {
   planToDMPCommonStandard,
   tombstoneDMP,
   updateDMP,
-  getDMPVersions
+  getDMPVersions,
+  getDMPs
 } from "@dmptool/utils";
 import { getDynamoConnectionParams } from "../config/awsConfig";
 import { generalConfig } from "../config/generalConfig";
@@ -28,6 +29,7 @@ import {
   DataCiteSourceFundingAffiliation,
   planToDataCiteMetadata
 } from "./dataciteXMLService";
+import { PlanVersionSnapshot } from "../types";
 
 
 /**
@@ -354,27 +356,162 @@ export async function saveMaDMPVersion(
  * @param reference A value to help identify the caller to help with logging
  * @param context The apollo context object
  * @param dmpId The DMP id of the plan to fetch versions for
- * @returns an array of { timestamp, url } for each past version
+ * @returns an array of { modified, dmpId } for each past version
  */
 export async function getPlanVersions(
   reference: string,
   context: MyContext,
   dmpId: string
-): Promise<{ timestamp: string, url: string }[]> {
+): Promise<{ modified: string, dmpId: string }[]> {
   if (isNullOrUndefined(dmpId)) return [];
 
   const dynamoConfig: DynamoConnectionParams = getDynamoConnectionParams(context.logger);
-
   try {
-    const versions = await getDMPVersions(dynamoConfig, dmpId);
+    return await getDMPVersions(dynamoConfig, dmpId);
 
-    return versions
-      .map((v) => ({
-        timestamp: v.modified,
-        url: `https://${generalConfig.domain}/dmps/${dmpId.replace('https://', '')}?version=${encodeURIComponent(v.modified)}`,
-      }));
   } catch (err) {
     context.logger.error({ dmpId, reference, err }, 'Unable to fetch DMP versions.');
     return [];
   }
 }
+
+/**
+ * Fetches the complete maDMP snapshot for a specific version of a DMP and maps
+ * it into the client-facing PlanVersionSnapshot shape.
+ *
+ * @param reference A value to help identify the caller to help with logging
+ * @param context The apollo context object
+ * @param dmpId The DMP id of the plan to fetch
+ * @param version The specific version timestamp to fetch
+ * @returns The mapped PlanVersionSnapshot, or null if the version could not be found
+ */
+export async function getPlanVersionSnapshot(
+  reference: string,
+  context: MyContext,
+  dmpId: string,
+  version: string,
+): Promise<PlanVersionSnapshot | null> {
+  if (isNullOrUndefined(dmpId) || isNullOrUndefined(version)) return null;
+
+  const dynamoConfig: DynamoConnectionParams = getDynamoConnectionParams(context.logger);
+
+  try {
+    const results = await getDMPs(dynamoConfig, generalConfig.domain, dmpId, version);
+
+    if (!results || results.length === 0) {
+      return null;
+    }
+
+    return await mapDMPToolDMPToSnapshot(results[0], version, context);
+  } catch (err) {
+    context.logger.error({ dmpId, version, reference, err }, 'Unable to fetch DMP version snapshot.');
+    return null;
+  }
+}
+
+export async function mapDMPToolDMPToSnapshot(
+  result: DMPToolDMPType,
+  version: string,
+  context: MyContext
+): Promise<PlanVersionSnapshot> {
+
+  console.log("***Result from DynamoDB: ", JSON.stringify(result, null, 2));
+  const dmp = result.dmp;
+  const project = dmp.project?.[0];
+
+  const dmpId = dmp.dmp_id?.identifier; // already a full https://doi.org/... URL
+
+  // Flatten narrative answers into the same {id, json} shape as live `answers`
+  const answers = (dmp.narrative?.template?.section ?? []).flatMap((section) =>
+    (section.question ?? [])
+      .filter((q) => q.answer)
+      .map((q) => ({
+        id: q.answer!.id,
+        questionText: q.text,
+        json: JSON.stringify(q.answer!.json),
+      }))
+  );
+
+  // Contact's email lets us flag which contributor is the primary contact
+  const contactEmail = dmp.contact?.mbox;
+
+  // Fetch every known role once, then match against contributor role URIs in memory.
+  const allMemberRoles = await MemberRole.all('mapDMPToolDMPToSnapshot.memberRoles', context);
+  const roleByUri = new Map(allMemberRoles.map((r) => [r.uri, r]));
+
+  const members = (dmp.contributor ?? []).map((c) => ({
+    name: c.name,
+    orcid: c.contributor_id?.find((id) => id.type === 'orcid')?.identifier,
+    affiliationName: c.affiliation?.[0]?.name,
+    isPrimaryContact: contactEmail
+      ? c.contributor_id?.some((id) => id.identifier === contactEmail) ?? false
+      : false,
+    memberRoles: (c.role ?? []).map((uri) => {
+      const matched = roleByUri.get(uri);
+      return matched
+        ? { id: matched.id, label: matched.label, uri: matched.uri }
+        : { id: undefined, label: uri, uri }; // fallback if a role URI isn't found in the table
+    }),
+  }));
+
+  return {
+    isHistoricalVersion: true,
+    versionTimestamp: version,
+
+    title: dmp.title,
+    dmpId,
+    created: dmp.created,
+    modified: dmp.modified,
+    registered: dmp.registered,
+    visibility: dmp.privacy === 'public' ? PlanVisibility.PUBLIC : PlanVisibility.PRIVATE,
+
+    versionedTemplate: dmp.narrative?.template
+      ? {
+        id: dmp.narrative.template.id,
+        title: dmp.narrative.template.title,
+        version: dmp.narrative.template.version,
+      }
+      : undefined,
+
+    project: project
+      ? {
+        title: project.title,
+        abstractText: project.description,
+        startDate: project.start,
+        endDate: project.end,
+        researchDomain: dmp.research_domain
+          ? { name: dmp.research_domain.name }
+          : undefined,
+      }
+      : undefined,
+    members: members,
+    fundings: (project.funding ?? []).map((f) => {
+      const funderIdentifier = f.funder_id?.identifier;
+      const opportunity = dmp.funding_opportunity?.find(
+        (fo) => fo.funder_id?.identifier === funderIdentifier
+      );
+      const fundingProject = dmp.funding_project?.find(
+        (fp) => fp.funder_id?.identifier === funderIdentifier
+      );
+
+      return {
+        funderName: f.name,
+        funderUri: funderIdentifier,
+        status: f.funding_status,
+        grantId: f.grant_id?.identifier,
+        funderOpportunityNumber: opportunity?.opportunity_identifier?.identifier,
+        funderProjectNumber: fundingProject?.project_identifier?.identifier,
+      };
+    }),
+
+    answers,
+
+    versions: (dmp.version ?? []).map((v) => ({
+      timestamp: v.version,
+      url: v.access_url,
+    })),
+
+    relatedWorkIdentifiers: (dmp.related_identifier ?? []).map((r) => r.identifier),
+  };
+}
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -2754,6 +2754,8 @@ export type Plan = {
   modified?: Maybe<Scalars['String']['output']>;
   /** The user who last modified the Object */
   modifiedById?: Maybe<Scalars['Int']['output']>;
+  /** The affiliation that owns the plan */
+  owner?: Maybe<Affiliation>;
   /** The user who created the plan */
   planCreator?: Maybe<User>;
   /** The progress the user has made within the plan */
@@ -2766,6 +2768,8 @@ export type Plan = {
   registered?: Maybe<Scalars['String']['output']>;
   /** The individual who registered the plan */
   registeredById?: Maybe<Scalars['Int']['output']>;
+  /** Other works related to this plan's project (e.g. publications, datasets) */
+  relatedWorks?: Maybe<Array<RelatedWorkSearchResult>>;
   /** The status/state of the plan */
   status?: Maybe<PlanStatus>;
   /** The title of the plan */
@@ -3097,9 +3101,89 @@ export type PlanStatus =
 /** A version of the plan */
 export type PlanVersion = {
   __typename?: 'PlanVersion';
+  /** The DMP ID for the version */
+  dmpId?: Maybe<Scalars['String']['output']>;
   /** The timestamp of the version, equates to the plan's modified date */
+  modified?: Maybe<Scalars['String']['output']>;
+};
+
+export type PlanVersionSnapshot = {
+  __typename?: 'PlanVersionSnapshot';
+  answers?: Maybe<Array<PlanVersionSnapshotAnswer>>;
+  created?: Maybe<Scalars['String']['output']>;
+  dmpId?: Maybe<Scalars['String']['output']>;
+  fundings?: Maybe<Array<PlanVersionSnapshotFunding>>;
+  isHistoricalVersion: Scalars['Boolean']['output'];
+  members?: Maybe<Array<PlanVersionSnapshotMember>>;
+  modified?: Maybe<Scalars['String']['output']>;
+  project?: Maybe<PlanVersionSnapshotProject>;
+  registered?: Maybe<Scalars['String']['output']>;
+  /** Bare related-work identifiers only — full citation metadata isn't preserved in archived snapshots */
+  relatedWorkIdentifiers?: Maybe<Array<Scalars['String']['output']>>;
+  title?: Maybe<Scalars['String']['output']>;
+  versionTimestamp: Scalars['String']['output'];
+  versionedTemplate?: Maybe<PlanVersionSnapshotTemplate>;
+  versions?: Maybe<Array<PlanVersionSnapshotVersion>>;
+  visibility?: Maybe<PlanVisibility>;
+};
+
+export type PlanVersionSnapshotAnswer = {
+  __typename?: 'PlanVersionSnapshotAnswer';
+  id?: Maybe<Scalars['Int']['output']>;
+  json?: Maybe<Scalars['String']['output']>;
+  questionText?: Maybe<Scalars['String']['output']>;
+};
+
+export type PlanVersionSnapshotFunding = {
+  __typename?: 'PlanVersionSnapshotFunding';
+  funderName?: Maybe<Scalars['String']['output']>;
+  funderOpportunityNumber?: Maybe<Scalars['String']['output']>;
+  funderProjectNumber?: Maybe<Scalars['String']['output']>;
+  funderUri?: Maybe<Scalars['String']['output']>;
+  grantId?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+};
+
+export type PlanVersionSnapshotMember = {
+  __typename?: 'PlanVersionSnapshotMember';
+  affiliationName?: Maybe<Scalars['String']['output']>;
+  isPrimaryContact?: Maybe<Scalars['Boolean']['output']>;
+  memberRoles?: Maybe<Array<PlanVersionSnapshotMemberRole>>;
+  name?: Maybe<Scalars['String']['output']>;
+  orcid?: Maybe<Scalars['String']['output']>;
+};
+
+export type PlanVersionSnapshotMemberRole = {
+  __typename?: 'PlanVersionSnapshotMemberRole';
+  id?: Maybe<Scalars['Int']['output']>;
+  label?: Maybe<Scalars['String']['output']>;
+  uri?: Maybe<Scalars['String']['output']>;
+};
+
+export type PlanVersionSnapshotProject = {
+  __typename?: 'PlanVersionSnapshotProject';
+  abstractText?: Maybe<Scalars['String']['output']>;
+  endDate?: Maybe<Scalars['String']['output']>;
+  researchDomain?: Maybe<PlanVersionSnapshotResearchDomain>;
+  startDate?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type PlanVersionSnapshotResearchDomain = {
+  __typename?: 'PlanVersionSnapshotResearchDomain';
+  name?: Maybe<Scalars['String']['output']>;
+};
+
+export type PlanVersionSnapshotTemplate = {
+  __typename?: 'PlanVersionSnapshotTemplate';
+  id?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+  version?: Maybe<Scalars['String']['output']>;
+};
+
+export type PlanVersionSnapshotVersion = {
+  __typename?: 'PlanVersionSnapshotVersion';
   timestamp?: Maybe<Scalars['String']['output']>;
-  /** The DMPHub URL for the version */
   url?: Maybe<Scalars['String']['output']>;
 };
 
@@ -3593,6 +3677,8 @@ export type Query = {
   projectMembers?: Maybe<Array<Maybe<ProjectMember>>>;
   /** Get a public plan by its DMP id */
   publicPlanByDMPId?: Maybe<Plan>;
+  /** Get data for one versioned plan */
+  publicPlanVersionByDMPId?: Maybe<PlanVersionSnapshot>;
   /** Get the published VersionedQuestionConditionGroups (and their nested conditions) for the specified versioned question */
   publishedConditionGroupsForQuestion?: Maybe<Array<Maybe<VersionedQuestionConditionGroup>>>;
   /** Get a specific published custom question based on versionedCustomQuestionId */
@@ -3958,6 +4044,12 @@ export type QueryProjectMembersArgs = {
 
 export type QueryPublicPlanByDmpIdArgs = {
   dmpId: Scalars['String']['input'];
+};
+
+
+export type QueryPublicPlanVersionByDmpIdArgs = {
+  dmpId: Scalars['String']['input'];
+  version: Scalars['String']['input'];
 };
 
 
@@ -6588,6 +6680,15 @@ export type ResolversTypes = {
   PlanSectionProgress: ResolverTypeWrapper<PlanSectionProgress>;
   PlanStatus: PlanStatus;
   PlanVersion: ResolverTypeWrapper<PlanVersion>;
+  PlanVersionSnapshot: ResolverTypeWrapper<PlanVersionSnapshot>;
+  PlanVersionSnapshotAnswer: ResolverTypeWrapper<PlanVersionSnapshotAnswer>;
+  PlanVersionSnapshotFunding: ResolverTypeWrapper<PlanVersionSnapshotFunding>;
+  PlanVersionSnapshotMember: ResolverTypeWrapper<PlanVersionSnapshotMember>;
+  PlanVersionSnapshotMemberRole: ResolverTypeWrapper<PlanVersionSnapshotMemberRole>;
+  PlanVersionSnapshotProject: ResolverTypeWrapper<PlanVersionSnapshotProject>;
+  PlanVersionSnapshotResearchDomain: ResolverTypeWrapper<PlanVersionSnapshotResearchDomain>;
+  PlanVersionSnapshotTemplate: ResolverTypeWrapper<PlanVersionSnapshotTemplate>;
+  PlanVersionSnapshotVersion: ResolverTypeWrapper<PlanVersionSnapshotVersion>;
   PlanVisibility: PlanVisibility;
   Project: ResolverTypeWrapper<Project>;
   ProjectCollaborator: ResolverTypeWrapper<ProjectCollaborator>;
@@ -6852,6 +6953,15 @@ export type ResolversParentTypes = {
   PlanSearchResult: PlanSearchResult;
   PlanSectionProgress: PlanSectionProgress;
   PlanVersion: PlanVersion;
+  PlanVersionSnapshot: PlanVersionSnapshot;
+  PlanVersionSnapshotAnswer: PlanVersionSnapshotAnswer;
+  PlanVersionSnapshotFunding: PlanVersionSnapshotFunding;
+  PlanVersionSnapshotMember: PlanVersionSnapshotMember;
+  PlanVersionSnapshotMemberRole: PlanVersionSnapshotMemberRole;
+  PlanVersionSnapshotProject: PlanVersionSnapshotProject;
+  PlanVersionSnapshotResearchDomain: PlanVersionSnapshotResearchDomain;
+  PlanVersionSnapshotTemplate: PlanVersionSnapshotTemplate;
+  PlanVersionSnapshotVersion: PlanVersionSnapshotVersion;
   Project: Project;
   ProjectCollaborator: ProjectCollaborator;
   ProjectCollaboratorErrors: ProjectCollaboratorErrors;
@@ -7771,12 +7881,14 @@ export type PlanResolvers<ContextType = MyContext, ParentType extends ResolversP
   members?: Resolver<Maybe<Array<ResolversTypes['PlanMember']>>, ParentType, ContextType>;
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   modifiedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  owner?: Resolver<Maybe<ResolversTypes['Affiliation']>, ParentType, ContextType>;
   planCreator?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
   progress?: Resolver<Maybe<ResolversTypes['PlanProgress']>, ParentType, ContextType>;
   project?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType>;
   readOnly?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   registered?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   registeredById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  relatedWorks?: Resolver<Maybe<Array<ResolversTypes['RelatedWorkSearchResult']>>, ParentType, ContextType>;
   status?: Resolver<Maybe<ResolversTypes['PlanStatus']>, ParentType, ContextType>;
   title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   versionedSections?: Resolver<Maybe<Array<ResolversTypes['PlanSectionProgress']>>, ParentType, ContextType>;
@@ -7955,6 +8067,76 @@ export type PlanSectionProgressResolvers<ContextType = MyContext, ParentType ext
 };
 
 export type PlanVersionResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanVersion'] = ResolversParentTypes['PlanVersion']> = {
+  dmpId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+};
+
+export type PlanVersionSnapshotResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanVersionSnapshot'] = ResolversParentTypes['PlanVersionSnapshot']> = {
+  answers?: Resolver<Maybe<Array<ResolversTypes['PlanVersionSnapshotAnswer']>>, ParentType, ContextType>;
+  created?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  dmpId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  fundings?: Resolver<Maybe<Array<ResolversTypes['PlanVersionSnapshotFunding']>>, ParentType, ContextType>;
+  isHistoricalVersion?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  members?: Resolver<Maybe<Array<ResolversTypes['PlanVersionSnapshotMember']>>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  project?: Resolver<Maybe<ResolversTypes['PlanVersionSnapshotProject']>, ParentType, ContextType>;
+  registered?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  relatedWorkIdentifiers?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  versionTimestamp?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  versionedTemplate?: Resolver<Maybe<ResolversTypes['PlanVersionSnapshotTemplate']>, ParentType, ContextType>;
+  versions?: Resolver<Maybe<Array<ResolversTypes['PlanVersionSnapshotVersion']>>, ParentType, ContextType>;
+  visibility?: Resolver<Maybe<ResolversTypes['PlanVisibility']>, ParentType, ContextType>;
+};
+
+export type PlanVersionSnapshotAnswerResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanVersionSnapshotAnswer'] = ResolversParentTypes['PlanVersionSnapshotAnswer']> = {
+  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  json?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  questionText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+};
+
+export type PlanVersionSnapshotFundingResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanVersionSnapshotFunding'] = ResolversParentTypes['PlanVersionSnapshotFunding']> = {
+  funderName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  funderOpportunityNumber?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  funderProjectNumber?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  funderUri?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  grantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+};
+
+export type PlanVersionSnapshotMemberResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanVersionSnapshotMember'] = ResolversParentTypes['PlanVersionSnapshotMember']> = {
+  affiliationName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  isPrimaryContact?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  memberRoles?: Resolver<Maybe<Array<ResolversTypes['PlanVersionSnapshotMemberRole']>>, ParentType, ContextType>;
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  orcid?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+};
+
+export type PlanVersionSnapshotMemberRoleResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanVersionSnapshotMemberRole'] = ResolversParentTypes['PlanVersionSnapshotMemberRole']> = {
+  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  label?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  uri?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+};
+
+export type PlanVersionSnapshotProjectResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanVersionSnapshotProject'] = ResolversParentTypes['PlanVersionSnapshotProject']> = {
+  abstractText?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  endDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  researchDomain?: Resolver<Maybe<ResolversTypes['PlanVersionSnapshotResearchDomain']>, ParentType, ContextType>;
+  startDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+};
+
+export type PlanVersionSnapshotResearchDomainResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanVersionSnapshotResearchDomain'] = ResolversParentTypes['PlanVersionSnapshotResearchDomain']> = {
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+};
+
+export type PlanVersionSnapshotTemplateResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanVersionSnapshotTemplate'] = ResolversParentTypes['PlanVersionSnapshotTemplate']> = {
+  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  version?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+};
+
+export type PlanVersionSnapshotVersionResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanVersionSnapshotVersion'] = ResolversParentTypes['PlanVersionSnapshotVersion']> = {
   timestamp?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 };
@@ -8209,6 +8391,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   projectMember?: Resolver<Maybe<ResolversTypes['ProjectMember']>, ParentType, ContextType, RequireFields<QueryProjectMemberArgs, 'projectMemberId'>>;
   projectMembers?: Resolver<Maybe<Array<Maybe<ResolversTypes['ProjectMember']>>>, ParentType, ContextType, RequireFields<QueryProjectMembersArgs, 'projectId'>>;
   publicPlanByDMPId?: Resolver<Maybe<ResolversTypes['Plan']>, ParentType, ContextType, RequireFields<QueryPublicPlanByDmpIdArgs, 'dmpId'>>;
+  publicPlanVersionByDMPId?: Resolver<Maybe<ResolversTypes['PlanVersionSnapshot']>, ParentType, ContextType, RequireFields<QueryPublicPlanVersionByDmpIdArgs, 'dmpId' | 'version'>>;
   publishedConditionGroupsForQuestion?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedQuestionConditionGroup']>>>, ParentType, ContextType, RequireFields<QueryPublishedConditionGroupsForQuestionArgs, 'versionedQuestionId'>>;
   publishedCustomQuestion?: Resolver<Maybe<ResolversTypes['VersionedCustomQuestion']>, ParentType, ContextType, RequireFields<QueryPublishedCustomQuestionArgs, 'versionedCustomQuestionId'>>;
   publishedCustomQuestions?: Resolver<Maybe<Array<Maybe<ResolversTypes['PublishedQuestion']>>>, ParentType, ContextType, RequireFields<QueryPublishedCustomQuestionsArgs, 'planId' | 'versionedCustomSectionId'>>;
@@ -9272,6 +9455,15 @@ export type Resolvers<ContextType = MyContext> = {
   PlanSearchResult?: PlanSearchResultResolvers<ContextType>;
   PlanSectionProgress?: PlanSectionProgressResolvers<ContextType>;
   PlanVersion?: PlanVersionResolvers<ContextType>;
+  PlanVersionSnapshot?: PlanVersionSnapshotResolvers<ContextType>;
+  PlanVersionSnapshotAnswer?: PlanVersionSnapshotAnswerResolvers<ContextType>;
+  PlanVersionSnapshotFunding?: PlanVersionSnapshotFundingResolvers<ContextType>;
+  PlanVersionSnapshotMember?: PlanVersionSnapshotMemberResolvers<ContextType>;
+  PlanVersionSnapshotMemberRole?: PlanVersionSnapshotMemberRoleResolvers<ContextType>;
+  PlanVersionSnapshotProject?: PlanVersionSnapshotProjectResolvers<ContextType>;
+  PlanVersionSnapshotResearchDomain?: PlanVersionSnapshotResearchDomainResolvers<ContextType>;
+  PlanVersionSnapshotTemplate?: PlanVersionSnapshotTemplateResolvers<ContextType>;
+  PlanVersionSnapshotVersion?: PlanVersionSnapshotVersionResolvers<ContextType>;
   Project?: ProjectResolvers<ContextType>;
   ProjectCollaborator?: ProjectCollaboratorResolvers<ContextType>;
   ProjectCollaboratorErrors?: ProjectCollaboratorErrorsResolvers<ContextType>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3114,6 +3114,7 @@ export type PlanVersionSnapshot = {
   dmpId?: Maybe<Scalars['String']['output']>;
   fundings?: Maybe<Array<PlanVersionSnapshotFunding>>;
   isHistoricalVersion: Scalars['Boolean']['output'];
+  latestVersionTimestamp: Scalars['String']['output'];
   members?: Maybe<Array<PlanVersionSnapshotMember>>;
   modified?: Maybe<Scalars['String']['output']>;
   owner?: Maybe<PlanVersionSnapshotOwner>;
@@ -3121,7 +3122,7 @@ export type PlanVersionSnapshot = {
   registered?: Maybe<Scalars['String']['output']>;
   /** Bare related-work identifiers only — full citation metadata isn't preserved in archived snapshots */
   relatedWorkIdentifiers?: Maybe<Array<Scalars['String']['output']>>;
-  relatedWorks?: Maybe<Array<RelatedWorkSearchResult>>;
+  relatedWorks?: Maybe<Array<PlanVersionSnapshotRelatedWork>>;
   title?: Maybe<Scalars['String']['output']>;
   versionTimestamp: Scalars['String']['output'];
   versionedTemplate?: Maybe<PlanVersionSnapshotTemplate>;
@@ -3143,7 +3144,7 @@ export type PlanVersionSnapshotFunding = {
   funderProjectNumber?: Maybe<Scalars['String']['output']>;
   funderUri?: Maybe<Scalars['String']['output']>;
   grantId?: Maybe<Scalars['String']['output']>;
-  status?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<ProjectFundingStatus>;
 };
 
 export type PlanVersionSnapshotMember = {
@@ -3180,6 +3181,14 @@ export type PlanVersionSnapshotProject = {
   title?: Maybe<Scalars['String']['output']>;
 };
 
+export type PlanVersionSnapshotRelatedWork = {
+  __typename?: 'PlanVersionSnapshotRelatedWork';
+  /** The unique identifier for the Object */
+  id?: Maybe<Scalars['Int']['output']>;
+  /** The version of the work */
+  workVersion: PlanVersionSnapshotWorkVersion;
+};
+
 export type PlanVersionSnapshotResearchDomain = {
   __typename?: 'PlanVersionSnapshotResearchDomain';
   name?: Maybe<Scalars['String']['output']>;
@@ -3196,6 +3205,38 @@ export type PlanVersionSnapshotVersion = {
   __typename?: 'PlanVersionSnapshotVersion';
   timestamp?: Maybe<Scalars['String']['output']>;
   url?: Maybe<Scalars['String']['output']>;
+};
+
+/** A lighter-weight view of a Work for use within a plan version snapshot. */
+export type PlanVersionSnapshotWork = {
+  __typename?: 'PlanVersionSnapshotWork';
+  /** The Digital Object Identifier (DOI) of the work */
+  doi: Scalars['String']['output'];
+};
+
+/**
+ * A lighter-weight view of a WorkVersion for use within a plan version snapshot —
+ *  only the fields needed for citation display, since full work-version metadata
+ *  (hash, institutions, funders, awards, timestamps) isn't preserved in archived snapshots.
+ */
+export type PlanVersionSnapshotWorkVersion = {
+  __typename?: 'PlanVersionSnapshotWorkVersion';
+  /** The authors of the work */
+  authors: Array<Author>;
+  /** The date that the work was published YYYY-MM-DD */
+  publicationDate?: Maybe<Scalars['String']['output']>;
+  /** The venue where the work was published, e.g. IEEE Transactions on Software Engineering, Zenodo etc */
+  publicationVenue?: Maybe<Scalars['String']['output']>;
+  /** The name of the source where the work was found */
+  sourceName: Scalars['String']['output'];
+  /** The URL for the source of the work */
+  sourceUrl?: Maybe<Scalars['String']['output']>;
+  /** The title of the work */
+  title?: Maybe<Scalars['String']['output']>;
+  /** The work */
+  work: PlanVersionSnapshotWork;
+  /** The type of the work */
+  workType: WorkType;
 };
 
 /** The visibility/privacy setting for the plan */
@@ -3686,9 +3727,7 @@ export type Query = {
   projectMember?: Maybe<ProjectMember>;
   /** Get all of the Users that a Members to the research project */
   projectMembers?: Maybe<Array<Maybe<ProjectMember>>>;
-  /** Get a public plan by its DMP id */
-  publicPlanByDMPId?: Maybe<Plan>;
-  /** Get data for one versioned plan */
+  /** Get data for a specific version of a plan */
   publicPlanVersionByDMPId?: Maybe<PlanVersionSnapshot>;
   /** Get the published VersionedQuestionConditionGroups (and their nested conditions) for the specified versioned question */
   publishedConditionGroupsForQuestion?: Maybe<Array<Maybe<VersionedQuestionConditionGroup>>>;
@@ -4050,11 +4089,6 @@ export type QueryProjectMemberArgs = {
 
 export type QueryProjectMembersArgs = {
   projectId: Scalars['Int']['input'];
-};
-
-
-export type QueryPublicPlanByDmpIdArgs = {
-  dmpId: Scalars['String']['input'];
 };
 
 
@@ -6700,9 +6734,12 @@ export type ResolversTypes = {
   PlanVersionSnapshotMemberRole: ResolverTypeWrapper<PlanVersionSnapshotMemberRole>;
   PlanVersionSnapshotOwner: ResolverTypeWrapper<PlanVersionSnapshotOwner>;
   PlanVersionSnapshotProject: ResolverTypeWrapper<PlanVersionSnapshotProject>;
+  PlanVersionSnapshotRelatedWork: ResolverTypeWrapper<PlanVersionSnapshotRelatedWork>;
   PlanVersionSnapshotResearchDomain: ResolverTypeWrapper<PlanVersionSnapshotResearchDomain>;
   PlanVersionSnapshotTemplate: ResolverTypeWrapper<PlanVersionSnapshotTemplate>;
   PlanVersionSnapshotVersion: ResolverTypeWrapper<PlanVersionSnapshotVersion>;
+  PlanVersionSnapshotWork: ResolverTypeWrapper<PlanVersionSnapshotWork>;
+  PlanVersionSnapshotWorkVersion: ResolverTypeWrapper<PlanVersionSnapshotWorkVersion>;
   PlanVisibility: PlanVisibility;
   Project: ResolverTypeWrapper<Project>;
   ProjectCollaborator: ResolverTypeWrapper<ProjectCollaborator>;
@@ -6974,9 +7011,12 @@ export type ResolversParentTypes = {
   PlanVersionSnapshotMemberRole: PlanVersionSnapshotMemberRole;
   PlanVersionSnapshotOwner: PlanVersionSnapshotOwner;
   PlanVersionSnapshotProject: PlanVersionSnapshotProject;
+  PlanVersionSnapshotRelatedWork: PlanVersionSnapshotRelatedWork;
   PlanVersionSnapshotResearchDomain: PlanVersionSnapshotResearchDomain;
   PlanVersionSnapshotTemplate: PlanVersionSnapshotTemplate;
   PlanVersionSnapshotVersion: PlanVersionSnapshotVersion;
+  PlanVersionSnapshotWork: PlanVersionSnapshotWork;
+  PlanVersionSnapshotWorkVersion: PlanVersionSnapshotWorkVersion;
   Project: Project;
   ProjectCollaborator: ProjectCollaborator;
   ProjectCollaboratorErrors: ProjectCollaboratorErrors;
@@ -8092,13 +8132,14 @@ export type PlanVersionSnapshotResolvers<ContextType = MyContext, ParentType ext
   dmpId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   fundings?: Resolver<Maybe<Array<ResolversTypes['PlanVersionSnapshotFunding']>>, ParentType, ContextType>;
   isHistoricalVersion?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  latestVersionTimestamp?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   members?: Resolver<Maybe<Array<ResolversTypes['PlanVersionSnapshotMember']>>, ParentType, ContextType>;
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   owner?: Resolver<Maybe<ResolversTypes['PlanVersionSnapshotOwner']>, ParentType, ContextType>;
   project?: Resolver<Maybe<ResolversTypes['PlanVersionSnapshotProject']>, ParentType, ContextType>;
   registered?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   relatedWorkIdentifiers?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
-  relatedWorks?: Resolver<Maybe<Array<ResolversTypes['RelatedWorkSearchResult']>>, ParentType, ContextType>;
+  relatedWorks?: Resolver<Maybe<Array<ResolversTypes['PlanVersionSnapshotRelatedWork']>>, ParentType, ContextType>;
   title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   versionTimestamp?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   versionedTemplate?: Resolver<Maybe<ResolversTypes['PlanVersionSnapshotTemplate']>, ParentType, ContextType>;
@@ -8118,7 +8159,7 @@ export type PlanVersionSnapshotFundingResolvers<ContextType = MyContext, ParentT
   funderProjectNumber?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   funderUri?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   grantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  status?: Resolver<Maybe<ResolversTypes['ProjectFundingStatus']>, ParentType, ContextType>;
 };
 
 export type PlanVersionSnapshotMemberResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanVersionSnapshotMember'] = ResolversParentTypes['PlanVersionSnapshotMember']> = {
@@ -8151,6 +8192,11 @@ export type PlanVersionSnapshotProjectResolvers<ContextType = MyContext, ParentT
   title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 };
 
+export type PlanVersionSnapshotRelatedWorkResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanVersionSnapshotRelatedWork'] = ResolversParentTypes['PlanVersionSnapshotRelatedWork']> = {
+  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  workVersion?: Resolver<ResolversTypes['PlanVersionSnapshotWorkVersion'], ParentType, ContextType>;
+};
+
 export type PlanVersionSnapshotResearchDomainResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanVersionSnapshotResearchDomain'] = ResolversParentTypes['PlanVersionSnapshotResearchDomain']> = {
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 };
@@ -8164,6 +8210,21 @@ export type PlanVersionSnapshotTemplateResolvers<ContextType = MyContext, Parent
 export type PlanVersionSnapshotVersionResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanVersionSnapshotVersion'] = ResolversParentTypes['PlanVersionSnapshotVersion']> = {
   timestamp?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+};
+
+export type PlanVersionSnapshotWorkResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanVersionSnapshotWork'] = ResolversParentTypes['PlanVersionSnapshotWork']> = {
+  doi?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+};
+
+export type PlanVersionSnapshotWorkVersionResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanVersionSnapshotWorkVersion'] = ResolversParentTypes['PlanVersionSnapshotWorkVersion']> = {
+  authors?: Resolver<Array<ResolversTypes['Author']>, ParentType, ContextType>;
+  publicationDate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  publicationVenue?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  sourceName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  sourceUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  work?: Resolver<ResolversTypes['PlanVersionSnapshotWork'], ParentType, ContextType>;
+  workType?: Resolver<ResolversTypes['WorkType'], ParentType, ContextType>;
 };
 
 export type ProjectResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Project'] = ResolversParentTypes['Project']> = {
@@ -8415,7 +8476,6 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   projectFundings?: Resolver<Maybe<Array<Maybe<ResolversTypes['ProjectFunding']>>>, ParentType, ContextType, RequireFields<QueryProjectFundingsArgs, 'projectId'>>;
   projectMember?: Resolver<Maybe<ResolversTypes['ProjectMember']>, ParentType, ContextType, RequireFields<QueryProjectMemberArgs, 'projectMemberId'>>;
   projectMembers?: Resolver<Maybe<Array<Maybe<ResolversTypes['ProjectMember']>>>, ParentType, ContextType, RequireFields<QueryProjectMembersArgs, 'projectId'>>;
-  publicPlanByDMPId?: Resolver<Maybe<ResolversTypes['Plan']>, ParentType, ContextType, RequireFields<QueryPublicPlanByDmpIdArgs, 'dmpId'>>;
   publicPlanVersionByDMPId?: Resolver<Maybe<ResolversTypes['PlanVersionSnapshot']>, ParentType, ContextType, RequireFields<QueryPublicPlanVersionByDmpIdArgs, 'dmpId' | 'version'>>;
   publishedConditionGroupsForQuestion?: Resolver<Maybe<Array<Maybe<ResolversTypes['VersionedQuestionConditionGroup']>>>, ParentType, ContextType, RequireFields<QueryPublishedConditionGroupsForQuestionArgs, 'versionedQuestionId'>>;
   publishedCustomQuestion?: Resolver<Maybe<ResolversTypes['VersionedCustomQuestion']>, ParentType, ContextType, RequireFields<QueryPublishedCustomQuestionArgs, 'versionedCustomQuestionId'>>;
@@ -9487,9 +9547,12 @@ export type Resolvers<ContextType = MyContext> = {
   PlanVersionSnapshotMemberRole?: PlanVersionSnapshotMemberRoleResolvers<ContextType>;
   PlanVersionSnapshotOwner?: PlanVersionSnapshotOwnerResolvers<ContextType>;
   PlanVersionSnapshotProject?: PlanVersionSnapshotProjectResolvers<ContextType>;
+  PlanVersionSnapshotRelatedWork?: PlanVersionSnapshotRelatedWorkResolvers<ContextType>;
   PlanVersionSnapshotResearchDomain?: PlanVersionSnapshotResearchDomainResolvers<ContextType>;
   PlanVersionSnapshotTemplate?: PlanVersionSnapshotTemplateResolvers<ContextType>;
   PlanVersionSnapshotVersion?: PlanVersionSnapshotVersionResolvers<ContextType>;
+  PlanVersionSnapshotWork?: PlanVersionSnapshotWorkResolvers<ContextType>;
+  PlanVersionSnapshotWorkVersion?: PlanVersionSnapshotWorkVersionResolvers<ContextType>;
   Project?: ProjectResolvers<ContextType>;
   ProjectCollaborator?: ProjectCollaboratorResolvers<ContextType>;
   ProjectCollaboratorErrors?: ProjectCollaboratorErrorsResolvers<ContextType>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3116,10 +3116,12 @@ export type PlanVersionSnapshot = {
   isHistoricalVersion: Scalars['Boolean']['output'];
   members?: Maybe<Array<PlanVersionSnapshotMember>>;
   modified?: Maybe<Scalars['String']['output']>;
+  owner?: Maybe<PlanVersionSnapshotOwner>;
   project?: Maybe<PlanVersionSnapshotProject>;
   registered?: Maybe<Scalars['String']['output']>;
   /** Bare related-work identifiers only — full citation metadata isn't preserved in archived snapshots */
   relatedWorkIdentifiers?: Maybe<Array<Scalars['String']['output']>>;
+  relatedWorks?: Maybe<Array<RelatedWorkSearchResult>>;
   title?: Maybe<Scalars['String']['output']>;
   versionTimestamp: Scalars['String']['output'];
   versionedTemplate?: Maybe<PlanVersionSnapshotTemplate>;
@@ -3157,6 +3159,15 @@ export type PlanVersionSnapshotMemberRole = {
   __typename?: 'PlanVersionSnapshotMemberRole';
   id?: Maybe<Scalars['Int']['output']>;
   label?: Maybe<Scalars['String']['output']>;
+  uri?: Maybe<Scalars['String']['output']>;
+};
+
+export type PlanVersionSnapshotOwner = {
+  __typename?: 'PlanVersionSnapshotOwner';
+  displayName?: Maybe<Scalars['String']['output']>;
+  homepage?: Maybe<Scalars['String']['output']>;
+  id?: Maybe<Scalars['Int']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
   uri?: Maybe<Scalars['String']['output']>;
 };
 
@@ -5522,6 +5533,8 @@ export type UpdateProjectMemberInput = {
   email?: InputMaybe<Scalars['String']['input']>;
   /** The Member's first/given name */
   givenName?: InputMaybe<Scalars['String']['input']>;
+  /** Whether or not the Member the primary contact for the Plan */
+  isPrimaryContact?: InputMaybe<Scalars['Boolean']['input']>;
   /** The roles the Member has on the research project */
   memberRoleIds?: InputMaybe<Array<Scalars['Int']['input']>>;
   /** The Member's ORCID */
@@ -6685,6 +6698,7 @@ export type ResolversTypes = {
   PlanVersionSnapshotFunding: ResolverTypeWrapper<PlanVersionSnapshotFunding>;
   PlanVersionSnapshotMember: ResolverTypeWrapper<PlanVersionSnapshotMember>;
   PlanVersionSnapshotMemberRole: ResolverTypeWrapper<PlanVersionSnapshotMemberRole>;
+  PlanVersionSnapshotOwner: ResolverTypeWrapper<PlanVersionSnapshotOwner>;
   PlanVersionSnapshotProject: ResolverTypeWrapper<PlanVersionSnapshotProject>;
   PlanVersionSnapshotResearchDomain: ResolverTypeWrapper<PlanVersionSnapshotResearchDomain>;
   PlanVersionSnapshotTemplate: ResolverTypeWrapper<PlanVersionSnapshotTemplate>;
@@ -6958,6 +6972,7 @@ export type ResolversParentTypes = {
   PlanVersionSnapshotFunding: PlanVersionSnapshotFunding;
   PlanVersionSnapshotMember: PlanVersionSnapshotMember;
   PlanVersionSnapshotMemberRole: PlanVersionSnapshotMemberRole;
+  PlanVersionSnapshotOwner: PlanVersionSnapshotOwner;
   PlanVersionSnapshotProject: PlanVersionSnapshotProject;
   PlanVersionSnapshotResearchDomain: PlanVersionSnapshotResearchDomain;
   PlanVersionSnapshotTemplate: PlanVersionSnapshotTemplate;
@@ -8079,9 +8094,11 @@ export type PlanVersionSnapshotResolvers<ContextType = MyContext, ParentType ext
   isHistoricalVersion?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   members?: Resolver<Maybe<Array<ResolversTypes['PlanVersionSnapshotMember']>>, ParentType, ContextType>;
   modified?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  owner?: Resolver<Maybe<ResolversTypes['PlanVersionSnapshotOwner']>, ParentType, ContextType>;
   project?: Resolver<Maybe<ResolversTypes['PlanVersionSnapshotProject']>, ParentType, ContextType>;
   registered?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   relatedWorkIdentifiers?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  relatedWorks?: Resolver<Maybe<Array<ResolversTypes['RelatedWorkSearchResult']>>, ParentType, ContextType>;
   title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   versionTimestamp?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   versionedTemplate?: Resolver<Maybe<ResolversTypes['PlanVersionSnapshotTemplate']>, ParentType, ContextType>;
@@ -8115,6 +8132,14 @@ export type PlanVersionSnapshotMemberResolvers<ContextType = MyContext, ParentTy
 export type PlanVersionSnapshotMemberRoleResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanVersionSnapshotMemberRole'] = ResolversParentTypes['PlanVersionSnapshotMemberRole']> = {
   id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   label?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  uri?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+};
+
+export type PlanVersionSnapshotOwnerResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['PlanVersionSnapshotOwner'] = ResolversParentTypes['PlanVersionSnapshotOwner']> = {
+  displayName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  homepage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   uri?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 };
 
@@ -9460,6 +9485,7 @@ export type Resolvers<ContextType = MyContext> = {
   PlanVersionSnapshotFunding?: PlanVersionSnapshotFundingResolvers<ContextType>;
   PlanVersionSnapshotMember?: PlanVersionSnapshotMemberResolvers<ContextType>;
   PlanVersionSnapshotMemberRole?: PlanVersionSnapshotMemberRoleResolvers<ContextType>;
+  PlanVersionSnapshotOwner?: PlanVersionSnapshotOwnerResolvers<ContextType>;
   PlanVersionSnapshotProject?: PlanVersionSnapshotProjectResolvers<ContextType>;
   PlanVersionSnapshotResearchDomain?: PlanVersionSnapshotResearchDomainResolvers<ContextType>;
   PlanVersionSnapshotTemplate?: PlanVersionSnapshotTemplateResolvers<ContextType>;


### PR DESCRIPTION
## Description

Fixed versioning issues. Was able to use the new `AcceptedWork` class to get related works.

- Updated `updateAnswer` resolver to update `plan.modified` to reflect that something had changed (for versioning). Otherwise, it wasn't registering as a version change.
- Added `isPrimaryContact` to UpdateProjectMemberInput because the `isPrimaryContact` field value was being overwritten to `false` when the input didn’t include it
- Added `owner` and `relatedWorks` to `PlanVersionSnapshot` schema - PlanVersionSnapshot is the schema for what is needed for the landing page. The `maDMPToolDMPToSnapshot` transforms the data into a shape that can easily be utilized by the client.
- Updated `getPlanVersions` in `planService` to exclude the `VERSION#latest` used for the dropdown list. Its not a queryable timestamped snapshot in and of itself.
- Updated `getPlanVersionSnapshot` to fetch the `planId` and `projectId` to pass to `mapDMPToolDMPToSnapshot`
- Updated `maDMPToolDMPToSnapshot` to get `isPrimaryContact` from correct place, and added `owner` and `relatedWorks` to the response

Fixes # ([339](https://github.com/CDLUC3/dmptool-doc/issues/339))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Manually tested with Apollo Explorer and frontend changes, and added new unit tests


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [NA] Any dependent changes have been merged and published in downstream modules

## Screen recording

https://github.com/user-attachments/assets/45ee98ec-158f-45d7-8bcf-e34c5ba50979



